### PR TITLE
fix: resolve out-of-bounds heap write in reorder_for_cache_locality

### DIFF
--- a/src/ops/ir/optimization.c
+++ b/src/ops/ir/optimization.c
@@ -667,7 +667,18 @@ static int fuse_operations(CMLGraph_t ir) {
 
 // Helper: Reorder operations for better cache locality
 static int reorder_for_cache_locality(CMLGraph_t ir) {
-    if (!ir || ir->node_count <= 0)
+    if (!ir)
+        return -1;
+
+    int actual_count = 0;
+    struct IRNode* curr = ir->head;
+    while (curr) {
+        actual_count++;
+        curr = curr->next;
+    }
+    ir->node_count = actual_count; // Resynchronize the counter
+
+    if (ir->node_count <= 0)
         return -1;
 
     // Topological sort using Kahn's algorithm


### PR DESCRIPTION
This PR resolves a critical heap memory corruption (Out-of-Bounds write) inside the IR optimization pipeline, specifically within `reorder_for_cache_locality`. 

### The Issue
Running `dead_code_example` with Valgrind (`--leak-check=full`) revealed an invalid write of size 8 at `optimization.c:692`. 
When earlier optimization passes (like CSE or dead code elimination) modify the computational graph, the global `ir->node_count` is not always safely synchronized. When `reorder_for_cache_locality` allocates the `all_nodes` array using this stale counter, the `while (node)` traversal writes past the allocated bounds, corrupting the heap and causing a `SIGABRT` / `malloc(): invalid size (unsorted)` crash later in the execution.

### The Fix
Implemented a "trust, but verify" synchronization block at the start of `reorder_for_cache_locality`. The function now dynamically recounts the exact number of nodes in the linked list and updates `ir->node_count` before any memory allocations occur, ensuring perfect array sizing and preventing the memory corruption.

### Testing
Compiled in Debug mode.
Verified `dead_code_example` completes successfully without crashing.
Valgrind confirms the invalid write is completely resolved.