### PR TITLE
Add Metal backend support and fix macOS compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,7 +266,6 @@ set(OPS_SOURCES
     src/ops/ir/gpu/rocm_backend.c
     src/ops/ir/gpu/wmma.c
     src/ops/ir/gpu/wgsl_codegen.c
-    src/ops/ir/gpu/metal_codegen.c
     src/ops/ir/gpu/ptx_codegen.c
     src/ops/ir/gpu/nv_driver.c
     src/ops/ir/gpu/nv_qmd.c
@@ -285,6 +284,7 @@ set(OPS_SOURCES
 
 if(METAL_FOUND)
     list(APPEND OPS_SOURCES src/ops/ir/gpu/metal_backend.m)
+    list(APPEND OPS_SOURCES src/ops/ir/gpu/metal_codegen.m)
 endif()
 
 list(APPEND OPS_SOURCES src/ops/ir/gpu/webgpu_backend.c)

--- a/benchmarks/bench_all.py
+++ b/benchmarks/bench_all.py
@@ -385,7 +385,12 @@ def main():
     print(f"\nRunning CML (GPU) benchmarks...")
     cml_gpu = bench_cml(cml_binary, env_extra={"CML_BACKEND": "opencl"})
     if cml_gpu:
-        all_results["cml(GPU)"] = cml_gpu
+        all_results["cml(OpenCL)"] = cml_gpu
+
+    print(f"\nRunning CML (Metal) benchmarks...")
+    cml_metal = bench_cml(cml_binary, env_extra={"CML_BACKEND": "metal"})
+    if cml_metal:
+        all_results["cml(Metal)"] = cml_metal
 
     try:
         import torch

--- a/benchmarks/bench_cross_framework.c
+++ b/benchmarks/bench_cross_framework.c
@@ -10,6 +10,7 @@
  *   5. Conv2d forward: batch=8, 3x32x32 -> 16x30x30
  *
  * Set CML_BACKEND=opencl to benchmark OpenCL GPU path.
+ * Set CML_BACKEND=metal to benchmark Metal GPU path (macOS).
  */
 #define _POSIX_C_SOURCE 199309L
 #include "cml.h"
@@ -260,7 +261,10 @@ static double bench_conv2d(void) {
 
 int main(void) {
     const char* backend = getenv("CML_BACKEND");
-    if (backend && strcmp(backend, "opencl") == 0) {
+    if (backend && strcmp(backend, "metal") == 0) {
+        g_device = DEVICE_METAL;
+        fprintf(stderr, "bench: using Metal GPU backend\n");
+    } else if (backend && strcmp(backend, "opencl") == 0) {
         g_device = DEVICE_OPENCL;
         fprintf(stderr, "bench: using OpenCL GPU backend\n");
     }

--- a/src/backend/threadpool.c
+++ b/src/backend/threadpool.c
@@ -1,4 +1,7 @@
 #define _POSIX_C_SOURCE 200809L
+#ifdef __APPLE__
+#define _DARWIN_C_SOURCE
+#endif
 #include "backend/threadpool.h"
 #include "core/logging.h"
 #include <pthread.h>

--- a/src/ops/ir/execution.c
+++ b/src/ops/ir/execution.c
@@ -3472,19 +3472,27 @@ int cml_ir_execute_up_to(CMLGraph_t ir, struct IRNode* target_node) {
 
     /* Check if graph should target a GPU backend via CML_BACKEND env.
      * Cache env check + dispatch context to avoid repeated getenv()/lookup. */
-    static int s_opencl_checked = 0;
-    static int s_use_opencl = 0;
+    static int s_backend_checked = 0;
+    static int s_use_backend = 0;
+    static CMLBackendType s_backend_type = CML_BACKEND_CPU_FALLBACK;
     static CMLDispatchContext* s_dispatch_ctx = NULL;
-    if (!s_opencl_checked) {
+    if (!s_backend_checked) {
         const char* backend_env = getenv("CML_BACKEND");
-        s_use_opencl = (backend_env && (strcasecmp(backend_env, "opencl") == 0 ||
-                                         strcasecmp(backend_env, "cl") == 0));
-        if (s_use_opencl)
+        if (backend_env) {
+            if (strcasecmp(backend_env, "metal") == 0 || strcasecmp(backend_env, "mtl") == 0) {
+                s_backend_type = CML_BACKEND_METAL;
+                s_use_backend = 1;
+            } else if (strcasecmp(backend_env, "opencl") == 0 || strcasecmp(backend_env, "cl") == 0) {
+                s_backend_type = CML_BACKEND_OPENCL;
+                s_use_backend = 1;
+            }
+        }
+        if (s_use_backend)
             s_dispatch_ctx = cml_dispatch_get_global();
-        s_opencl_checked = 1;
+        s_backend_checked = 1;
     }
-    if (s_use_opencl && s_dispatch_ctx) {
-        int r = cml_dispatch_execute_on(s_dispatch_ctx, CML_BACKEND_OPENCL, ir, NULL, 0, NULL, 0);
+    if (s_use_backend && s_dispatch_ctx) {
+        int r = cml_dispatch_execute_on(s_dispatch_ctx, s_backend_type, ir, NULL, 0, NULL, 0);
         if (r == 0) return 0;
     }
 

--- a/src/ops/ir/gpu/am_driver.c
+++ b/src/ops/ir/gpu/am_driver.c
@@ -23,6 +23,9 @@
 #include <time.h>
 #endif
 
+#define AM_VA_START   0x100000000ULL
+#define AM_VA_END     0x800000000ULL
+
 #ifdef CML_AM_MOCK_GPU
 #include "ops/ir/gpu/am_mock.h"
 #define open(...)    cml_am_mock_open(__VA_ARGS__)
@@ -156,9 +159,6 @@ struct kfd_ioctl_unmap_memory_from_gpu_args {
 
 #define AM_PAGE_SIZE         4096
 #define AM_PAGE_ALIGN(x)     (((x) + AM_PAGE_SIZE - 1) & ~(uint64_t)(AM_PAGE_SIZE - 1))
-
-#define AM_VA_START   0x100000000ULL
-#define AM_VA_END     0x800000000ULL
 
 #define AM_SIGNAL_INIT 0
 

--- a/src/ops/ir/gpu/amx.c
+++ b/src/ops/ir/gpu/amx.c
@@ -5,83 +5,16 @@
 
 #if defined(__APPLE__) && defined(__aarch64__)
 
-#define AMX_SET()   __asm__ volatile(".word (0x00201000 + (17 << 5))" ::: "memory")
-#define AMX_CLR()   __asm__ volatile(".word (0x00201000 + (17 << 5) + 1)" ::: "memory")
-
-#define AMX_LDX(ptr, reg) \
-    __asm__ volatile(".word (0x00205000 + (%0 & 0x1F) + ((" #reg " & 0x7) << 10))" \
-        :: "r"((uint64_t)(ptr)) : "memory")
-
-#define AMX_LDY(ptr, reg) \
-    __asm__ volatile(".word (0x00205100 + (%0 & 0x1F) + ((" #reg " & 0x7) << 10))" \
-        :: "r"((uint64_t)(ptr)) : "memory")
-
-#define AMX_STZ(ptr, reg) \
-    __asm__ volatile(".word (0x00205200 + (%0 & 0x1F) + ((" #reg " & 0x7) << 10))" \
-        :: "r"((uint64_t)(ptr)) : "memory")
-
-#define AMX_FMA32(operand) \
-    __asm__ volatile(".word (0x00205C00 + (%0 & 0x1F))" \
-        :: "r"((uint64_t)(operand)) : "memory")
-
-#define AMX_TILE_DIM 32
-
 bool cml_amx_available(void) {
-    return true;
+    return false;
 }
 
 int cml_amx_matmul_f32(const float* A, const float* B, float* C,
                        int M, int N, int K, int lda, int ldb, int ldc) {
-    if (!A || !B || !C || M <= 0 || N <= 0 || K <= 0)
-        return -1;
-
-    float tile_a[AMX_TILE_DIM * AMX_TILE_DIM] __attribute__((aligned(128)));
-    float tile_b[AMX_TILE_DIM * AMX_TILE_DIM] __attribute__((aligned(128)));
-    float tile_c[AMX_TILE_DIM * AMX_TILE_DIM] __attribute__((aligned(128)));
-
-    AMX_SET();
-
-    for (int m0 = 0; m0 < M; m0 += AMX_TILE_DIM) {
-        int tile_m = (m0 + AMX_TILE_DIM <= M) ? AMX_TILE_DIM : M - m0;
-        for (int n0 = 0; n0 < N; n0 += AMX_TILE_DIM) {
-            int tile_n = (n0 + AMX_TILE_DIM <= N) ? AMX_TILE_DIM : N - n0;
-
-            memset(tile_c, 0, sizeof(tile_c));
-
-            for (int k0 = 0; k0 < K; k0 += AMX_TILE_DIM) {
-                int tile_k = (k0 + AMX_TILE_DIM <= K) ? AMX_TILE_DIM : K - k0;
-
-                memset(tile_a, 0, sizeof(tile_a));
-                for (int i = 0; i < tile_m; i++)
-                    for (int j = 0; j < tile_k; j++)
-                        tile_a[i * AMX_TILE_DIM + j] = A[(m0 + i) * lda + k0 + j];
-
-                memset(tile_b, 0, sizeof(tile_b));
-                for (int i = 0; i < tile_k; i++)
-                    for (int j = 0; j < tile_n; j++)
-                        tile_b[i * AMX_TILE_DIM + j] = B[(k0 + i) * ldb + n0 + j];
-
-                for (int i = 0; i < AMX_TILE_DIM; i++) {
-                    AMX_LDX(&tile_a[i * AMX_TILE_DIM], 0);
-                    for (int j = 0; j < AMX_TILE_DIM; j++) {
-                        AMX_LDY(&tile_b[j * AMX_TILE_DIM], 0);
-                        uint64_t operand = ((uint64_t)i << 10) | ((uint64_t)j << 20);
-                        AMX_FMA32(operand);
-                    }
-                }
-            }
-
-            for (int i = 0; i < AMX_TILE_DIM; i++)
-                AMX_STZ(&tile_c[i * AMX_TILE_DIM], 0);
-
-            for (int i = 0; i < tile_m; i++)
-                for (int j = 0; j < tile_n; j++)
-                    C[(m0 + i) * ldc + n0 + j] += tile_c[i * AMX_TILE_DIM + j];
-        }
-    }
-
-    AMX_CLR();
-    return 0;
+    (void)A; (void)B; (void)C;
+    (void)M; (void)N; (void)K;
+    (void)lda; (void)ldb; (void)ldc;
+    return -1;
 }
 
 int cml_amx_matmul_f16(const void* A, const void* B, float* C,
@@ -92,7 +25,7 @@ int cml_amx_matmul_f16(const void* A, const void* B, float* C,
     return -1;
 }
 
-#else /* !Apple Silicon */
+#else
 
 bool cml_amx_available(void) {
     return false;

--- a/src/ops/ir/gpu/metal_backend.m
+++ b/src/ops/ir/gpu/metal_backend.m
@@ -1,6 +1,8 @@
+/*
  * Objective-C implementation using the Metal framework.
  * Entirely guarded by CML_HAS_METAL -- on non-Apple platforms every
  * public function compiles to a safe stub that returns false/NULL/-1.
+ */
 
 #include "ops/ir/gpu/metal_backend.h"
 #include "core/logging.h"
@@ -288,7 +290,7 @@ int cml_metal_backend_init(CMLMetalBackend* backend) {
             backend->device = NULL;
             return -1;
         }
-        backend->command_queue = (__bridge_retained void*)queue;
+        backend->command_queue = (void*)CFBridgingRetain(queue);
 
         const char* name = [[device name] UTF8String];
         if (name) {
@@ -314,7 +316,7 @@ int cml_metal_backend_init(CMLMetalBackend* backend) {
         } else {
 #define COMPILE_PSO(field, name) \
             { id<MTLComputePipelineState> pso = compile_pipeline(device, lib, name); \
-              if (pso) backend->field = (__bridge_retained void*)pso; }
+              if (pso) backend->field = (void*)CFBridgingRetain(pso); }
 
             COMPILE_PSO(k_fill,                   "k_fill");
             COMPILE_PSO(k_relu,                   "k_relu");
@@ -432,9 +434,9 @@ CMLMetalKernel* cml_metal_compile_msl(CMLMetalBackend* backend,
             return NULL;
         }
 
-        kernel->pipeline = (__bridge_retained void*)pipeline;
-        kernel->library  = (__bridge_retained void*)library;
-        kernel->function = (__bridge_retained void*)function;
+        kernel->pipeline = (void*)CFBridgingRetain(pipeline);
+        kernel->library  = (void*)CFBridgingRetain(library);
+        kernel->function = (void*)CFBridgingRetain(function);
         strncpy(kernel->name, function_name, sizeof(kernel->name) - 1);
         kernel->name[sizeof(kernel->name) - 1] = '\0';
 
@@ -562,7 +564,7 @@ void* cml_metal_alloc(CMLMetalBackend* backend, size_t size) {
             return NULL;
         }
 
-        return (__bridge_retained void*)buffer;
+        return (void*)CFBridgingRetain(buffer);
     }
 }
 
@@ -667,7 +669,7 @@ void* cml_metal_get_or_upload_buffer(CMLMetalBackend* backend,
         }
         memcpy([buf contents], data_ptr, size);
 
-        void* retained_buf = (__bridge_retained void*)buf;
+        void* retained_buf = (void*)CFBridgingRetain(buf);
 
         CMLMetalBufferEntry* e = &backend->buffers[backend->buffer_count++];
         e->data_ptr = data_ptr;
@@ -705,7 +707,7 @@ void* cml_metal_alloc_output_buffer(CMLMetalBackend* backend,
             return NULL;
         }
 
-        void* retained_buf = (__bridge_retained void*)buf;
+        void* retained_buf = (void*)CFBridgingRetain(buf);
 
         CMLMetalBufferEntry* e = &backend->buffers[backend->buffer_count++];
         e->data_ptr = tensor_key;

--- a/src/ops/ir/gpu/metal_codegen.m
+++ b/src/ops/ir/gpu/metal_codegen.m
@@ -3,6 +3,8 @@
 #include "ops/uops.h"
 #include "core/logging.h"
 
+#import <Metal/Metal.h>
+#include <CoreFoundation/CoreFoundation.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/ops/ir/gpu/nv_driver.c
+++ b/src/ops/ir/gpu/nv_driver.c
@@ -3,12 +3,17 @@
 #include "ops/ir/internal.h"
 #include "core/logging.h"
 
+#define _POSIX_C_SOURCE 200809L
+#ifdef __APPLE__
+#define _DARWIN_C_SOURCE
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>

--- a/src/ops/ir/hcq_opencl.c
+++ b/src/ops/ir/hcq_opencl.c
@@ -67,10 +67,15 @@ CMLHCQQueue* cml_hcq_opencl_queue_create(void) {
     queue->backend = CML_HCQ_OPENCL;
 
     cl_int err;
+#ifdef __APPLE__
+    cl_command_queue cq = clCreateCommandQueue(
+        g_ocl_ctx.context, g_ocl_ctx.device, 0, &err);
+#else
     cl_command_queue cq = clCreateCommandQueueWithProperties(
         g_ocl_ctx.context, g_ocl_ctx.device, NULL, &err);
+#endif
     if (err != CL_SUCCESS) {
-        LOG_ERROR("OpenCL HCQ: clCreateCommandQueueWithProperties failed (err=%d)", err);
+        LOG_ERROR("OpenCL HCQ: clCreateCommandQueue failed (err=%d)", err);
         free(queue);
         return NULL;
     }


### PR DESCRIPTION
## Summary

This PR adds Metal GPU backend support to the benchmark system and fixes several macOS compilation issues:

### Changes
1. **Metal Backend Integration** (`bench_cross_framework.c`, `bench_all.py`)
   - Added `CML_BACKEND=metal` environment variable support
   - Added `cml(Metal)` to benchmark comparison table

2. **macOS Compilation Fixes**
   - `hcq_opencl.c`: Use `clCreateCommandQueue` instead of `clCreateCommandQueueWithProperties` on macOS
   - `amx.c`: Disabled AMX inline assembly on Apple AArch64 (incompatible with macOS clang)
   - `metal_backend.m`: Fixed `__bridge_retained` casts to use `CFBridgingRetain` for non-ARC compatibility
   - `metal_codegen.m`: Renamed from `.c` to `.m` and added Metal framework import
   - `threadpool.c`: Added `_DARWIN_C_SOURCE` for macOS compatibility
   - `nv_driver.c` & `am_driver.c`: Added platform-specific includes

3. **IR Execution Fix** (`execution.c`)
   - Extended backend selection to support Metal alongside OpenCL

### Benchmark Results
The Metal backend now appears in `bench_all.py` comparison with NumPy, PyTorch, and TinyGrad.