### PR TITLE
perf: introduce high-performance custom allocator replacing malloc/calloc/free

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,6 +217,7 @@ set(ALLOC_SOURCES
     src/alloc/memory_pools.c
     src/alloc/graph_allocator.c
     src/alloc/tlsf_alloc.c
+    src/alloc/cml_allocator.c
 )
 
 set(BACKEND_SOURCES

--- a/benchmarks/bench_cross_framework.c
+++ b/benchmarks/bench_cross_framework.c
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <time.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 static DeviceType g_device = DEVICE_CPU;
 
@@ -53,8 +54,8 @@ static double bench_gemm(int N) {
     TensorConfig cfg = {
         .dtype = DTYPE_FLOAT32, .device = g_device, .has_dtype = true, .has_device = true};
 
-    float* a_data = malloc(sizeof(float) * N * N);
-    float* b_data = malloc(sizeof(float) * N * N);
+    float* a_data = cml_malloc(sizeof(float) * N * N);
+    float* b_data = cml_malloc(sizeof(float) * N * N);
     fill_random(a_data, N * N);
     fill_random(b_data, N * N);
 
@@ -81,8 +82,8 @@ static double bench_gemm(int N) {
         times[r] = (now() - t0) / iters * 1e3;
     }
 
-    free(a_data);
-    free(b_data);
+    cml_free(a_data);
+    cml_free(b_data);
     return median(times, rounds);
 }
 
@@ -92,9 +93,9 @@ static double bench_fused(int N) {
     TensorConfig cfg = {
         .dtype = DTYPE_FLOAT32, .device = g_device, .has_dtype = true, .has_device = true};
 
-    float* a_data    = malloc(sizeof(float) * N * N);
-    float* b_data    = malloc(sizeof(float) * N * N);
-    float* bias_data = malloc(sizeof(float) * N);
+    float* a_data    = cml_malloc(sizeof(float) * N * N);
+    float* b_data    = cml_malloc(sizeof(float) * N * N);
+    float* bias_data = cml_malloc(sizeof(float) * N);
     fill_random(a_data, N * N);
     fill_random(b_data, N * N);
     fill_random(bias_data, N);
@@ -121,9 +122,9 @@ static double bench_fused(int N) {
         cml_reset_ir_context();
     }
 
-    free(a_data);
-    free(b_data);
-    free(bias_data);
+    cml_free(a_data);
+    cml_free(b_data);
+    cml_free(bias_data);
     return median(times, rounds);
 }
 
@@ -133,7 +134,7 @@ static double bench_mlp_forward(void) {
     TensorConfig cfg = {
         .dtype = DTYPE_FLOAT32, .device = g_device, .has_dtype = true, .has_device = true};
 
-    float* x_data = malloc(sizeof(float) * batch * in_f);
+    float* x_data = cml_malloc(sizeof(float) * batch * in_f);
     fill_random(x_data, batch * in_f);
     Tensor* X = cml_tensor(x_data, x_shape, 2, &cfg);
 
@@ -165,7 +166,7 @@ static double bench_mlp_forward(void) {
     }
     cml_reset_ir_context();
 
-    free(x_data);
+    cml_free(x_data);
     module_free((Module*)model);
     return median(times, 5);
 }
@@ -177,8 +178,8 @@ static double bench_mlp_train(void) {
     TensorConfig cfg = {
         .dtype = DTYPE_FLOAT32, .device = g_device, .has_dtype = true, .has_device = true};
 
-    float* x_data = malloc(sizeof(float) * batch * in_f);
-    float* y_data = malloc(sizeof(float) * batch * out_f);
+    float* x_data = cml_malloc(sizeof(float) * batch * in_f);
+    float* y_data = cml_malloc(sizeof(float) * batch * out_f);
     fill_random(x_data, batch * in_f);
     fill_random(y_data, batch * out_f);
 
@@ -220,8 +221,8 @@ static double bench_mlp_train(void) {
         cml_reset_ir_context();
     }
 
-    free(x_data);
-    free(y_data);
+    cml_free(x_data);
+    cml_free(y_data);
     optimizer_free(opt);
     module_free((Module*)model);
     return median(times, 5);
@@ -234,7 +235,7 @@ static double bench_conv2d(void) {
         .dtype = DTYPE_FLOAT32, .device = g_device, .has_dtype = true, .has_device = true};
 
     int numel     = batch * ic * h * w;
-    float* x_data = malloc(sizeof(float) * numel);
+    float* x_data = cml_malloc(sizeof(float) * numel);
     fill_random(x_data, numel);
     Tensor* X = cml_tensor(x_data, x_shape, 4, &cfg);
 
@@ -262,7 +263,7 @@ static double bench_conv2d(void) {
     }
     cml_reset_ir_context();
 
-    free(x_data);
+    cml_free(x_data);
     module_free(conv);
     return median(times, 5);
 }

--- a/benchmarks/profile_mlp_conv.c
+++ b/benchmarks/profile_mlp_conv.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include "alloc/cml_allocator.h"
 
 static double now(void) {
     struct timespec ts;
@@ -35,13 +36,13 @@ int main(void) {
     {
         CMLBlasContext* blas = cml_blas_get_context();
         if (blas && blas->initialized) {
-            float* X   = malloc(sizeof(float) * batch * in_f);
-            float* W1  = malloc(sizeof(float) * hid * in_f);   /* [128,784] stored */
-            float* B1  = malloc(sizeof(float) * hid);
-            float* H   = malloc(sizeof(float) * batch * hid);
-            float* W2  = malloc(sizeof(float) * out_f * hid);  /* [10,128] stored */
-            float* B2  = malloc(sizeof(float) * out_f);
-            float* OUT = malloc(sizeof(float) * batch * out_f);
+            float* X   = cml_malloc(sizeof(float) * batch * in_f);
+            float* W1  = cml_malloc(sizeof(float) * hid * in_f);   /* [128,784] stored */
+            float* B1  = cml_malloc(sizeof(float) * hid);
+            float* H   = cml_malloc(sizeof(float) * batch * hid);
+            float* W2  = cml_malloc(sizeof(float) * out_f * hid);  /* [10,128] stored */
+            float* B2  = cml_malloc(sizeof(float) * out_f);
+            float* OUT = cml_malloc(sizeof(float) * batch * out_f);
             fill_random(X, batch * in_f);
             fill_random(W1, hid * in_f);
             fill_random(B1, hid);
@@ -80,7 +81,7 @@ int main(void) {
             double ms = (now() - t0) / iters * 1e3;
             printf("Raw BLAS MLP forward:    %8.3f ms\n", ms);
 
-            free(X); free(W1); free(B1); free(H); free(W2); free(B2); free(OUT);
+            cml_free(X); cml_free(W1); cml_free(B1); cml_free(H); cml_free(W2); cml_free(B2); cml_free(OUT);
         }
     }
 
@@ -89,7 +90,7 @@ int main(void) {
         int x_shape[] = {batch, in_f};
         TensorConfig cfg = {.dtype = DTYPE_FLOAT32, .device = DEVICE_CPU,
                             .has_dtype = true, .has_device = true};
-        float* x_data = malloc(sizeof(float) * batch * in_f);
+        float* x_data = cml_malloc(sizeof(float) * batch * in_f);
         fill_random(x_data, batch * in_f);
         Tensor* X = cml_tensor(x_data, x_shape, 2, &cfg);
 
@@ -139,7 +140,7 @@ int main(void) {
                t_matmul1 / iters * 1e3, t_ir_reset / iters * 1e3,
                (t_matmul1 + t_ir_reset) / iters * 1e3);
 
-        free(x_data);
+        cml_free(x_data);
         module_free((Module*)model);
     }
 
@@ -155,10 +156,10 @@ int main(void) {
             int col_h = ic * kh * kw;  /* 27 */
             int col_w = oh * ow;       /* 900 */
 
-            float* input = malloc(sizeof(float) * cb * ic * ih * iw);
-            float* weight = malloc(sizeof(float) * oc * col_h);
-            float* col = malloc(sizeof(float) * col_h * col_w);
-            float* output = malloc(sizeof(float) * cb * oc * oh * ow);
+            float* input = cml_malloc(sizeof(float) * cb * ic * ih * iw);
+            float* weight = cml_malloc(sizeof(float) * oc * col_h);
+            float* col = cml_malloc(sizeof(float) * col_h * col_w);
+            float* output = cml_malloc(sizeof(float) * cb * oc * oh * ow);
             fill_random(input, cb * ic * ih * iw);
             fill_random(weight, oc * col_h);
 
@@ -200,7 +201,7 @@ int main(void) {
             double ms = (now() - t0) / iters * 1e3;
             printf("Raw BLAS im2col+mm conv: %8.3f ms\n", ms);
 
-            free(input); free(weight); free(col); free(output);
+            cml_free(input); cml_free(weight); cml_free(col); cml_free(output);
         }
     }
 
@@ -210,7 +211,7 @@ int main(void) {
         int x_shape[] = {cb, ic, h, w};
         TensorConfig cfg = {.dtype = DTYPE_FLOAT32, .device = DEVICE_CPU,
                             .has_dtype = true, .has_device = true};
-        float* x_data = malloc(sizeof(float) * cb * ic * h * w);
+        float* x_data = cml_malloc(sizeof(float) * cb * ic * h * w);
         fill_random(x_data, cb * ic * h * w);
         Tensor* X = cml_tensor(x_data, x_shape, 4, &cfg);
 
@@ -231,7 +232,7 @@ int main(void) {
         double ms = (now() - t0) / iters * 1e3;
         printf("CML Conv2d forward:      %8.3f ms\n", ms);
 
-        free(x_data);
+        cml_free(x_data);
         module_free((Module*)conv);
     }
 

--- a/benchmarks/profile_overhead.c
+++ b/benchmarks/profile_overhead.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include "alloc/cml_allocator.h"
 
 static double now(void) {
     struct timespec ts;
@@ -32,9 +33,9 @@ int main(void) {
     /* --- 1. Raw BLAS matmul (zero overhead baseline) --- */
     {
         CMLBlasContext* blas = cml_blas_get_context();
-        float* A = malloc(sizeof(float) * N * N);
-        float* B = malloc(sizeof(float) * N * N);
-        float* C = malloc(sizeof(float) * N * N);
+        float* A = cml_malloc(sizeof(float) * N * N);
+        float* B = cml_malloc(sizeof(float) * N * N);
+        float* C = cml_malloc(sizeof(float) * N * N);
         fill_random(A, N * N);
         fill_random(B, N * N);
 
@@ -48,7 +49,7 @@ int main(void) {
         } else {
             printf("1. Raw BLAS: NOT AVAILABLE\n");
         }
-        free(A); free(B); free(C);
+        cml_free(A); cml_free(B); cml_free(C);
     }
 
     /* --- 2. cml_matmul through IR (includes graph overhead) --- */
@@ -56,8 +57,8 @@ int main(void) {
         int shape[] = {N, N};
         TensorConfig cfg = {.dtype = DTYPE_FLOAT32, .device = DEVICE_CPU,
                             .has_dtype = true, .has_device = true};
-        float* a_data = malloc(sizeof(float) * N * N);
-        float* b_data = malloc(sizeof(float) * N * N);
+        float* a_data = cml_malloc(sizeof(float) * N * N);
+        float* b_data = cml_malloc(sizeof(float) * N * N);
         fill_random(a_data, N * N);
         fill_random(b_data, N * N);
         Tensor* A = cml_tensor(a_data, shape, 2, &cfg);
@@ -78,7 +79,7 @@ int main(void) {
         printf("2. cml_matmul (IR path):        %8.3f ms\n", ms);
 
         tensor_free(A); tensor_free(B);
-        free(a_data); free(b_data);
+        cml_free(a_data); cml_free(b_data);
     }
 
     /* --- 3. Fused: cml_matmul + cml_add + cml_relu --- */
@@ -87,9 +88,9 @@ int main(void) {
         int bias_shape[] = {1, N};
         TensorConfig cfg = {.dtype = DTYPE_FLOAT32, .device = DEVICE_CPU,
                             .has_dtype = true, .has_device = true};
-        float* a_data = malloc(sizeof(float) * N * N);
-        float* b_data = malloc(sizeof(float) * N * N);
-        float* bias_data = malloc(sizeof(float) * N);
+        float* a_data = cml_malloc(sizeof(float) * N * N);
+        float* b_data = cml_malloc(sizeof(float) * N * N);
+        float* bias_data = cml_malloc(sizeof(float) * N);
         fill_random(a_data, N * N);
         fill_random(b_data, N * N);
         fill_random(bias_data, N);
@@ -110,7 +111,7 @@ int main(void) {
         printf("3. cml fused (mm+add+relu):     %8.3f ms\n", ms);
 
         tensor_free(A); tensor_free(B); tensor_free(bias);
-        free(a_data); free(b_data); free(bias_data);
+        cml_free(a_data); cml_free(b_data); cml_free(bias_data);
     }
 
     /* --- 4. IR graph creation only (no computation) --- */
@@ -118,8 +119,8 @@ int main(void) {
         int shape[] = {N, N};
         TensorConfig cfg = {.dtype = DTYPE_FLOAT32, .device = DEVICE_CPU,
                             .has_dtype = true, .has_device = true};
-        float* a_data = malloc(sizeof(float) * N * N);
-        float* b_data = malloc(sizeof(float) * N * N);
+        float* a_data = cml_malloc(sizeof(float) * N * N);
+        float* b_data = cml_malloc(sizeof(float) * N * N);
         fill_random(a_data, N * N);
         fill_random(b_data, N * N);
         Tensor* A = cml_tensor(a_data, shape, 2, &cfg);
@@ -134,7 +135,7 @@ int main(void) {
         printf("4. IR graph creation only (mm): %8.3f ms  (x%d iters)\n", ms, iters * 100);
 
         tensor_free(A); tensor_free(B);
-        free(a_data); free(b_data);
+        cml_free(a_data); cml_free(b_data);
     }
 
     /* --- 5. cml_reset_ir_context cost --- */
@@ -143,8 +144,8 @@ int main(void) {
         int shape2[] = {784, 128};
         TensorConfig cfg = {.dtype = DTYPE_FLOAT32, .device = DEVICE_CPU,
                             .has_dtype = true, .has_device = true};
-        float* a_data = malloc(sizeof(float) * 64 * 784);
-        float* b_data = malloc(sizeof(float) * 784 * 128);
+        float* a_data = cml_malloc(sizeof(float) * 64 * 784);
+        float* b_data = cml_malloc(sizeof(float) * 784 * 128);
         fill_random(a_data, 64 * 784);
         fill_random(b_data, 784 * 128);
 
@@ -162,7 +163,7 @@ int main(void) {
         }
         double ms = total_reset / (iters * 10) * 1e3;
         printf("5. cml_reset_ir_context cost:   %8.3f ms  (per reset, %d resets)\n", ms, iters * 10);
-        free(a_data); free(b_data);
+        cml_free(a_data); cml_free(b_data);
     }
 
     /* --- 6. MLP forward: breakdown --- */
@@ -171,7 +172,7 @@ int main(void) {
         int x_shape[] = {batch, in_f};
         TensorConfig cfg = {.dtype = DTYPE_FLOAT32, .device = DEVICE_CPU,
                             .has_dtype = true, .has_device = true};
-        float* x_data = malloc(sizeof(float) * batch * in_f);
+        float* x_data = cml_malloc(sizeof(float) * batch * in_f);
         fill_random(x_data, batch * in_f);
         Tensor* X = cml_tensor(x_data, x_shape, 2, &cfg);
 
@@ -198,7 +199,7 @@ int main(void) {
 
         /* Forward + backward */
         int y_shape[] = {batch, out_f};
-        float* y_data = malloc(sizeof(float) * batch * out_f);
+        float* y_data = cml_malloc(sizeof(float) * batch * out_f);
         fill_random(y_data, batch * out_f);
         Tensor* Y = cml_tensor(y_data, y_shape, 2, &cfg);
         Optimizer* opt = cml_optim_sgd_for_model((Module*)model, 0.01f, 0.0f, 0.0f);
@@ -228,7 +229,7 @@ int main(void) {
         printf("   Full train step:             %8.3f ms\n", train_ms);
         printf("   Backward+optim overhead:     %8.3f ms\n", train_ms - fwd_ms);
 
-        free(x_data); free(y_data);
+        cml_free(x_data); cml_free(y_data);
         optimizer_free(opt);
         module_free((Module*)model);
     }
@@ -239,7 +240,7 @@ int main(void) {
         int x_shape[] = {batch, ic, h, w};
         TensorConfig cfg = {.dtype = DTYPE_FLOAT32, .device = DEVICE_CPU,
                             .has_dtype = true, .has_device = true};
-        float* x_data = malloc(sizeof(float) * batch * ic * h * w);
+        float* x_data = cml_malloc(sizeof(float) * batch * ic * h * w);
         fill_random(x_data, batch * ic * h * w);
         Tensor* X = cml_tensor(x_data, x_shape, 4, &cfg);
 
@@ -260,7 +261,7 @@ int main(void) {
         double ms = (now() - t0) / (iters * 5) * 1e3;
         printf("\n7. Conv2d forward (8x3x32x32): %8.3f ms\n", ms);
 
-        free(x_data);
+        cml_free(x_data);
         module_free((Module*)conv);
     }
 

--- a/benchmarks/profile_overhead_detailed.c
+++ b/benchmarks/profile_overhead_detailed.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include "alloc/cml_allocator.h"
 
 static double now(void) {
     struct timespec ts;
@@ -36,9 +37,9 @@ int main(void) {
     printf("=== GEMM 512x512 Overhead Breakdown (%d iters) ===\n\n", iters);
     {
         int N = 512;
-        float* A = malloc(sizeof(float) * N * N);
-        float* B = malloc(sizeof(float) * N * N);
-        float* C = malloc(sizeof(float) * N * N);
+        float* A = cml_malloc(sizeof(float) * N * N);
+        float* B = cml_malloc(sizeof(float) * N * N);
+        float* C = cml_malloc(sizeof(float) * N * N);
         fill_random(A, N * N);
         fill_random(B, N * N);
 
@@ -102,17 +103,17 @@ int main(void) {
         printf("  IR create+reset only:   %8.3f ms\n", ir_create);
         printf("  Overhead (IR - BLAS):   %8.3f ms\n\n", cml_ir - raw_blas);
 
-        free(A); free(B); free(C);
+        cml_free(A); cml_free(B); cml_free(C);
     }
 
     /* ═══ 2. Fused 512: mm+bias+relu ═══ */
     printf("=== Fused 512 (mm+bias+relu) Overhead Breakdown ===\n\n");
     {
         int N = 512;
-        float* A = malloc(sizeof(float) * N * N);
-        float* B = malloc(sizeof(float) * N * N);
-        float* C = malloc(sizeof(float) * N * N);
-        float* bias = malloc(sizeof(float) * N);
+        float* A = cml_malloc(sizeof(float) * N * N);
+        float* B = cml_malloc(sizeof(float) * N * N);
+        float* C = cml_malloc(sizeof(float) * N * N);
+        float* bias = cml_malloc(sizeof(float) * N);
         fill_random(A, N * N);
         fill_random(B, N * N);
         fill_random(bias, N);
@@ -137,9 +138,9 @@ int main(void) {
         int bias_shape[] = {1, N};
         TensorConfig cfg = {.dtype = DTYPE_FLOAT32, .device = DEVICE_CPU,
                             .has_dtype = true, .has_device = true};
-        float* a_cpy = malloc(sizeof(float) * N * N);
-        float* b_cpy = malloc(sizeof(float) * N * N);
-        float* bi_cpy = malloc(sizeof(float) * N);
+        float* a_cpy = cml_malloc(sizeof(float) * N * N);
+        float* b_cpy = cml_malloc(sizeof(float) * N * N);
+        float* bi_cpy = cml_malloc(sizeof(float) * N);
         memcpy(a_cpy, A, sizeof(float) * N * N);
         memcpy(b_cpy, B, sizeof(float) * N * N);
         memcpy(bi_cpy, bias, sizeof(float) * N);
@@ -164,8 +165,8 @@ int main(void) {
         printf("  CML fused (with reset): %8.3f ms  (%.1fx raw)\n", cml_fused, cml_fused / raw);
         printf("  Overhead:               %8.3f ms\n\n", cml_fused - raw);
 
-        free(A); free(B); free(C); free(bias);
-        free(a_cpy); free(b_cpy); free(bi_cpy);
+        cml_free(A); cml_free(B); cml_free(C); cml_free(bias);
+        cml_free(a_cpy); cml_free(b_cpy); cml_free(bi_cpy);
     }
 
     /* ═══ 3. MLP forward ═══ */
@@ -174,13 +175,13 @@ int main(void) {
         int batch = 64, in_f = 784, hid = 128, out_f = 10;
 
         /* 3a. Raw BLAS MLP */
-        float* X   = malloc(sizeof(float) * batch * in_f);
-        float* W1  = malloc(sizeof(float) * hid * in_f);
-        float* B1  = malloc(sizeof(float) * hid);
-        float* H   = malloc(sizeof(float) * batch * hid);
-        float* W2  = malloc(sizeof(float) * out_f * hid);
-        float* B2  = malloc(sizeof(float) * out_f);
-        float* OUT = malloc(sizeof(float) * batch * out_f);
+        float* X   = cml_malloc(sizeof(float) * batch * in_f);
+        float* W1  = cml_malloc(sizeof(float) * hid * in_f);
+        float* B1  = cml_malloc(sizeof(float) * hid);
+        float* H   = cml_malloc(sizeof(float) * batch * hid);
+        float* W2  = cml_malloc(sizeof(float) * out_f * hid);
+        float* B2  = cml_malloc(sizeof(float) * out_f);
+        float* OUT = cml_malloc(sizeof(float) * batch * out_f);
         fill_random(X, batch * in_f);
         fill_random(W1, hid * in_f);
         fill_random(B1, hid);
@@ -219,7 +220,7 @@ int main(void) {
         int x_shape[] = {batch, in_f};
         TensorConfig cfg = {.dtype = DTYPE_FLOAT32, .device = DEVICE_CPU,
                             .has_dtype = true, .has_device = true};
-        float* x_data = malloc(sizeof(float) * batch * in_f);
+        float* x_data = cml_malloc(sizeof(float) * batch * in_f);
         memcpy(x_data, X, sizeof(float) * batch * in_f);
         Tensor* tX = cml_tensor(x_data, x_shape, 2, &cfg);
         Sequential* model = cml_nn_sequential();
@@ -269,8 +270,8 @@ int main(void) {
             printf("  Overhead vs BLAS:       %8.3f ms\n\n", cml_mlp - raw_mlp);
         }
 
-        free(X); free(W1); free(B1); free(H); free(W2); free(B2); free(OUT);
-        free(x_data);
+        cml_free(X); cml_free(W1); cml_free(B1); cml_free(H); cml_free(W2); cml_free(B2); cml_free(OUT);
+        cml_free(x_data);
         module_free((Module*)model);
     }
 
@@ -283,21 +284,21 @@ int main(void) {
         /* calloc + free */
         double t0 = now();
         for (int i = 0; i < alloc_iters; i++) {
-            float* p = calloc(N * N, sizeof(float));
-            free(p);
+            float* p = cml_calloc(N * N, sizeof(float));
+            cml_free(p);
         }
         double alloc_time = (now() - t0) / alloc_iters * 1e3;
 
         /* malloc + memset + free */
         t0 = now();
         for (int i = 0; i < alloc_iters; i++) {
-            float* p = malloc(N * N * sizeof(float));
+            float* p = cml_malloc(N * N * sizeof(float));
             memset(p, 0, N * N * sizeof(float));
-            free(p);
+            cml_free(p);
         }
         double malloc_time = (now() - t0) / alloc_iters * 1e3;
 
-        printf("  calloc(%d) + free:      %8.4f ms\n", N*N, alloc_time);
+        printf("  cml_calloc(%d) + free:      %8.4f ms\n", N*N, alloc_time);
         printf("  malloc+memset+free:     %8.4f ms\n\n", malloc_time);
     }
 
@@ -309,10 +310,10 @@ int main(void) {
         int col_h = ic * kh * kw;
         int col_w = oh * ow;
 
-        float* input  = malloc(sizeof(float) * cb * ic * ih * iw);
-        float* weight = malloc(sizeof(float) * oc * col_h);
-        float* col    = malloc(sizeof(float) * col_h * col_w);
-        float* output = malloc(sizeof(float) * cb * oc * oh * ow);
+        float* input  = cml_malloc(sizeof(float) * cb * ic * ih * iw);
+        float* weight = cml_malloc(sizeof(float) * oc * col_h);
+        float* col    = cml_malloc(sizeof(float) * col_h * col_w);
+        float* output = cml_malloc(sizeof(float) * cb * oc * oh * ow);
         fill_random(input, cb * ic * ih * iw);
         fill_random(weight, oc * col_h);
 
@@ -383,7 +384,7 @@ int main(void) {
         int x_shape[] = {cb, ic, ih, iw};
         TensorConfig cfg = {.dtype = DTYPE_FLOAT32, .device = DEVICE_CPU,
                             .has_dtype = true, .has_device = true};
-        float* x_data = malloc(sizeof(float) * cb * ic * ih * iw);
+        float* x_data = cml_malloc(sizeof(float) * cb * ic * ih * iw);
         memcpy(x_data, input, sizeof(float) * cb * ic * ih * iw);
         Tensor* X = cml_tensor(x_data, x_shape, 4, &cfg);
         Conv2d* conv = cml_nn_conv2d(ic, oc, kh, 1, 0, 1, true, DTYPE_FLOAT32, DEVICE_CPU);
@@ -406,7 +407,7 @@ int main(void) {
         printf("  CML Conv2d:             %8.3f ms  (%.1fx raw)\n", cml_conv, cml_conv / raw_conv);
         printf("  CML overhead:           %8.3f ms\n\n", cml_conv - raw_conv);
 
-        free(input); free(weight); free(col); free(output); free(x_data);
+        cml_free(input); cml_free(weight); cml_free(col); cml_free(output); cml_free(x_data);
         module_free((Module*)conv);
     }
 

--- a/benchmarks/profile_train_conv.c
+++ b/benchmarks/profile_train_conv.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include "alloc/cml_allocator.h"
 
 static double now(void) {
     struct timespec ts;
@@ -34,8 +35,8 @@ int main(void) {
         TensorConfig cfg = {.dtype = DTYPE_FLOAT32, .device = DEVICE_CPU,
                             .has_dtype = true, .has_device = true};
 
-        float* x_data = malloc(sizeof(float) * batch * in_f);
-        float* y_data = malloc(sizeof(float) * batch * out_f);
+        float* x_data = cml_malloc(sizeof(float) * batch * in_f);
+        float* y_data = cml_malloc(sizeof(float) * batch * out_f);
         fill_random(x_data, batch * in_f);
         fill_random(y_data, batch * out_f);
 
@@ -105,7 +106,7 @@ int main(void) {
         printf("  ─────────────────────────────\n");
         printf("  Total:           %8.3f ms\n\n", t_total / iters * 1e3);
 
-        free(x_data); free(y_data);
+        cml_free(x_data); cml_free(y_data);
         optimizer_free(opt);
         module_free((Module*)model);
     }
@@ -120,11 +121,11 @@ int main(void) {
         CMLBlasContext* blas = cml_blas_get_context();
         int col_h = ic * kh * kw;
         int col_w = oh * ow;
-        float* input  = malloc(sizeof(float) * cb * ic * ih * iw);
-        float* weight = malloc(sizeof(float) * oc * col_h);
-        float* col    = malloc(sizeof(float) * col_h * col_w);
-        float* output = malloc(sizeof(float) * cb * oc * oh * ow);
-        float* bias   = malloc(sizeof(float) * oc);
+        float* input  = cml_malloc(sizeof(float) * cb * ic * ih * iw);
+        float* weight = cml_malloc(sizeof(float) * oc * col_h);
+        float* col    = cml_malloc(sizeof(float) * col_h * col_w);
+        float* output = cml_malloc(sizeof(float) * cb * oc * oh * ow);
+        float* bias   = cml_malloc(sizeof(float) * oc);
         fill_random(input, cb * ic * ih * iw);
         fill_random(weight, oc * col_h);
         fill_random(bias, oc);
@@ -179,7 +180,7 @@ int main(void) {
         int x_shape[] = {cb, ic, ih, iw};
         TensorConfig cfg = {.dtype = DTYPE_FLOAT32, .device = DEVICE_CPU,
                             .has_dtype = true, .has_device = true};
-        float* x_data = malloc(sizeof(float) * cb * ic * ih * iw);
+        float* x_data = cml_malloc(sizeof(float) * cb * ic * ih * iw);
         memcpy(x_data, input, sizeof(float) * cb * ic * ih * iw);
         Tensor* X = cml_tensor(x_data, x_shape, 4, &cfg);
         Conv2d* conv = cml_nn_conv2d(ic, oc, kh, 1, 0, 1, true, DTYPE_FLOAT32, DEVICE_CPU);
@@ -213,7 +214,7 @@ int main(void) {
         printf("  Execution only:         %8.3f ms\n", cml_total - ir_create);
         printf("  Overhead:               %8.3f ms\n\n", cml_total - raw_full);
 
-        free(input); free(weight); free(col); free(output); free(bias); free(x_data);
+        cml_free(input); cml_free(weight); cml_free(col); cml_free(output); cml_free(bias); cml_free(x_data);
         module_free((Module*)conv);
     }
 

--- a/examples/benchmarks/bench_gemm.c
+++ b/examples/benchmarks/bench_gemm.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include "alloc/cml_allocator.h"
 
 static double get_time_sec(void) {
 #if defined(__linux__) || defined(__APPLE__)
@@ -28,7 +29,7 @@ static void naive_sgemm(const float* A, const float* B, float* C, int N) {
 }
 
 static float* alloc_random(int n) {
-    float* p = malloc((size_t)n * sizeof(float));
+    float* p = cml_malloc((size_t)n * sizeof(float));
     for (int i = 0; i < n; i++)
         p[i] = (float)rand() / (float)RAND_MAX - 0.5f;
     return p;
@@ -51,7 +52,7 @@ static BenchResult bench_naive(int N, int iters) {
     int n2   = N * N;
     float* A = alloc_random(n2);
     float* B = alloc_random(n2);
-    float* C = calloc((size_t)n2, sizeof(float));
+    float* C = cml_calloc((size_t)n2, sizeof(float));
 
     naive_sgemm(A, B, C, N);
 
@@ -60,9 +61,9 @@ static BenchResult bench_naive(int N, int iters) {
         naive_sgemm(A, B, C, N);
     double elapsed = get_time_sec() - start;
 
-    free(A);
-    free(B);
-    free(C);
+    cml_free(A);
+    cml_free(B);
+    cml_free(C);
     double flop = gemm_flops(N) * iters;
     return (BenchResult){.gflops = flop / elapsed / 1e9, .time_ms = elapsed / iters * 1e3};
 }
@@ -71,7 +72,7 @@ static BenchResult bench_blas(CMLBlasContext* blas, int N, int iters) {
     int n2   = N * N;
     float* A = alloc_random(n2);
     float* B = alloc_random(n2);
-    float* C = calloc((size_t)n2, sizeof(float));
+    float* C = cml_calloc((size_t)n2, sizeof(float));
 
     cml_blas_sgemm(blas, A, B, C, N, N, N, 1.0f, 0.0f);
 
@@ -80,9 +81,9 @@ static BenchResult bench_blas(CMLBlasContext* blas, int N, int iters) {
         cml_blas_sgemm(blas, A, B, C, N, N, N, 1.0f, 0.0f);
     double elapsed = get_time_sec() - start;
 
-    free(A);
-    free(B);
-    free(C);
+    cml_free(A);
+    cml_free(B);
+    cml_free(C);
     double flop = gemm_flops(N) * iters;
     return (BenchResult){.gflops = flop / elapsed / 1e9, .time_ms = elapsed / iters * 1e3};
 }
@@ -121,7 +122,7 @@ static BenchResult bench_blas_unfused(CMLBlasContext* blas, int N, int iters) {
     int n2      = N * N;
     float* A    = alloc_random(n2);
     float* B    = alloc_random(n2);
-    float* C    = calloc((size_t)n2, sizeof(float));
+    float* C    = cml_calloc((size_t)n2, sizeof(float));
     float* bias = alloc_random(N);
 
     cml_blas_sgemm(blas, A, B, C, N, N, N, 1.0f, 0.0f);
@@ -137,10 +138,10 @@ static BenchResult bench_blas_unfused(CMLBlasContext* blas, int N, int iters) {
     }
     double elapsed = get_time_sec() - start;
 
-    free(A);
-    free(B);
-    free(C);
-    free(bias);
+    cml_free(A);
+    cml_free(B);
+    cml_free(C);
+    cml_free(bias);
     double flop = fused_flops(N) * iters;
     return (BenchResult){.gflops = flop / elapsed / 1e9, .time_ms = elapsed / iters * 1e3};
 }

--- a/examples/demos/auto_capture_example.c
+++ b/examples/demos/auto_capture_example.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 int main(void) {
     cml_init();
@@ -66,7 +67,7 @@ int main(void) {
     char* cuda_code = cml_ir_compile(ir, NULL);
     if (cuda_code) {
         printf("\nGenerated CUDA code (after optimization/fusion):\n%s\n", cuda_code);
-        free(cuda_code);
+        cml_free(cuda_code);
     }
 
     if (e)

--- a/examples/demos/comprehensive_fusion_example.c
+++ b/examples/demos/comprehensive_fusion_example.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 int main(void) {
     cml_init();
@@ -190,8 +191,8 @@ int main(void) {
             printf("Exported kernel analysis to kernels.json\n");
         }
     }
-    free(raw_json);
-    free(opt_json);
+    cml_free(raw_json);
+    cml_free(opt_json);
 
     char* graph_json = cml_ir_export_graph_json(ir);
     if (graph_json) {
@@ -201,14 +202,14 @@ int main(void) {
             fclose(f);
             printf("Exported graph topology to graph.json\n");
         }
-        free(graph_json);
+        cml_free(graph_json);
     }
 
     /* Print IR summary */
     char* ir_str = cml_ir_to_string(ir);
     if (ir_str) {
         printf("\nIR Summary:\n%s\n", ir_str);
-        free(ir_str);
+        cml_free(ir_str);
     }
 
     /* Clean up */

--- a/examples/demos/dead_code_example.c
+++ b/examples/demos/dead_code_example.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 int main(void) {
     printf("Dead Code & IR Optimization Demo\n\n");
@@ -87,9 +88,9 @@ int main(void) {
         }
 
         if (unopt)
-            free(unopt);
+            cml_free(unopt);
         if (opt)
-            free(opt);
+            cml_free(opt);
     } else {
         printf("Warning: No IR context available\n");
     }

--- a/examples/demos/mnist_example.c
+++ b/examples/demos/mnist_example.c
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <math.h>
 #include <time.h>
+#include "alloc/cml_allocator.h"
 
 static double get_time_sec(void) {
 #if defined(__linux__) || defined(__APPLE__)
@@ -45,18 +46,18 @@ static float* load_mnist_images(const char* filename, int* num_images, int* rows
     printf("Loading %d images (%dx%d)...\n", *num_images, *rows, *cols);
 
     int image_size = (*rows) * (*cols);
-    float* data    = (float*)malloc(sizeof(float) * (*num_images) * image_size);
+    float* data    = (float*)cml_malloc(sizeof(float) * (*num_images) * image_size);
     if (!data) {
         fclose(f);
         return NULL;
     }
 
-    uint8_t* buffer = (uint8_t*)malloc(image_size);
+    uint8_t* buffer = (uint8_t*)cml_malloc(image_size);
     for (int i = 0; i < *num_images; i++) {
         if (fread(buffer, 1, image_size, f) != (size_t)image_size) {
             printf("Error: Failed to read image %d\n", i);
-            free(data);
-            free(buffer);
+            cml_free(data);
+            cml_free(buffer);
             fclose(f);
             return NULL;
         }
@@ -65,7 +66,7 @@ static float* load_mnist_images(const char* filename, int* num_images, int* rows
         }
     }
 
-    free(buffer);
+    cml_free(buffer);
     fclose(f);
     return data;
 }
@@ -87,7 +88,7 @@ static float* load_mnist_labels(const char* filename, int* num_labels) {
     *num_labels = (int)read_uint32_be(f);
     printf("Loading %d labels...\n", *num_labels);
 
-    float* data = (float*)calloc((*num_labels) * 10, sizeof(float));
+    float* data = (float*)cml_calloc((*num_labels) * 10, sizeof(float));
     if (!data) {
         fclose(f);
         return NULL;
@@ -97,7 +98,7 @@ static float* load_mnist_labels(const char* filename, int* num_labels) {
         uint8_t label;
         if (fread(&label, 1, 1, f) != 1) {
             printf("Error: Failed to read label %d\n", i);
-            free(data);
+            cml_free(data);
             fclose(f);
             return NULL;
         }
@@ -171,7 +172,7 @@ int main(int argc, char** argv) {
     int num_train_labels;
     float* train_labels = load_mnist_labels(train_labels_path, &num_train_labels);
     if (!train_labels) {
-        free(train_images);
+        cml_free(train_images);
         return 1;
     }
 
@@ -296,9 +297,9 @@ int main(int argc, char** argv) {
                         }
                     }
                     if (unopt)
-                        free(unopt);
+                        cml_free(unopt);
                     if (opt)
-                        free(opt);
+                        cml_free(opt);
                 }
             }
 
@@ -349,12 +350,12 @@ int main(int argc, char** argv) {
     }
 
     printf("\nDone\n");
-    free(train_images);
-    free(train_labels);
+    cml_free(train_images);
+    cml_free(train_labels);
     if (test_images)
-        free(test_images);
+        cml_free(test_images);
     if (test_labels)
-        free(test_labels);
+        cml_free(test_labels);
 
     tensor_free(X_train);
     tensor_free(y_train);

--- a/examples/demos/training_loop_example.c
+++ b/examples/demos/training_loop_example.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 static void training_example(void) {
     cml_init();
@@ -181,9 +182,9 @@ static void training_example(void) {
                         }
                     }
                     if (unopt)
-                        free(unopt);
+                        cml_free(unopt);
                     if (opt)
-                        free(opt);
+                        cml_free(opt);
                 }
             }
 

--- a/examples/mlperf/mlperf_resnet50.c
+++ b/examples/mlperf/mlperf_resnet50.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <math.h>
 #include <time.h>
+#include "alloc/cml_allocator.h"
 
 typedef struct {
     const char* data_dir;
@@ -65,7 +66,7 @@ static void random_crop_flip(float* img, int h, int w, int c) {
     int off_y = rand() % (h - crop_h + 1);
     int off_x = rand() % (w - crop_w + 1);
 
-    float* tmp = malloc(sizeof(float) * crop_h * crop_w * c);
+    float* tmp = cml_malloc(sizeof(float) * crop_h * crop_w * c);
     if (!tmp) return;
 
     for (int y = 0; y < crop_h; y++)
@@ -88,7 +89,7 @@ static void random_crop_flip(float* img, int h, int w, int c) {
     }
 
     memcpy(img, tmp, sizeof(float) * crop_h * crop_w * c);
-    free(tmp);
+    cml_free(tmp);
 }
 
 static int compute_topk(Tensor* logits, int* labels, int batch_size, int num_classes, int k) {
@@ -161,13 +162,13 @@ int main(int argc, char** argv) {
 
     int input_shape[] = { cfg.batch_size, img_c, img_h, img_w };
 
-    float* batch_data = malloc(sizeof(float) * cfg.batch_size * img_c * img_h * img_w);
-    int* batch_labels = malloc(sizeof(int) * cfg.batch_size);
+    float* batch_data = cml_malloc(sizeof(float) * cfg.batch_size * img_c * img_h * img_w);
+    int* batch_labels = cml_malloc(sizeof(int) * cfg.batch_size);
 
     if (!batch_data || !batch_labels) {
         fprintf(stderr, "Failed to allocate batch buffers\n");
-        free(batch_data);
-        free(batch_labels);
+        cml_free(batch_data);
+        cml_free(batch_labels);
         optimizer_free(opt);
         module_free(model);
         return 1;
@@ -202,7 +203,7 @@ int main(int argc, char** argv) {
                 continue;
             }
 
-            float* label_floats = malloc(sizeof(float) * cfg.batch_size * num_classes);
+            float* label_floats = cml_malloc(sizeof(float) * cfg.batch_size * num_classes);
             if (!label_floats) continue;
             memset(label_floats, 0, sizeof(float) * cfg.batch_size * num_classes);
             for (int b = 0; b < cfg.batch_size; b++)
@@ -226,7 +227,7 @@ int main(int argc, char** argv) {
                        epoch + 1, step, steps_per_epoch, loss_val, throughput);
             }
 
-            free(label_floats);
+            cml_free(label_floats);
             cml_reset_ir_context();
         }
 
@@ -284,8 +285,8 @@ int main(int argc, char** argv) {
     mlperf_log_metric("total_training_time", total_time);
     mlperf_log_end("resnet50", converged ? "success" : "aborted");
 
-    free(batch_data);
-    free(batch_labels);
+    cml_free(batch_data);
+    cml_free(batch_labels);
     optimizer_free(opt);
     module_free(model);
 

--- a/examples/tutorials/conv_net.c
+++ b/examples/tutorials/conv_net.c
@@ -1,6 +1,7 @@
 #include "cml.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include "alloc/cml_allocator.h"
 
 int main(void) {
     cml_init();
@@ -33,8 +34,8 @@ int main(void) {
     int n_test = n - n_train;
     printf("Train: %d, Test: %d\n\n", n_train, n_test);
 
-    float* train_labels = malloc(sizeof(float) * n_train);
-    float* test_labels = malloc(sizeof(float) * n_test);
+    float* train_labels = cml_malloc(sizeof(float) * n_train);
+    float* test_labels = cml_malloc(sizeof(float) * n_test);
     for (int i = 0; i < n_train; i++)
         train_labels[i] = (y_all[i] < 5.0f) ? 0.0f : 1.0f;
     for (int i = 0; i < n_test; i++)
@@ -82,8 +83,8 @@ int main(void) {
     printf("\nTest accuracy (low vs high digits): %d/%d (%.1f%%)\n",
            correct, n_test, correct / (float)n_test * 100);
 
-    free(train_labels);
-    free(test_labels);
+    cml_free(train_labels);
+    cml_free(test_labels);
     cml_cleanup();
     return 0;
 }

--- a/examples/tutorials/mlp_classifier.c
+++ b/examples/tutorials/mlp_classifier.c
@@ -1,6 +1,7 @@
 #include "cml.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include "alloc/cml_allocator.h"
 
 int main(void) {
     cml_init();
@@ -21,7 +22,7 @@ int main(void) {
     int nc = 3;
 
     float* train_y_raw = (float*)tensor_data_ptr(train->y);
-    float* onehot = calloc(n_train * nc, sizeof(float));
+    float* onehot = cml_calloc(n_train * nc, sizeof(float));
     for (int i = 0; i < n_train; i++) {
         int cls = (int)train_y_raw[i];
         if (cls >= 0 && cls < nc)
@@ -75,7 +76,7 @@ int main(void) {
     printf("\nTest accuracy: %d/%d (%.1f%%)\n", correct, n_test,
            correct / (float)n_test * 100);
 
-    free(onehot);
+    cml_free(onehot);
     cml_cleanup();
     return 0;
 }

--- a/examples/tutorials/multi_task.c
+++ b/examples/tutorials/multi_task.c
@@ -1,6 +1,7 @@
 #include "cml.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include "alloc/cml_allocator.h"
 
 #define N_EPOCHS 100
 
@@ -14,17 +15,17 @@ int main(void) {
     int n = ds->num_samples;
     int nf = ds->input_size;
 
-    float* raw_y = malloc(sizeof(float) * n);
+    float* raw_y = cml_malloc(sizeof(float) * n);
     for (int i = 0; i < n; i++)
         raw_y[i] = tensor_get_float(ds->y, i);
 
-    float* reg_target = malloc(sizeof(float) * n);
+    float* reg_target = cml_malloc(sizeof(float) * n);
     for (int i = 0; i < n; i++)
         reg_target[i] = tensor_get_float(ds->X, i * nf + 0);
 
     dataset_normalize(ds, "minmax");
 
-    float* cls_target = malloc(sizeof(float) * n);
+    float* cls_target = cml_malloc(sizeof(float) * n);
     for (int i = 0; i < n; i++)
         cls_target[i] = (raw_y[i] == 1.0f) ? 1.0f : 0.0f;
 
@@ -112,9 +113,9 @@ int main(void) {
     printf("Classification accuracy: %d/%d (%.0f%%)\n",
            total_correct, n, total_correct / (float)n * 100);
 
-    free(raw_y);
-    free(reg_target);
-    free(cls_target);
+    cml_free(raw_y);
+    cml_free(reg_target);
+    cml_free(cls_target);
     cml_cleanup();
     return 0;
 }

--- a/include/alloc/cml_allocator.h
+++ b/include/alloc/cml_allocator.h
@@ -1,0 +1,40 @@
+#ifndef CML_ALLOCATOR_H
+#define CML_ALLOCATOR_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Ultra fast custom allocator replacing malloc/calloc/realloc/free/strdup.
+ * Design: thread-local caches + size-class segregated freelists + slab carving.
+ * Small/medium allocations are O(1) with almost no lock contention on fast path.
+ * Large allocations fall back to mmap-backed direct paths (zero syscall amortization).
+ * Allocations are at least 16-byte aligned (64-byte for >=64B requests when possible).
+ */
+
+/* Core replacements */
+void*  cml_malloc(size_t size);
+void*  cml_calloc(size_t nmemb, size_t size);
+void*  cml_realloc(void* ptr, size_t new_size);
+void   cml_free(void* ptr);
+
+/* String helper */
+char*  cml_strdup(const char* s);
+
+/* Aligned allocation (alignment must be power of two, >= 16) */
+void*  cml_aligned_alloc(size_t size, size_t alignment);
+void   cml_aligned_free(void* ptr); /* safe to mix with cml_free in most cases */
+
+/* Stats (approximate, racy) */
+void   cml_allocator_get_stats(size_t* bytes_allocated, size_t* peak_bytes, size_t* alloc_count);
+
+/* Optional: flush this thread's caches back to central (call before thread exit if desired) */
+void   cml_allocator_flush_thread_cache(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CML_ALLOCATOR_H */

--- a/include/alloc/cml_allocator.h
+++ b/include/alloc/cml_allocator.h
@@ -23,9 +23,27 @@ void   cml_free(void* ptr);
 /* String helper */
 char*  cml_strdup(const char* s);
 
-/* Aligned allocation (alignment must be power of two, >= 16) */
+/* Aligned allocation (alignment must be power of two, >= 16).
+ *
+ * IMPORTANT: pointers returned by cml_aligned_alloc() MUST be freed with
+ * cml_aligned_free(), not cml_free().
+ *
+ * cml_aligned_alloc() returns an address that may not point at the normal
+ * AllocHeader layout used by cml_malloc(); it stores a small delta prefix
+ * before the returned pointer so the real backing block can be recovered.
+ * Passing that pointer directly to cml_free() will read a bogus header
+ * (magic mismatch / wrong class_idx) and either leak the block or corrupt
+ * the allocator state.
+ *
+ * Conversely, cml_malloc()/cml_calloc()/cml_realloc() pointers must be freed
+ * with cml_free() (or cml_realloc(ptr, 0)), never cml_aligned_free().
+ *
+ * Also never mix system malloc/calloc/aligned_alloc/posix_memalign pointers
+ * with cml_free() or cml_aligned_free() — those must go through the matching
+ * system free() (or cml_malloc/cml_aligned_alloc equivalents end-to-end).
+ */
 void*  cml_aligned_alloc(size_t size, size_t alignment);
-void   cml_aligned_free(void* ptr); /* safe to mix with cml_free in most cases */
+void   cml_aligned_free(void* ptr);
 
 /* Stats (approximate, racy) */
 void   cml_allocator_get_stats(size_t* bytes_allocated, size_t* peak_bytes, size_t* alloc_count);

--- a/include/cml.h
+++ b/include/cml.h
@@ -5,6 +5,7 @@
 
 #include "core/logging.h"
 #include "alloc/memory_management.h"
+#include "alloc/cml_allocator.h"
 #include "core/error_codes.h"
 #include "core/error_stack.h"
 #include "core/dataset.h"

--- a/include/core/logging.h
+++ b/include/core/logging.h
@@ -2,6 +2,7 @@
 #define CML_LOGGING_H
 
 #include <stdarg.h>
+#include "alloc/cml_allocator.h"
 
 typedef enum {
     LOG_LEVEL_DEBUG   = 0,

--- a/src/alloc/cml_allocator.c
+++ b/src/alloc/cml_allocator.c
@@ -1,0 +1,576 @@
+/*
+ * cml_allocator.c
+ *
+ * Extremely fast general-purpose allocator for C-ML.
+ * - Thread-cached size-class segregated freelists (rpmalloc / tcmalloc inspiration, simplified).
+ * - Slabs carved from backing (malloc for portability + simplicity; hot path is pure freelist).
+ * - Low contention: hot alloc/free usually no locks.
+ * - 16B alignment base. Larger requests get better alignment opportunistically.
+ * - Direct path (mmap style via libc or aligned) for huge allocations.
+ * Goal: beat or match system malloc in throughput + much lower latency variance for ML workloads.
+ */
+
+#include "alloc/cml_allocator.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>   /* only for optional stats print, remove if want zero dep */
+
+/* System backing allocator for internal slab/large acquisition only.
+ * We must NEVER call our own cml_* here for bootstrapping the allocator itself. */
+static inline void* system_malloc(size_t sz) { return malloc(sz); }
+static inline void  system_free(void* p)     { free(p); }
+static inline int   system_posix_memalign(void** memptr, size_t alignment, size_t size) {
+    return posix_memalign(memptr, alignment, size);
+}
+
+/* Tunables for "fast as fuck" */
+#define CML_SLAB_SIZE          (256 * 1024)   /* 256 KiB slabs - sweet spot for cache + TLB */
+#define CML_MAX_LOCAL_CACHE    64             /* max free objects kept per class in TLS before flushing batch */
+#define CML_LARGE_THRESHOLD    (128 * 1024)   /* >=128KiB: direct path */
+#define CML_MIN_ALIGN          16
+#define CML_HEADER_SIZE        16             /* 16B header => good default alignment for returned ptrs */
+
+_Static_assert(CML_HEADER_SIZE >= 16 && (CML_HEADER_SIZE % 16) == 0, "header must preserve alignment");
+
+/* Per-allocation header. Lives immediately before user pointer. */
+typedef struct {
+    uint32_t size;       /* requested user bytes */
+    uint16_t class_idx;  /* which size class (0xffff for large/direct) */
+    uint16_t magic;      /* 0xC4A1 for sanity */
+} AllocHeader;
+
+#define ALLOC_MAGIC 0xC4A1
+
+static inline AllocHeader* header_from_user(void* user) {
+    if (!user) return NULL;
+    return (AllocHeader*)((char*)user - CML_HEADER_SIZE);
+}
+
+static inline void* user_from_header(AllocHeader* h) {
+    return (char*)h + CML_HEADER_SIZE;
+}
+
+/* ---------------- Size classes ----------------
+ * We use a compact table of increasing sizes. Good balance of internal fragmentation vs #classes.
+ * Classes chosen so small objects (common for structs, nodes, small temps) have tight fits.
+ */
+static const size_t SIZE_CLASSES[] = {
+    /* 0-15: 16B granularity for tiny */
+    16,  32,  48,  64,  80,  96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256,
+    /* 16-23: 32B steps */
+    288, 320, 352, 384, 416, 448, 480, 512,
+    /* 24-29: 64B steps */
+    576, 640, 704, 768, 832, 896,
+    /* 30-33: 128B steps */
+    1024, 1152, 1280, 1408,
+    /* 34-37: 256B steps */
+    1536, 1792, 2048, 2304,
+    /* 38-41: 512B steps */
+    2560, 3072, 3584, 4096,
+    /* 42-45: 1KiB steps up to 8KiB */
+    4608, 5120, 5632, 6144, 6656, 7168, 7680, 8192,
+    /* 50-53: 2KiB steps */
+    9216, 10240, 11264, 12288,
+    /* 54-57: 4KiB steps to 24KiB */
+    14336, 16384, 18432, 20480, 22528, 24576,
+    /* 60-62: bigger for "medium" */
+    28672, 32768, 40960,
+    /* last few before large threshold */
+    49152, 65536, 98304
+};
+#define NUM_SIZE_CLASSES (sizeof(SIZE_CLASSES) / sizeof(SIZE_CLASSES[0]))
+
+static inline int size_to_class(size_t size) {
+    if (size <= SIZE_CLASSES[0]) return 0;
+    /* Linear scan is fine: NUM_SIZE_CLASSES ~ 65, called only on slow paths or first alloc per size. */
+    for (int i = 0; i < NUM_SIZE_CLASSES; ++i) {
+        if (size <= SIZE_CLASSES[i]) return i;
+    }
+    return -1; /* large */
+}
+
+static inline size_t class_to_size(int cls) {
+    if (cls < 0 || cls >= NUM_SIZE_CLASSES) return 0;
+    return SIZE_CLASSES[cls];
+}
+
+/* ---------------- Slab + block structures ---------------- */
+
+typedef struct FreeNode {
+    struct FreeNode* next;
+} FreeNode;
+
+typedef struct Slab {
+    struct Slab*   next;
+    uint32_t       class_idx;
+    uint32_t       num_blocks;
+    uint32_t       used_blocks;
+    char           data[];   /* flexible: the carved blocks start here */
+} Slab;
+
+/* One central freelist + mutex per size class */
+typedef struct {
+    pthread_mutex_t lock;
+    FreeNode*       head;
+    size_t          total_slabs;   /* approx */
+} CentralBin;
+
+/* Thread-local cache */
+typedef struct {
+    FreeNode* heads[NUM_SIZE_CLASSES];
+    uint16_t  counts[NUM_SIZE_CLASSES];
+    bool      initialized;
+} ThreadCache;
+
+static CentralBin   g_central[NUM_SIZE_CLASSES];
+static pthread_mutex_t g_init_lock = PTHREAD_MUTEX_INITIALIZER;
+static bool         g_initialized = false;
+
+/* Thread local */
+static __thread ThreadCache tl_cache = {0};
+
+/* Stats (best effort, not perfectly accurate under races) */
+static size_t g_total_allocated_bytes = 0;
+static size_t g_peak_allocated_bytes  = 0;
+static size_t g_alloc_count           = 0;
+
+/* Forward */
+static void*  alloc_from_class(int cls, size_t user_size);
+static void   free_to_class(int cls, void* user_ptr, size_t user_size);
+static void*  alloc_large(size_t size);
+static void   free_large(void* ptr);
+static void   init_once(void);
+static Slab*  carve_new_slab(int cls);
+static void   refill_from_central(int cls);
+static void   flush_local_to_central(int cls, int keep);
+
+/* ---------------- Initialization ---------------- */
+
+static void init_central_bins(void) {
+    for (int i = 0; i < NUM_SIZE_CLASSES; ++i) {
+        pthread_mutex_init(&g_central[i].lock, NULL);
+        g_central[i].head = NULL;
+        g_central[i].total_slabs = 0;
+    }
+}
+
+static void init_once(void) {
+    pthread_mutex_lock(&g_init_lock);
+    if (!g_initialized) {
+        init_central_bins();
+        g_initialized = true;
+    }
+    pthread_mutex_unlock(&g_init_lock);
+}
+
+static inline void ensure_init(void) {
+    if (!g_initialized) {
+        init_once();
+    }
+    if (!tl_cache.initialized) {
+        memset(&tl_cache, 0, sizeof(tl_cache));
+        tl_cache.initialized = true;
+    }
+}
+
+/* ---------------- Slab carving ---------------- */
+
+static Slab* carve_new_slab(int cls) {
+    size_t bin_size = class_to_size(cls);
+    if (bin_size == 0) return NULL;
+
+    /* We allocate the slab header + data region with libc malloc.
+     * This cost is amortized over hundreds of objects per slab.
+     */
+    size_t usable = CML_SLAB_SIZE - sizeof(Slab);
+    size_t num_blocks = usable / (CML_HEADER_SIZE + bin_size);
+    if (num_blocks < 1) {
+        /* Extremely large class inside "small" path - fall back */
+        num_blocks = 1;
+    }
+
+    size_t alloc_sz = sizeof(Slab) + num_blocks * (CML_HEADER_SIZE + bin_size);
+    /* Align the slab allocation a bit */
+    void* raw = system_malloc(alloc_sz + 64);
+    if (!raw) return NULL;
+
+    /* Align start of Slab data area for cleanliness */
+    uintptr_t base = (uintptr_t)raw;
+    uintptr_t aligned_base = (base + 63) & ~(uintptr_t)63;
+    Slab* slab = (Slab*)aligned_base;
+
+    slab->next = NULL;
+    slab->class_idx = (uint32_t)cls;
+    slab->num_blocks = (uint32_t)num_blocks;
+    slab->used_blocks = 0;
+
+    /* Build intrusive free list for this slab directly into the central for this class */
+    char* p = (char*)slab->data;
+    FreeNode* first = NULL;
+    FreeNode* prev = NULL;
+
+    for (uint32_t i = 0; i < num_blocks; ++i) {
+        AllocHeader* hdr = (AllocHeader*)p;
+        hdr->size = 0;
+        hdr->class_idx = (uint16_t)cls;
+        hdr->magic = ALLOC_MAGIC;
+
+        FreeNode* node = (FreeNode*)(p + CML_HEADER_SIZE);
+        node->next = NULL;
+
+        if (!first) first = node;
+        if (prev) prev->next = node;
+        prev = node;
+
+        p += CML_HEADER_SIZE + bin_size;
+    }
+
+    /* Insert the whole chain into central under caller lock (or we can do it here) */
+    if (first) {
+        pthread_mutex_lock(&g_central[cls].lock);
+        prev->next = g_central[cls].head;
+        g_central[cls].head = first;
+        g_central[cls].total_slabs++;
+        pthread_mutex_unlock(&g_central[cls].lock);
+    }
+
+    return slab;
+}
+
+/* ---------------- Refill / flush ---------------- */
+
+static void refill_from_central(int cls) {
+    /* Steal a batch from central into thread local */
+    const int want = 32; /* batch size */
+    FreeNode* stolen = NULL;
+    int got = 0;
+
+    pthread_mutex_lock(&g_central[cls].lock);
+    FreeNode* cur = g_central[cls].head;
+    FreeNode* prev = NULL;
+    while (cur && got < want) {
+        FreeNode* next = cur->next;
+        /* unlink */
+        if (prev) prev->next = next;
+        else g_central[cls].head = next;
+        cur->next = stolen;
+        stolen = cur;
+        cur = next;
+        ++got;
+    }
+    pthread_mutex_unlock(&g_central[cls].lock);
+
+    if (got > 0) {
+        tl_cache.heads[cls] = stolen;
+        tl_cache.counts[cls] = (uint16_t)got;
+    }
+}
+
+static void flush_local_to_central(int cls, int keep) {
+    FreeNode* list = tl_cache.heads[cls];
+    uint16_t cnt = tl_cache.counts[cls];
+    if (!list || cnt <= (uint16_t)keep) return;
+
+    /* Detach the excess tail */
+    FreeNode* keep_head = list;
+    FreeNode* tail = list;
+    int keep_cnt = 0;
+    while (keep_cnt < keep && tail) {
+        ++keep_cnt;
+        if (keep_cnt < keep) tail = tail->next;
+    }
+    if (!tail) {
+        /* nothing to flush */
+        return;
+    }
+    FreeNode* flush_head = tail->next;
+    tail->next = NULL;
+    tl_cache.heads[cls] = keep_head;
+    tl_cache.counts[cls] = (uint16_t)keep_cnt;
+
+    if (flush_head) {
+        /* Append flush list to central */
+        pthread_mutex_lock(&g_central[cls].lock);
+        /* Find end of flush list to splice */
+        FreeNode* f = flush_head;
+        while (f->next) f = f->next;
+        f->next = g_central[cls].head;
+        g_central[cls].head = flush_head;
+        pthread_mutex_unlock(&g_central[cls].lock);
+    }
+}
+
+/* ---------------- Allocation paths ---------------- */
+
+static void* alloc_from_class(int cls, size_t user_size) {
+    ensure_init();
+
+    /* Fast path: thread local */
+    FreeNode* node = tl_cache.heads[cls];
+    if (node) {
+        tl_cache.heads[cls] = node->next;
+        tl_cache.counts[cls]--;
+        AllocHeader* hdr = (AllocHeader*)((char*)node - CML_HEADER_SIZE);
+        hdr->size = (uint32_t)user_size;
+        hdr->class_idx = (uint16_t)cls;
+        hdr->magic = ALLOC_MAGIC;
+
+        /* update stats */
+        __atomic_add_fetch(&g_total_allocated_bytes, user_size, __ATOMIC_RELAXED);
+        __atomic_add_fetch(&g_alloc_count, 1, __ATOMIC_RELAXED);
+        size_t cur = __atomic_load_n(&g_total_allocated_bytes, __ATOMIC_RELAXED);
+        size_t pk = __atomic_load_n(&g_peak_allocated_bytes, __ATOMIC_RELAXED);
+        if (cur > pk) {
+            __atomic_store_n(&g_peak_allocated_bytes, cur, __ATOMIC_RELAXED);
+        }
+        return user_from_header(hdr);
+    }
+
+    /* Slow path: refill */
+    if (tl_cache.counts[cls] == 0) {
+        refill_from_central(cls);
+    }
+
+    node = tl_cache.heads[cls];
+    if (!node) {
+        /* Still nothing: carve a new slab (this will also populate central) */
+        (void)carve_new_slab(cls);
+        refill_from_central(cls);
+        node = tl_cache.heads[cls];
+    }
+
+    if (!node) {
+        /* OOM fallback: try libc directly for this bin size */
+        size_t bin = class_to_size(cls);
+        void* raw = system_malloc(CML_HEADER_SIZE + bin);
+        if (!raw) return NULL;
+        AllocHeader* hdr = (AllocHeader*)raw;
+        hdr->size = (uint32_t)user_size;
+        hdr->class_idx = (uint16_t)cls;
+        hdr->magic = ALLOC_MAGIC;
+        return user_from_header(hdr);
+    }
+
+    tl_cache.heads[cls] = node->next;
+    tl_cache.counts[cls]--;
+
+    AllocHeader* hdr = (AllocHeader*)((char*)node - CML_HEADER_SIZE);
+    hdr->size = (uint32_t)user_size;
+    hdr->class_idx = (uint16_t)cls;
+    hdr->magic = ALLOC_MAGIC;
+
+    __atomic_add_fetch(&g_total_allocated_bytes, user_size, __ATOMIC_RELAXED);
+    __atomic_add_fetch(&g_alloc_count, 1, __ATOMIC_RELAXED);
+    size_t cur = __atomic_load_n(&g_total_allocated_bytes, __ATOMIC_RELAXED);
+    size_t pk = __atomic_load_n(&g_peak_allocated_bytes, __ATOMIC_RELAXED);
+    if (cur > pk) __atomic_store_n(&g_peak_allocated_bytes, cur, __ATOMIC_RELAXED);
+
+    return user_from_header(hdr);
+}
+
+static void* alloc_large(size_t size) {
+    ensure_init();
+    /* Large: allocate with extra header using system backing (never our cml_*) */
+    size_t total = CML_HEADER_SIZE + size;
+    /* Force good alignment for large data (64B) */
+    void* raw = NULL;
+    if (system_posix_memalign(&raw, 64, total) != 0) {
+        raw = system_malloc(total);
+        if (!raw) return NULL;
+    }
+    AllocHeader* hdr = (AllocHeader*)raw;
+    hdr->size = (uint32_t)size;
+    hdr->class_idx = 0xffff;
+    hdr->magic = ALLOC_MAGIC;
+
+    __atomic_add_fetch(&g_total_allocated_bytes, size, __ATOMIC_RELAXED);
+    __atomic_add_fetch(&g_alloc_count, 1, __ATOMIC_RELAXED);
+    size_t cur = __atomic_load_n(&g_total_allocated_bytes, __ATOMIC_RELAXED);
+    size_t pk = __atomic_load_n(&g_peak_allocated_bytes, __ATOMIC_RELAXED);
+    if (cur > pk) __atomic_store_n(&g_peak_allocated_bytes, cur, __ATOMIC_RELAXED);
+
+    return user_from_header(hdr);
+}
+
+void* cml_malloc(size_t size) {
+    if (size == 0) size = 1; /* classic */
+
+    if (size >= CML_LARGE_THRESHOLD) {
+        return alloc_large(size);
+    }
+
+    int cls = size_to_class(size);
+    if (cls < 0) {
+        return alloc_large(size);
+    }
+    return alloc_from_class(cls, size);
+}
+
+void* cml_calloc(size_t nmemb, size_t size) {
+    size_t bytes;
+    if (__builtin_mul_overflow(nmemb, size, &bytes)) return NULL;
+    void* p = cml_malloc(bytes);
+    if (p) {
+        memset(p, 0, bytes);
+    }
+    return p;
+}
+
+void* cml_realloc(void* ptr, size_t new_size) {
+    if (!ptr) return cml_malloc(new_size);
+    if (new_size == 0) {
+        cml_free(ptr);
+        return NULL;
+    }
+
+    AllocHeader* hdr = header_from_user(ptr);
+    if (!hdr || hdr->magic != ALLOC_MAGIC) {
+        /* Not from us or corrupted. Fall back to libc behavior? */
+        /* For safety in mixed world we could abort or delegate, but assume all go through us. */
+        return NULL;
+    }
+
+    size_t old_size = hdr->size;
+    if (new_size <= old_size) {
+        /* Shrink: keep same block, just update header */
+        hdr->size = (uint32_t)new_size;
+        /* Note: we do not give memory back to freelist for shrink here (common & fast) */
+        __atomic_sub_fetch(&g_total_allocated_bytes, (old_size - new_size), __ATOMIC_RELAXED);
+        return ptr;
+    }
+
+    /* Grow: allocate new + copy */
+    void* newp = cml_malloc(new_size);
+    if (!newp) return NULL;
+    memcpy(newp, ptr, old_size < new_size ? old_size : new_size);
+    cml_free(ptr);
+    return newp;
+}
+
+static void free_to_class(int cls, void* user_ptr, size_t user_size) {
+    (void)user_size;
+    ensure_init();
+
+    AllocHeader* hdr = header_from_user(user_ptr);
+    if (!hdr || hdr->magic != ALLOC_MAGIC) return;
+
+    /* Mark as freed for double-free detection (optional) */
+    hdr->magic = 0xdead;
+
+    FreeNode* node = (FreeNode*)user_ptr;  /* user_ptr is exactly after header */
+    node->next = tl_cache.heads[cls];
+    tl_cache.heads[cls] = node;
+    tl_cache.counts[cls]++;
+
+    __atomic_sub_fetch(&g_total_allocated_bytes, user_size, __ATOMIC_RELAXED);
+
+    /* If local cache is fat, flush some back to central (keeps memory bounded per thread) */
+    if (tl_cache.counts[cls] > CML_MAX_LOCAL_CACHE) {
+        flush_local_to_central(cls, CML_MAX_LOCAL_CACHE / 2);
+    }
+}
+
+static void free_large(void* ptr) {
+    AllocHeader* hdr = header_from_user(ptr);
+    if (!hdr || hdr->magic != ALLOC_MAGIC) return;
+    size_t sz = hdr->size;
+    hdr->magic = 0xdead;
+
+    __atomic_sub_fetch(&g_total_allocated_bytes, sz, __ATOMIC_RELAXED);
+
+    /* Use system free on the raw header start (we used posix_memalign or system_malloc) */
+    system_free(hdr);
+}
+
+void cml_free(void* ptr) {
+    if (!ptr) return;
+
+    AllocHeader* hdr = header_from_user(ptr);
+    if (!hdr || hdr->magic != ALLOC_MAGIC) {
+        /* Foreign pointer: ignore or optionally call system free. For purity we ignore. */
+        return;
+    }
+
+    int cls = hdr->class_idx;
+    size_t sz = hdr->size;
+
+    if (cls == 0xffff || sz >= CML_LARGE_THRESHOLD) {
+        free_large(ptr);
+        return;
+    }
+
+    free_to_class(cls, ptr, sz);
+}
+
+char* cml_strdup(const char* s) {
+    if (!s) return NULL;
+    size_t len = strlen(s) + 1;
+    char* p = (char*)cml_malloc(len);
+    if (p) memcpy(p, s, len);
+    return p;
+}
+
+void* cml_aligned_alloc(size_t size, size_t alignment) {
+    if (alignment < CML_MIN_ALIGN) alignment = CML_MIN_ALIGN;
+    if ((alignment & (alignment - 1)) != 0) {
+        /* not power of 2: normalize */
+        alignment--;
+        alignment |= alignment >> 1;
+        alignment |= alignment >> 2;
+        alignment |= alignment >> 4;
+        alignment |= alignment >> 8;
+        alignment |= alignment >> 16;
+        alignment++;
+    }
+
+    /* We allocate extra space so we can store header + satisfy alignment */
+    size_t header_and_pad = CML_HEADER_SIZE + alignment - 1;
+    void* raw = cml_malloc(size + header_and_pad);
+    if (!raw) return NULL;
+
+    /* Find aligned user position after header */
+    uintptr_t addr = (uintptr_t)raw + CML_HEADER_SIZE;
+    uintptr_t aligned = (addr + alignment - 1) & ~(alignment - 1);
+
+    /* We need to store the original base (raw) so free can find the header.
+     * To keep things simple we over-allocate in the header a "delta".
+     * For speed we store the delta to the real header start in the first bytes after padding.
+     * Simpler approach: use a slightly larger header area for aligned.
+     *
+     * For this impl we record the "backing header" by writing a small prefix right before the aligned user ptr.
+     * We will store at (aligned - 8) the distance back to our AllocHeader.
+     */
+    ptrdiff_t delta = (ptrdiff_t)(aligned - (uintptr_t)raw);
+    /* Store delta just before user data. We use 8 bytes for delta (fits in the alignment padding). */
+    *((ptrdiff_t*)((char*)aligned - sizeof(ptrdiff_t))) = delta;
+
+    /* Return the aligned address. The header lives at (aligned - delta) */
+    return (void*)aligned;
+}
+
+void cml_aligned_free(void* ptr) {
+    if (!ptr) return;
+    /* Recover the original header using stored delta */
+    ptrdiff_t delta = *((ptrdiff_t*)((char*)ptr - sizeof(ptrdiff_t)));
+    void* real_user = (char*)ptr - delta;
+    cml_free(real_user);
+}
+
+void cml_allocator_get_stats(size_t* bytes_allocated, size_t* peak_bytes, size_t* alloc_count) {
+    if (bytes_allocated) *bytes_allocated = __atomic_load_n(&g_total_allocated_bytes, __ATOMIC_RELAXED);
+    if (peak_bytes)      *peak_bytes      = __atomic_load_n(&g_peak_allocated_bytes, __ATOMIC_RELAXED);
+    if (alloc_count)     *alloc_count     = __atomic_load_n(&g_alloc_count, __ATOMIC_RELAXED);
+}
+
+void cml_allocator_flush_thread_cache(void) {
+    if (!tl_cache.initialized) return;
+    for (int c = 0; c < NUM_SIZE_CLASSES; ++c) {
+        if (tl_cache.counts[c] > 0) {
+            flush_local_to_central(c, 0);
+        }
+    }
+}

--- a/src/alloc/cml_allocator.c
+++ b/src/alloc/cml_allocator.c
@@ -36,12 +36,16 @@ static inline int   system_posix_memalign(void** memptr, size_t alignment, size_
 
 _Static_assert(CML_HEADER_SIZE >= 16 && (CML_HEADER_SIZE % 16) == 0, "header must preserve alignment");
 
-/* Per-allocation header. Lives immediately before user pointer. */
+/* Per-allocation header. Lives immediately before user pointer.
+ * size is size_t so large tensors / buffers well beyond 4 GiB are representable. */
 typedef struct {
-    uint32_t size;       /* requested user bytes */
+    size_t   size;       /* requested user bytes */
     uint16_t class_idx;  /* which size class (0xffff for large/direct) */
     uint16_t magic;      /* 0xC4A1 for sanity */
 } AllocHeader;
+
+_Static_assert(sizeof(AllocHeader) <= CML_HEADER_SIZE,
+               "AllocHeader must fit in CML_HEADER_SIZE");
 
 #define ALLOC_MAGIC 0xC4A1
 
@@ -106,11 +110,18 @@ typedef struct FreeNode {
 
 typedef struct Slab {
     struct Slab*   next;
+    void*          system_base; /* original pointer from system_malloc; used for system_free */
     uint32_t       class_idx;
     uint32_t       num_blocks;
     uint32_t       used_blocks;
     char           data[];   /* flexible: the carved blocks start here */
 } Slab;
+
+/* Track live slabs so we can eventually system_free their original base.
+ * Currently slabs are process-lifetime (standard for this style of allocator),
+ * but we must not lose the system_malloc pointer after alignment. */
+static pthread_mutex_t g_slab_list_lock = PTHREAD_MUTEX_INITIALIZER;
+static Slab* g_slab_list = NULL;
 
 /* One central freelist + mutex per size class */
 typedef struct {
@@ -194,16 +205,17 @@ static Slab* carve_new_slab(int cls) {
     }
 
     size_t alloc_sz = sizeof(Slab) + num_blocks * (CML_HEADER_SIZE + bin_size);
-    /* Align the slab allocation a bit */
+    /* Align the slab allocation a bit; keep the original system pointer so we can free it. */
     void* raw = system_malloc(alloc_sz + 64);
     if (!raw) return NULL;
 
-    /* Align start of Slab data area for cleanliness */
+    /* Align start of Slab structure for cleanliness */
     uintptr_t base = (uintptr_t)raw;
     uintptr_t aligned_base = (base + 63) & ~(uintptr_t)63;
     Slab* slab = (Slab*)aligned_base;
 
     slab->next = NULL;
+    slab->system_base = raw; /* MUST retain: system_free(raw), not system_free(slab) */
     slab->class_idx = (uint32_t)cls;
     slab->num_blocks = (uint32_t)num_blocks;
     slab->used_blocks = 0;
@@ -237,6 +249,12 @@ static Slab* carve_new_slab(int cls) {
         g_central[cls].total_slabs++;
         pthread_mutex_unlock(&g_central[cls].lock);
     }
+
+    /* Register slab so its system_base is never lost (process-lifetime today). */
+    pthread_mutex_lock(&g_slab_list_lock);
+    slab->next = g_slab_list;
+    g_slab_list = slab;
+    pthread_mutex_unlock(&g_slab_list_lock);
 
     return slab;
 }
@@ -315,7 +333,7 @@ static void* alloc_from_class(int cls, size_t user_size) {
         tl_cache.heads[cls] = node->next;
         tl_cache.counts[cls]--;
         AllocHeader* hdr = (AllocHeader*)((char*)node - CML_HEADER_SIZE);
-        hdr->size = (uint32_t)user_size;
+        hdr->size = user_size;
         hdr->class_idx = (uint16_t)cls;
         hdr->magic = ALLOC_MAGIC;
 
@@ -349,7 +367,7 @@ static void* alloc_from_class(int cls, size_t user_size) {
         void* raw = system_malloc(CML_HEADER_SIZE + bin);
         if (!raw) return NULL;
         AllocHeader* hdr = (AllocHeader*)raw;
-        hdr->size = (uint32_t)user_size;
+        hdr->size = user_size;
         hdr->class_idx = (uint16_t)cls;
         hdr->magic = ALLOC_MAGIC;
         return user_from_header(hdr);
@@ -359,7 +377,7 @@ static void* alloc_from_class(int cls, size_t user_size) {
     tl_cache.counts[cls]--;
 
     AllocHeader* hdr = (AllocHeader*)((char*)node - CML_HEADER_SIZE);
-    hdr->size = (uint32_t)user_size;
+    hdr->size = user_size;
     hdr->class_idx = (uint16_t)cls;
     hdr->magic = ALLOC_MAGIC;
 
@@ -383,7 +401,7 @@ static void* alloc_large(size_t size) {
         if (!raw) return NULL;
     }
     AllocHeader* hdr = (AllocHeader*)raw;
-    hdr->size = (uint32_t)size;
+    hdr->size = size;
     hdr->class_idx = 0xffff;
     hdr->magic = ALLOC_MAGIC;
 
@@ -437,7 +455,7 @@ void* cml_realloc(void* ptr, size_t new_size) {
     size_t old_size = hdr->size;
     if (new_size <= old_size) {
         /* Shrink: keep same block, just update header */
-        hdr->size = (uint32_t)new_size;
+        hdr->size = new_size;
         /* Note: we do not give memory back to freelist for shrink here (common & fast) */
         __atomic_sub_fetch(&g_total_allocated_bytes, (old_size - new_size), __ATOMIC_RELAXED);
         return ptr;

--- a/src/alloc/graph_allocator.c
+++ b/src/alloc/graph_allocator.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <limits.h>
+#include "alloc/cml_allocator.h"
 
 struct CMLGraphAllocator {
     CMLBackendBufferType_t* buffer_types;
@@ -27,29 +28,29 @@ CMLGraphAllocator_t cml_graph_allocator_new(CMLBackendBufferType_t buft) {
         return NULL;
     }
 
-    CMLGraphAllocator_t galloc = malloc(sizeof(struct CMLGraphAllocator));
+    CMLGraphAllocator_t galloc = cml_malloc(sizeof(struct CMLGraphAllocator));
     if (!galloc)
         return NULL;
 
-    galloc->buffer_types    = malloc(sizeof(CMLBackendBufferType_t));
-    galloc->buffers         = malloc(sizeof(CMLBackendBuffer_t));
-    galloc->buffer_sizes    = malloc(sizeof(size_t));
-    galloc->buffer_reserved = malloc(sizeof(bool));
-    galloc->memory_pools    = malloc(sizeof(MemoryPool*));
+    galloc->buffer_types    = cml_malloc(sizeof(CMLBackendBufferType_t));
+    galloc->buffers         = cml_malloc(sizeof(CMLBackendBuffer_t));
+    galloc->buffer_sizes    = cml_malloc(sizeof(size_t));
+    galloc->buffer_reserved = cml_malloc(sizeof(bool));
+    galloc->memory_pools    = cml_malloc(sizeof(MemoryPool*));
 
     if (!galloc->buffer_types || !galloc->buffers || !galloc->buffer_sizes ||
         !galloc->buffer_reserved || !galloc->memory_pools) {
         if (galloc->buffer_types)
-            free(galloc->buffer_types);
+            cml_free(galloc->buffer_types);
         if (galloc->buffers)
-            free(galloc->buffers);
+            cml_free(galloc->buffers);
         if (galloc->buffer_sizes)
-            free(galloc->buffer_sizes);
+            cml_free(galloc->buffer_sizes);
         if (galloc->buffer_reserved)
-            free(galloc->buffer_reserved);
+            cml_free(galloc->buffer_reserved);
         if (galloc->memory_pools)
-            free(galloc->memory_pools);
-        free(galloc);
+            cml_free(galloc->memory_pools);
+        cml_free(galloc);
         return NULL;
     }
 
@@ -70,29 +71,29 @@ CMLGraphAllocator_t cml_graph_allocator_new_n(CMLBackendBufferType_t* bufts, int
         return NULL;
     }
 
-    CMLGraphAllocator_t galloc = malloc(sizeof(struct CMLGraphAllocator));
+    CMLGraphAllocator_t galloc = cml_malloc(sizeof(struct CMLGraphAllocator));
     if (!galloc)
         return NULL;
 
-    galloc->buffer_types    = malloc((size_t)n_bufs * sizeof(CMLBackendBufferType_t));
-    galloc->buffers         = malloc((size_t)n_bufs * sizeof(CMLBackendBuffer_t));
-    galloc->buffer_sizes    = malloc((size_t)n_bufs * sizeof(size_t));
-    galloc->buffer_reserved = malloc((size_t)n_bufs * sizeof(bool));
-    galloc->memory_pools    = malloc((size_t)n_bufs * sizeof(MemoryPool*));
+    galloc->buffer_types    = cml_malloc((size_t)n_bufs * sizeof(CMLBackendBufferType_t));
+    galloc->buffers         = cml_malloc((size_t)n_bufs * sizeof(CMLBackendBuffer_t));
+    galloc->buffer_sizes    = cml_malloc((size_t)n_bufs * sizeof(size_t));
+    galloc->buffer_reserved = cml_malloc((size_t)n_bufs * sizeof(bool));
+    galloc->memory_pools    = cml_malloc((size_t)n_bufs * sizeof(MemoryPool*));
 
     if (!galloc->buffer_types || !galloc->buffers || !galloc->buffer_sizes ||
         !galloc->buffer_reserved || !galloc->memory_pools) {
         if (galloc->buffer_types)
-            free(galloc->buffer_types);
+            cml_free(galloc->buffer_types);
         if (galloc->buffers)
-            free(galloc->buffers);
+            cml_free(galloc->buffers);
         if (galloc->buffer_sizes)
-            free(galloc->buffer_sizes);
+            cml_free(galloc->buffer_sizes);
         if (galloc->buffer_reserved)
-            free(galloc->buffer_reserved);
+            cml_free(galloc->buffer_reserved);
         if (galloc->memory_pools)
-            free(galloc->memory_pools);
-        free(galloc);
+            cml_free(galloc->memory_pools);
+        cml_free(galloc);
         return NULL;
     }
 
@@ -120,7 +121,7 @@ void cml_graph_allocator_free(CMLGraphAllocator_t galloc) {
                 cml_backend_buffer_free(galloc->buffers[i]);
             }
         }
-        free(galloc->buffers);
+        cml_free(galloc->buffers);
     }
 
     if (galloc->memory_pools) {
@@ -129,17 +130,17 @@ void cml_graph_allocator_free(CMLGraphAllocator_t galloc) {
                 memory_pool_free(galloc->memory_pools[i]);
             }
         }
-        free(galloc->memory_pools);
+        cml_free(galloc->memory_pools);
     }
 
     if (galloc->buffer_types)
-        free(galloc->buffer_types);
+        cml_free(galloc->buffer_types);
     if (galloc->buffer_sizes)
-        free(galloc->buffer_sizes);
+        cml_free(galloc->buffer_sizes);
     if (galloc->buffer_reserved)
-        free(galloc->buffer_reserved);
+        cml_free(galloc->buffer_reserved);
 
-    free(galloc);
+    cml_free(galloc);
 }
 
 static size_t calculate_tensor_size(Tensor* tensor) {
@@ -163,20 +164,20 @@ static size_t calculate_peak_memory(CMLComputationGraph_t graph) {
     if (node_count == 0)
         return 0;
 
-    size_t* tensor_sizes = calloc(node_count, sizeof(size_t));
-    int* execution_order = calloc(node_count, sizeof(int));
-    int* use_counts      = calloc(node_count, sizeof(int));
-    bool* is_leaf        = calloc(node_count, sizeof(bool));
+    size_t* tensor_sizes = cml_calloc(node_count, sizeof(size_t));
+    int* execution_order = cml_calloc(node_count, sizeof(int));
+    int* use_counts      = cml_calloc(node_count, sizeof(int));
+    bool* is_leaf        = cml_calloc(node_count, sizeof(bool));
 
     if (!tensor_sizes || !execution_order || !use_counts || !is_leaf) {
         if (tensor_sizes)
-            free(tensor_sizes);
+            cml_free(tensor_sizes);
         if (execution_order)
-            free(execution_order);
+            cml_free(execution_order);
         if (use_counts)
-            free(use_counts);
+            cml_free(use_counts);
         if (is_leaf)
-            free(is_leaf);
+            cml_free(is_leaf);
         // Fallback to adaptive analysis if full analysis fails
         return calculate_peak_memory_simple(graph);
     }
@@ -216,12 +217,12 @@ static size_t calculate_peak_memory(CMLComputationGraph_t graph) {
     }
 
     // Use Kahn's algorithm
-    int* in_degree = calloc(node_count, sizeof(int));
+    int* in_degree = cml_calloc(node_count, sizeof(int));
     if (!in_degree) {
-        free(tensor_sizes);
-        free(execution_order);
-        free(use_counts);
-        free(is_leaf);
+        cml_free(tensor_sizes);
+        cml_free(execution_order);
+        cml_free(use_counts);
+        cml_free(is_leaf);
         return calculate_peak_memory_simple(graph);
     }
 
@@ -238,13 +239,13 @@ static size_t calculate_peak_memory(CMLComputationGraph_t graph) {
         }
     }
 
-    size_t* queue = malloc(node_count * sizeof(size_t));
+    size_t* queue = cml_malloc(node_count * sizeof(size_t));
     if (!queue) {
-        free(tensor_sizes);
-        free(execution_order);
-        free(use_counts);
-        free(is_leaf);
-        free(in_degree);
+        cml_free(tensor_sizes);
+        cml_free(execution_order);
+        cml_free(use_counts);
+        cml_free(is_leaf);
+        cml_free(in_degree);
         return calculate_peak_memory_simple(graph);
     }
 
@@ -287,17 +288,17 @@ static size_t calculate_peak_memory(CMLComputationGraph_t graph) {
         }
     }
 
-    free(in_degree);
-    free(queue);
+    cml_free(in_degree);
+    cml_free(queue);
 
     size_t peak_memory = 0;
 
-    int* alive_until = calloc(node_count, sizeof(int));
+    int* alive_until = cml_calloc(node_count, sizeof(int));
     if (!alive_until) {
-        free(tensor_sizes);
-        free(execution_order);
-        free(use_counts);
-        free(is_leaf);
+        cml_free(tensor_sizes);
+        cml_free(execution_order);
+        cml_free(use_counts);
+        cml_free(is_leaf);
         return calculate_peak_memory_simple(graph);
     }
 
@@ -348,11 +349,11 @@ static size_t calculate_peak_memory(CMLComputationGraph_t graph) {
         }
     }
 
-    free(tensor_sizes);
-    free(execution_order);
-    free(use_counts);
-    free(is_leaf);
-    free(alive_until);
+    cml_free(tensor_sizes);
+    cml_free(execution_order);
+    cml_free(use_counts);
+    cml_free(is_leaf);
+    cml_free(alive_until);
 
     // Ensure minimum allocation (1MB) for small graphs
     if (peak_memory < 1024 * 1024) {
@@ -451,7 +452,7 @@ bool cml_graph_allocator_reserve_n(CMLGraphAllocator_t galloc, void* graph,
     if (graph && node_buffer_ids && leaf_buffer_ids) {
         CMLComputationGraph_t cgraph = (CMLComputationGraph_t)graph;
 
-        size_t* buffer_memory = calloc((size_t)galloc->num_buffers, sizeof(size_t));
+        size_t* buffer_memory = cml_calloc((size_t)galloc->num_buffers, sizeof(size_t));
         if (!buffer_memory) {
             // Fallback to basic reserve
             return cml_graph_allocator_reserve(galloc, graph);
@@ -502,7 +503,7 @@ bool cml_graph_allocator_reserve_n(CMLGraphAllocator_t galloc, void* graph,
             }
         }
 
-        free(buffer_memory);
+        cml_free(buffer_memory);
     } else {
         // Fallback to basic reserve
         return cml_graph_allocator_reserve(galloc, graph);
@@ -659,7 +660,7 @@ struct CMLContext {
 };
 
 CMLContext_t cml_context_new(CMLContextParams params) {
-    CMLContext_t ctx = malloc(sizeof(struct CMLContext));
+    CMLContext_t ctx = cml_malloc(sizeof(struct CMLContext));
     if (!ctx)
         return NULL;
 
@@ -673,13 +674,13 @@ CMLContext_t cml_context_new(CMLContextParams params) {
     if (params.mem_buffer) {
         CMLBackendBufferType_t buft = cml_backend_buffer_type_for_device(ctx->device);
         if (!buft) {
-            free(ctx);
+            cml_free(ctx);
             return NULL;
         }
 
         ctx->buffer = cml_backend_buffer_type_alloc_buffer(buft, params.mem_size);
         if (!ctx->buffer) {
-            free(ctx);
+            cml_free(ctx);
             return NULL;
         }
 
@@ -693,13 +694,13 @@ CMLContext_t cml_context_new(CMLContextParams params) {
     } else if (params.mem_size > 0 && !params.no_alloc) {
         CMLBackendBufferType_t buft = cml_backend_buffer_type_for_device(ctx->device);
         if (!buft) {
-            free(ctx);
+            cml_free(ctx);
             return NULL;
         }
 
         ctx->buffer = cml_backend_buffer_type_alloc_buffer(buft, params.mem_size);
         if (!ctx->buffer) {
-            free(ctx);
+            cml_free(ctx);
             return NULL;
         }
 
@@ -722,7 +723,7 @@ void cml_context_free(CMLContext_t ctx) {
         cml_backend_buffer_free(ctx->buffer);
     }
 
-    free(ctx);
+    cml_free(ctx);
 }
 
 size_t cml_context_used_mem(CMLContext_t ctx) {
@@ -765,7 +766,7 @@ Tensor* cml_context_alloc_tensor(CMLContext_t ctx, int* shape, int ndim, DType d
             tensor->buffer_handle = NULL;
         } else if (tensor->data) {
             if (tensor->device == DEVICE_CPU || tensor->device == DEVICE_AUTO) {
-                free(tensor->data);
+                cml_free(tensor->data);
             } else {
                 device_free(tensor->data, tensor->device);
             }
@@ -826,7 +827,7 @@ int cml_context_set_param(CMLContext_t ctx, Tensor* tensor) {
          * release that allocation first. */
         if (tensor->owns_data && tensor->data) {
             if (tensor->device == DEVICE_CPU || tensor->device == DEVICE_AUTO) {
-                free(tensor->data);
+                cml_free(tensor->data);
             } else {
                 device_free(tensor->data, tensor->device);
             }

--- a/src/alloc/memory_management.c
+++ b/src/alloc/memory_management.c
@@ -4,9 +4,10 @@
 #include "core/error_codes.h"
 #include "core/logging.h"
 #include "backend/device.h"
+#include "alloc/cml_allocator.h"
 
 void* cml_safe_malloc(size_t size, const char* file, int line) {
-    void* ptr = malloc(size);
+    void* ptr = cml_malloc(size);
     if (ptr == NULL) {
         LOG_ERROR("Memory allocation failed for %zu bytes in %s at line %d.", size, file, line);
         return (void*)CM_MEMORY_ALLOCATION_ERROR;
@@ -16,7 +17,7 @@ void* cml_safe_malloc(size_t size, const char* file, int line) {
 }
 
 void* cml_safe_calloc(size_t num, size_t size, const char* file, int line) {
-    void* ptr = calloc(num, size);
+    void* ptr = cml_calloc(num, size);
     if (ptr == NULL) {
         LOG_ERROR("Memory allocation failed for %zu elements of size %zu bytes in %s at line %d.",
                   num, size, file, line);
@@ -28,13 +29,13 @@ void* cml_safe_calloc(size_t num, size_t size, const char* file, int line) {
 
 void cml_safe_free(void** ptr) {
     if (ptr != NULL && *ptr != NULL) {
-        free(*ptr);
+        cml_free(*ptr);
         *ptr = NULL;
     }
 }
 
 void* cml_safe_realloc(void* ptr, size_t size, const char* file, int line) {
-    void* new_ptr = realloc(ptr, size);
+    void* new_ptr = cml_realloc(ptr, size);
     if (new_ptr == NULL) {
         LOG_ERROR("Memory reallocation failed for %zu bytes in %s at line %d.", size, file, line);
         return (void*)CM_MEMORY_ALLOCATION_ERROR;

--- a/src/alloc/memory_pools.c
+++ b/src/alloc/memory_pools.c
@@ -3,6 +3,7 @@
 #include "tensor/tensor.h"
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 MemoryPool* memory_pool_create(size_t block_size, int num_blocks, DType dtype) {
     if (block_size == 0 || num_blocks <= 0) {
@@ -10,35 +11,35 @@ MemoryPool* memory_pool_create(size_t block_size, int num_blocks, DType dtype) {
         return NULL;
     }
 
-    MemoryPool* pool = malloc(sizeof(MemoryPool));
+    MemoryPool* pool = cml_malloc(sizeof(MemoryPool));
     if (!pool)
         return NULL;
 
-    pool->blocks      = malloc((size_t)num_blocks * sizeof(void*));
-    pool->block_sizes = malloc((size_t)num_blocks * sizeof(size_t));
-    pool->used        = malloc((size_t)num_blocks * sizeof(size_t));
+    pool->blocks      = cml_malloc((size_t)num_blocks * sizeof(void*));
+    pool->block_sizes = cml_malloc((size_t)num_blocks * sizeof(size_t));
+    pool->used        = cml_malloc((size_t)num_blocks * sizeof(size_t));
 
     if (!pool->blocks || !pool->block_sizes || !pool->used) {
         if (pool->blocks)
-            free(pool->blocks);
+            cml_free(pool->blocks);
         if (pool->block_sizes)
-            free(pool->block_sizes);
+            cml_free(pool->block_sizes);
         if (pool->used)
-            free(pool->used);
-        free(pool);
+            cml_free(pool->used);
+        cml_free(pool);
         return NULL;
     }
 
     for (int i = 0; i < num_blocks; i++) {
-        pool->blocks[i] = malloc(block_size);
+        pool->blocks[i] = cml_malloc(block_size);
         if (!pool->blocks[i]) {
             for (int j = 0; j < i; j++) {
-                free(pool->blocks[j]);
+                cml_free(pool->blocks[j]);
             }
-            free(pool->blocks);
-            free(pool->block_sizes);
-            free(pool->used);
-            free(pool);
+            cml_free(pool->blocks);
+            cml_free(pool->block_sizes);
+            cml_free(pool->used);
+            cml_free(pool);
             return NULL;
         }
         pool->block_sizes[i] = block_size;
@@ -60,17 +61,17 @@ void memory_pool_free(MemoryPool* pool) {
     if (pool->blocks) {
         for (int i = 0; i < pool->num_blocks; i++) {
             if (pool->blocks[i]) {
-                free(pool->blocks[i]);
+                cml_free(pool->blocks[i]);
             }
         }
-        free(pool->blocks);
+        cml_free(pool->blocks);
     }
 
     if (pool->block_sizes)
-        free(pool->block_sizes);
+        cml_free(pool->block_sizes);
     if (pool->used)
-        free(pool->used);
-    free(pool);
+        cml_free(pool->used);
+    cml_free(pool);
 }
 
 void* memory_pool_alloc(MemoryPool* pool) {
@@ -109,22 +110,22 @@ TensorPool* tensor_pool_create(int* shape, int ndim, size_t num_tensors, DType d
         return NULL;
     }
 
-    TensorPool* pool = malloc(sizeof(TensorPool));
+    TensorPool* pool = cml_malloc(sizeof(TensorPool));
     if (!pool)
         return NULL;
 
-    pool->tensors = malloc(num_tensors * sizeof(Tensor*));
-    pool->in_use  = malloc(num_tensors * sizeof(bool));
+    pool->tensors = cml_malloc(num_tensors * sizeof(Tensor*));
+    pool->in_use  = cml_malloc(num_tensors * sizeof(bool));
     pool->shape   = tensor_shape_copy(shape, ndim);
 
     if (!pool->tensors || !pool->in_use || !pool->shape) {
         if (pool->tensors)
-            free(pool->tensors);
+            cml_free(pool->tensors);
         if (pool->in_use)
-            free(pool->in_use);
+            cml_free(pool->in_use);
         if (pool->shape)
-            free(pool->shape);
-        free(pool);
+            cml_free(pool->shape);
+        cml_free(pool);
         return NULL;
     }
 
@@ -135,10 +136,10 @@ TensorPool* tensor_pool_create(int* shape, int ndim, size_t num_tensors, DType d
             for (size_t j = 0; j < i; j++) {
                 tensor_free(pool->tensors[j]);
             }
-            free(pool->tensors);
-            free(pool->in_use);
-            free(pool->shape);
-            free(pool);
+            cml_free(pool->tensors);
+            cml_free(pool->in_use);
+            cml_free(pool->shape);
+            cml_free(pool);
             return NULL;
         }
         pool->in_use[i] = false;
@@ -163,12 +164,12 @@ void tensor_pool_free(TensorPool* pool) {
                 tensor_free(pool->tensors[i]);
             }
         }
-        free(pool->tensors);
+        cml_free(pool->tensors);
     }
 
     if (pool->in_use)
-        free(pool->in_use);
+        cml_free(pool->in_use);
     if (pool->shape)
-        free(pool->shape);
-    free(pool);
+        cml_free(pool->shape);
+    cml_free(pool);
 }

--- a/src/alloc/tlsf_alloc.c
+++ b/src/alloc/tlsf_alloc.c
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 static inline int tlsf_fls(uint32_t x)
 {
@@ -329,20 +330,20 @@ CMLTLSFAllocator* cml_tlsf_create(size_t pool_size)
     /* Allocate metadata and pool separately to avoid confusion with
      * malloc's bookkeeping (the pool contains our own block headers
      * which could alias malloc metadata if placed in the same allocation). */
-    CMLTLSFAllocator* a = (CMLTLSFAllocator*)calloc(1, sizeof(CMLTLSFAllocator));
+    CMLTLSFAllocator* a = (CMLTLSFAllocator*)cml_calloc(1, sizeof(CMLTLSFAllocator));
     if (!a) return NULL;
 
-    a->pool = malloc(pool_size);
+    a->pool = cml_malloc(pool_size);
     if (!a->pool) {
-        free(a);
+        cml_free(a);
         return NULL;
     }
     a->pool_size = pool_size;
     a->owns_pool = true;
 
     if (init_pool(a) != 0) {
-        free(a->pool);
-        free(a);
+        cml_free(a->pool);
+        cml_free(a);
         return NULL;
     }
 
@@ -355,7 +356,7 @@ CMLTLSFAllocator* cml_tlsf_create_with_pool(void* pool, size_t pool_size)
         return NULL;
     }
 
-    CMLTLSFAllocator* a = (CMLTLSFAllocator*)calloc(1, sizeof(CMLTLSFAllocator));
+    CMLTLSFAllocator* a = (CMLTLSFAllocator*)cml_calloc(1, sizeof(CMLTLSFAllocator));
     if (!a) return NULL;
 
     a->pool = pool;
@@ -363,7 +364,7 @@ CMLTLSFAllocator* cml_tlsf_create_with_pool(void* pool, size_t pool_size)
     a->owns_pool = false;
 
     if (init_pool(a) != 0) {
-        free(a);
+        cml_free(a);
         return NULL;
     }
 
@@ -374,9 +375,9 @@ void cml_tlsf_destroy(CMLTLSFAllocator* a)
 {
     if (!a) return;
     if (a->owns_pool) {
-        free(a->pool);
+        cml_free(a->pool);
     }
-    free(a);
+    cml_free(a);
 }
 
 void* cml_tlsf_alloc(CMLTLSFAllocator* a, size_t size)
@@ -687,11 +688,11 @@ CMLTimelinePlanner* cml_timeline_planner_create(int initial_capacity)
 {
     if (initial_capacity <= 0) initial_capacity = 16;
 
-    CMLTimelinePlanner* p = (CMLTimelinePlanner*)calloc(1, sizeof(CMLTimelinePlanner));
+    CMLTimelinePlanner* p = (CMLTimelinePlanner*)cml_calloc(1, sizeof(CMLTimelinePlanner));
     if (!p) return NULL;
 
-    p->records = (CMLTimelineRecord*)calloc((size_t)initial_capacity, sizeof(CMLTimelineRecord));
-    if (!p->records) { free(p); return NULL; }
+    p->records = (CMLTimelineRecord*)cml_calloc((size_t)initial_capacity, sizeof(CMLTimelineRecord));
+    if (!p->records) { cml_free(p); return NULL; }
 
     p->record_capacity = initial_capacity;
     return p;
@@ -700,8 +701,8 @@ CMLTimelinePlanner* cml_timeline_planner_create(int initial_capacity)
 void cml_timeline_planner_destroy(CMLTimelinePlanner* p)
 {
     if (!p) return;
-    free(p->records);
-    free(p);
+    cml_free(p->records);
+    cml_free(p);
 }
 
 int cml_timeline_planner_add(CMLTimelinePlanner* p, int tensor_id,
@@ -712,7 +713,7 @@ int cml_timeline_planner_add(CMLTimelinePlanner* p, int tensor_id,
 
     if (p->num_records >= p->record_capacity) {
         int new_cap = p->record_capacity * 2;
-        CMLTimelineRecord* tmp = (CMLTimelineRecord*)realloc(
+        CMLTimelineRecord* tmp = (CMLTimelineRecord*)cml_realloc(
             p->records, (size_t)new_cap * sizeof(CMLTimelineRecord));
         if (!tmp) return -1;
         p->records = tmp;

--- a/src/autograd/amp.c
+++ b/src/autograd/amp.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <math.h>
 #include <float.h>
+#include "alloc/cml_allocator.h"
 
 static AutocastContext g_autocast_ctx = {
     .enabled      = false,
@@ -52,7 +53,7 @@ bool autocast_should_keep_float32(OpType op) {
 
 GradScaler* grad_scaler_create(float init_scale, float growth_factor,
                                 float backoff_factor, int growth_interval) {
-    GradScaler* scaler = calloc(1, sizeof(GradScaler));
+    GradScaler* scaler = cml_calloc(1, sizeof(GradScaler));
     if (!scaler) {
         LOG_ERROR("GradScaler: failed to allocate memory");
         return NULL;
@@ -71,7 +72,7 @@ GradScaler* grad_scaler_create(float init_scale, float growth_factor,
 void grad_scaler_free(GradScaler* scaler) {
     if (!scaler)
         return;
-    free(scaler);
+    cml_free(scaler);
 }
 
 Tensor* grad_scaler_scale(GradScaler* scaler, Tensor* loss) {

--- a/src/autograd/autograd.c
+++ b/src/autograd/autograd.c
@@ -19,7 +19,7 @@ static pthread_mutex_t g_hook_lock = PTHREAD_MUTEX_INITIALIZER;
 static void autograd_init_once(void) {
     if (global_autograd_engine) return;
 
-    global_autograd_engine = malloc(sizeof(AutogradEngine));
+    global_autograd_engine = cml_malloc(sizeof(AutogradEngine));
     if (!global_autograd_engine) {
         LOG_ERROR("Failed to initialize autograd engine");
         return;
@@ -48,7 +48,7 @@ void autograd_shutdown(void) {
             pthread_mutex_destroy(&global_autograd_engine->lock);
             global_autograd_engine->lock_initialized = false;
         }
-        free(global_autograd_engine);
+        cml_free(global_autograd_engine);
         global_autograd_engine = NULL;
         /* Reset pthread_once so re-init is possible (e.g., in tests) */
         g_autograd_once = (pthread_once_t)PTHREAD_ONCE_INIT;
@@ -142,7 +142,7 @@ typedef struct {
 
 static TensorHookList* get_tensor_hooks(Tensor* t) {
     if (!t->user_data) {
-        t->user_data = calloc(1, sizeof(TensorHookList));
+        t->user_data = cml_calloc(1, sizeof(TensorHookList));
     }
     return (TensorHookList*)t->user_data;
 }
@@ -179,7 +179,7 @@ int module_register_backward_hook(struct Module* module, ModuleBackwardHook hook
     }
 
     if (!module->user_data) {
-        module->user_data = malloc(sizeof(ModuleBackwardHook));
+        module->user_data = cml_malloc(sizeof(ModuleBackwardHook));
         if (!module->user_data) {
             LOG_ERROR("Failed to allocate memory for module hook");
             return -1;
@@ -345,10 +345,10 @@ void tensor_backward(Tensor* tensor, Tensor* gradient, bool retain_graph, bool c
                     fclose(f);
                     LOG_INFO("CML_VIZ exported kernels to kernels.json");
                 }
-                free(kernel_json_raw);
+                cml_free(kernel_json_raw);
             }
             if (kernel_json_opt) {
-                free(kernel_json_opt);
+                cml_free(kernel_json_opt);
             }
             tensor_ensure_executed(tensor);
             cml_ir_ensure_gradients_executed(tensor->ir_context);
@@ -415,7 +415,7 @@ int* broadcast_shapes(int* shape1, int ndim1, int* shape2, int ndim2, int* out_n
     }
 
     int max_ndim = ndim1 > ndim2 ? ndim1 : ndim2;
-    int* result  = malloc((size_t)max_ndim * sizeof(int));
+    int* result  = cml_malloc((size_t)max_ndim * sizeof(int));
     if (!result)
         return NULL;
 
@@ -451,10 +451,10 @@ int* broadcast_multi_shapes(int** shapes, int* ndims, int num_shapes, int* out_n
         int* new_result =
             broadcast_shapes(result, current_ndim, shapes[i], ndims[i], &current_ndim);
         if (!new_result) {
-            free(result);
+            cml_free(result);
             return NULL;
         }
-        free(result);
+        cml_free(result);
         result = new_result;
     }
 
@@ -494,14 +494,14 @@ void tensor_compute_grad_for_broadcast(Tensor* grad_output, int* original_shape,
     float* grad_out_data = (float*)grad_output->data;
     float* grad_in_data  = (float*)(*grad_input)->data;
 
-    size_t* out_strides = malloc((size_t)grad_output->ndim * sizeof(size_t));
-    size_t* in_strides  = malloc((size_t)ndim * sizeof(size_t));
+    size_t* out_strides = cml_malloc((size_t)grad_output->ndim * sizeof(size_t));
+    size_t* in_strides  = cml_malloc((size_t)ndim * sizeof(size_t));
 
     if (!out_strides || !in_strides) {
         if (out_strides)
-            free(out_strides);
+            cml_free(out_strides);
         if (in_strides)
-            free(in_strides);
+            cml_free(in_strides);
         return;
     }
 
@@ -536,8 +536,8 @@ void tensor_compute_grad_for_broadcast(Tensor* grad_output, int* original_shape,
         grad_in_data[in_idx] += grad_out_data[i];
     }
 
-    free(out_strides);
-    free(in_strides);
+    cml_free(out_strides);
+    cml_free(in_strides);
 
 }
 
@@ -584,6 +584,7 @@ void autograd_print_graph(Tensor* tensor) {
 }
 
 #include <inttypes.h>
+#include "alloc/cml_allocator.h"
 
 typedef struct {
     const void** keys; // Stores const pointers for comparison only
@@ -600,9 +601,9 @@ static void map_init(PtrIdMap* m) {
 }
 static void map_free(PtrIdMap* m) {
     if (m->keys)
-        free(m->keys);
+        cml_free(m->keys);
     if (m->ids)
-        free(m->ids);
+        cml_free(m->ids);
 }
 static int map_get_or_insert(PtrIdMap* m, const void* key, int next_id) {
     for (int i = 0; i < m->size; i++)
@@ -610,8 +611,8 @@ static int map_get_or_insert(PtrIdMap* m, const void* key, int next_id) {
             return m->ids[i];
     if (m->size >= m->cap) {
         int ncap           = m->cap ? m->cap * 2 : 64;
-        const void** nkeys = realloc(m->keys, (size_t)ncap * sizeof(const void*));
-        int* nids          = realloc(m->ids, (size_t)ncap * sizeof(int));
+        const void** nkeys = cml_realloc(m->keys, (size_t)ncap * sizeof(const void*));
+        int* nids          = cml_realloc(m->ids, (size_t)ncap * sizeof(int));
         if (!nkeys || !nids)
             return -1;
         m->keys = nkeys;
@@ -669,7 +670,7 @@ int autograd_export_json(Tensor* root, const char* path) {
     }
 
     int stack_cap         = 256;
-    struct IRNode** stack = malloc(stack_cap * sizeof(struct IRNode*));
+    struct IRNode** stack = cml_malloc(stack_cap * sizeof(struct IRNode*));
     int stack_size        = 0;
     if (stack) {
         stack[stack_size++] = root->ir_node;
@@ -686,7 +687,7 @@ int autograd_export_json(Tensor* root, const char* path) {
                 if (already == 1) {
                     if (stack_size >= stack_cap) {
                         stack_cap *= 2;
-                        struct IRNode** new_stack = realloc(stack, stack_cap * sizeof(struct IRNode*));
+                        struct IRNode** new_stack = cml_realloc(stack, stack_cap * sizeof(struct IRNode*));
                         if (!new_stack) {
                             stack_ok = false;
                             break;
@@ -697,7 +698,7 @@ int autograd_export_json(Tensor* root, const char* path) {
                 }
             }
         }
-        free(stack);
+        cml_free(stack);
     }
 
     fputs("{\n", f);

--- a/src/autograd/checkpointing.c
+++ b/src/autograd/checkpointing.c
@@ -9,6 +9,7 @@
 #include "core/logging.h"
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 static bool checkpointing_enabled = false;
 
@@ -38,7 +39,7 @@ int autograd_checkpoint(Tensor* tensor) {
     if (num_checkpointed >= checkpointed_capacity) {
         int new_capacity = checkpointed_capacity == 0 ? 16 : checkpointed_capacity * 2;
         CheckpointedTensor** new_array =
-            realloc(checkpointed_tensors, (size_t)new_capacity * sizeof(CheckpointedTensor*));
+            cml_realloc(checkpointed_tensors, (size_t)new_capacity * sizeof(CheckpointedTensor*));
         if (!new_array)
             return -1;
 
@@ -46,7 +47,7 @@ int autograd_checkpoint(Tensor* tensor) {
         checkpointed_capacity = new_capacity;
     }
 
-    CheckpointedTensor* checkpoint = malloc(sizeof(CheckpointedTensor));
+    CheckpointedTensor* checkpoint = cml_malloc(sizeof(CheckpointedTensor));
     if (!checkpoint)
         return -1;
 
@@ -56,9 +57,9 @@ int autograd_checkpoint(Tensor* tensor) {
 
     if (tensor->ir_node && tensor->ir_node->inputs) {
         checkpoint->num_inputs   = tensor->ir_node->num_inputs;
-        checkpoint->saved_inputs = malloc((size_t)checkpoint->num_inputs * sizeof(Tensor*));
+        checkpoint->saved_inputs = cml_malloc((size_t)checkpoint->num_inputs * sizeof(Tensor*));
         if (!checkpoint->saved_inputs) {
-            free(checkpoint);
+            cml_free(checkpoint);
             return -1;
         }
         for (int i = 0; i < checkpoint->num_inputs; i++) {
@@ -332,12 +333,12 @@ void autograd_checkpointing_cleanup(void) {
         for (int i = 0; i < num_checkpointed; i++) {
             if (checkpointed_tensors[i]) {
                 if (checkpointed_tensors[i]->saved_inputs) {
-                    free(checkpointed_tensors[i]->saved_inputs);
+                    cml_free(checkpointed_tensors[i]->saved_inputs);
                 }
-                free(checkpointed_tensors[i]);
+                cml_free(checkpointed_tensors[i]);
             }
         }
-        free(checkpointed_tensors);
+        cml_free(checkpointed_tensors);
         checkpointed_tensors  = NULL;
         num_checkpointed      = 0;
         checkpointed_capacity = 0;

--- a/src/autograd/forward_ops.c
+++ b/src/autograd/forward_ops.c
@@ -8,6 +8,7 @@
 #include <math.h>
 #include <string.h>
 #include <float.h>
+#include "alloc/cml_allocator.h"
 
 Tensor* tensor_add(Tensor* a, Tensor* b) {
     if (!a || !b) {
@@ -253,7 +254,7 @@ Tensor* tensor_sum(Tensor* a, int dim, bool keepdim) {
     ReduceParams params;
     int* dims = NULL;
     if (dim >= 0 && dim < a->ndim) {
-        dims = malloc(sizeof(int));
+        dims = cml_malloc(sizeof(int));
         if (!dims)
             return NULL;
         dims[0]         = dim;
@@ -268,7 +269,7 @@ Tensor* tensor_sum(Tensor* a, int dim, bool keepdim) {
     Tensor* result = uop_sum(a, &params);
 
     if (dims)
-        free(dims);
+        cml_free(dims);
     return result;
 }
 
@@ -279,7 +280,7 @@ Tensor* tensor_mean(Tensor* a, int dim, bool keepdim) {
     ReduceParams params;
     int* dims = NULL;
     if (dim >= 0 && dim < a->ndim) {
-        dims = malloc(sizeof(int));
+        dims = cml_malloc(sizeof(int));
         if (!dims)
             return NULL;
         dims[0]         = dim;
@@ -294,7 +295,7 @@ Tensor* tensor_mean(Tensor* a, int dim, bool keepdim) {
     Tensor* result = uop_mean(a, &params);
 
     if (dims)
-        free(dims);
+        cml_free(dims);
     return result;
 }
 
@@ -305,7 +306,7 @@ Tensor* tensor_max(Tensor* a, int dim, bool keepdim) {
     ReduceParams params;
     int* dims = NULL;
     if (dim >= 0 && dim < a->ndim) {
-        dims = malloc(sizeof(int));
+        dims = cml_malloc(sizeof(int));
         if (!dims)
             return NULL;
         dims[0]         = dim;
@@ -320,7 +321,7 @@ Tensor* tensor_max(Tensor* a, int dim, bool keepdim) {
     Tensor* result = uop_max_reduce(a, &params);
 
     if (dims)
-        free(dims);
+        cml_free(dims);
     return result;
 }
 
@@ -336,7 +337,7 @@ Tensor* tensor_min(Tensor* a, int dim, bool keepdim) {
     ReduceParams params;
     int* dims = NULL;
     if (dim >= 0 && dim < a->ndim) {
-        dims = malloc(sizeof(int));
+        dims = cml_malloc(sizeof(int));
         if (!dims) {
             tensor_free(neg_a);
             return NULL;
@@ -355,7 +356,7 @@ Tensor* tensor_min(Tensor* a, int dim, bool keepdim) {
 
     if (!neg_max) {
         if (dims)
-            free(dims);
+            cml_free(dims);
         return NULL;
     }
 
@@ -363,7 +364,7 @@ Tensor* tensor_min(Tensor* a, int dim, bool keepdim) {
     tensor_free(neg_max);
 
     if (dims)
-        free(dims);
+        cml_free(dims);
     return result;
 }
 
@@ -382,7 +383,7 @@ Tensor* tensor_transpose(Tensor* a, int dim0, int dim1) {
         return NULL;
     }
 
-    int* perm = malloc((size_t)a->ndim * sizeof(int));
+    int* perm = cml_malloc((size_t)a->ndim * sizeof(int));
     if (!perm)
         return NULL;
 
@@ -398,7 +399,7 @@ Tensor* tensor_transpose(Tensor* a, int dim0, int dim1) {
 
     Tensor* result = uop_permute(a, &params);
 
-    free(perm);
+    cml_free(perm);
     return result;
 }
 
@@ -418,7 +419,7 @@ Tensor* tensor_matmul(Tensor* a, Tensor* b) {
     struct IRNode* node = cml_ir_get_tail(ir);
     int batch_dims = (a->ndim > 2) ? a->ndim - 2 : 0;
     int out_ndim = batch_dims + 2;
-    node->output_shape = malloc((size_t)out_ndim * sizeof(int));
+    node->output_shape = cml_malloc((size_t)out_ndim * sizeof(int));
     if (!node->output_shape) {
         LOG_ERROR("Failed to allocate output shape for matmul");
         return NULL;

--- a/src/backend/backend.c
+++ b/src/backend/backend.c
@@ -225,6 +225,7 @@ static BackendOps scalar_ops = {.matmul     = scalar_matmul,
 #ifdef __SSE__
 #include <immintrin.h>
 #include <emmintrin.h>
+#include "alloc/cml_allocator.h"
 
 static void simd_add(const void* a, const void* b, void* out, size_t n, DType dtype) {
     if (!a || !b || !out || n == 0) {
@@ -551,13 +552,13 @@ int backend_init(BackendType type) {
 
     if (g_current_backend) {
         if (g_current_backend->context) {
-            free(g_current_backend->context);
+            cml_free(g_current_backend->context);
         }
-        free(g_current_backend);
+        cml_free(g_current_backend);
         g_current_backend = NULL;
     }
 
-    g_current_backend = malloc(sizeof(Backend));
+    g_current_backend = cml_malloc(sizeof(Backend));
     if (!g_current_backend) {
         backend_unlock();
         LOG_ERROR("Failed to allocate backend");
@@ -685,9 +686,9 @@ void backend_cleanup(void) {
     backend_lock();
     if (g_current_backend) {
         if (g_current_backend->context) {
-            free(g_current_backend->context);
+            cml_free(g_current_backend->context);
         }
-        free(g_current_backend);
+        cml_free(g_current_backend);
         g_current_backend = NULL;
     }
     backend_unlock();

--- a/src/backend/backend_buffer.c
+++ b/src/backend/backend_buffer.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <limits.h>
+#include "alloc/cml_allocator.h"
 
 struct CMLBackendBufferType {
     const char* name;
@@ -29,15 +30,15 @@ struct CMLBackendBuffer {
 
 static CMLBackendBuffer_t cpu_buffer_alloc(struct CMLBackendBufferType* buft, size_t size) {
     (void)buft; // Unused
-    void* ptr = malloc(size);
+    void* ptr = cml_malloc(size);
     if (!ptr) {
         LOG_ERROR("Failed to allocate CPU buffer of size %zu", size);
         return NULL;
     }
 
-    CMLBackendBuffer_t buffer = malloc(sizeof(struct CMLBackendBuffer));
+    CMLBackendBuffer_t buffer = cml_malloc(sizeof(struct CMLBackendBuffer));
     if (!buffer) {
-        free(ptr);
+        cml_free(ptr);
         return NULL;
     }
 
@@ -65,7 +66,7 @@ static CMLBackendBuffer_t cuda_buffer_alloc(struct CMLBackendBufferType* buft, s
         return NULL;
     }
 
-    CMLBackendBuffer_t buffer = malloc(sizeof(struct CMLBackendBuffer));
+    CMLBackendBuffer_t buffer = cml_malloc(sizeof(struct CMLBackendBuffer));
     if (!buffer) {
         device_free(ptr, DEVICE_CUDA);
         return NULL;
@@ -97,7 +98,7 @@ static CMLBackendBuffer_t metal_buffer_alloc(struct CMLBackendBufferType* buft, 
         return NULL;
     }
 
-    CMLBackendBuffer_t buffer = malloc(sizeof(struct CMLBackendBuffer));
+    CMLBackendBuffer_t buffer = cml_malloc(sizeof(struct CMLBackendBuffer));
     if (!buffer) {
         device_free(ptr, DEVICE_METAL);
         return NULL;
@@ -127,7 +128,7 @@ static CMLBackendBuffer_t rocm_buffer_alloc(struct CMLBackendBufferType* buft, s
         return NULL;
     }
 
-    CMLBackendBuffer_t buffer = malloc(sizeof(struct CMLBackendBuffer));
+    CMLBackendBuffer_t buffer = cml_malloc(sizeof(struct CMLBackendBuffer));
     if (!buffer) {
         device_free(ptr, DEVICE_ROCM);
         return NULL;
@@ -251,7 +252,7 @@ void cml_backend_buffer_free(CMLBackendBuffer_t buffer) {
         device_free(buffer->base, buffer->device);
     }
 
-    free(buffer);
+    cml_free(buffer);
 }
 
 void* cml_backend_buffer_get_base(CMLBackendBuffer_t buffer) {

--- a/src/backend/blas.c
+++ b/src/backend/blas.c
@@ -267,8 +267,8 @@ void cml_blas_free(CMLBlasContext* ctx) {
     }
     blas_unlock();
 
-    cml_free(ctx->pack_a_buf);
-    cml_free(ctx->pack_b_buf);
+    cml_aligned_free(ctx->pack_a_buf);
+    cml_aligned_free(ctx->pack_b_buf);
     cml_free(ctx);
 }
 
@@ -574,13 +574,13 @@ int cml_blas_sgemm(CMLBlasContext* ctx, const float* A, const float* B, float* C
             size_t need_b = (size_t)nc_alloc * PACKED_KC * sizeof(float);
             /* Grow context-resident buffers lazily — amortises alloc across calls */
             if (ctx->pack_a_size < need_a) {
-                cml_free(ctx->pack_a_buf);
-                ctx->pack_a_buf  = (float*)aligned_alloc(32, need_a);
+                cml_aligned_free(ctx->pack_a_buf);
+                ctx->pack_a_buf  = (float*)cml_aligned_alloc(need_a, 32);
                 ctx->pack_a_size = ctx->pack_a_buf ? need_a : 0;
             }
             if (ctx->pack_b_size < need_b) {
-                cml_free(ctx->pack_b_buf);
-                ctx->pack_b_buf  = (float*)aligned_alloc(32, need_b);
+                cml_aligned_free(ctx->pack_b_buf);
+                ctx->pack_b_buf  = (float*)cml_aligned_alloc(need_b, 32);
                 ctx->pack_b_size = ctx->pack_b_buf ? need_b : 0;
             }
             if (ctx->pack_a_buf && ctx->pack_b_buf) {

--- a/src/backend/blas.c
+++ b/src/backend/blas.c
@@ -7,6 +7,7 @@
 #include <math.h>
 #include <stdatomic.h>
 #include <pthread.h>
+#include "alloc/cml_allocator.h"
 #ifdef __linux__
 #include <unistd.h>
 #endif
@@ -180,7 +181,7 @@ static inline void blas_set_threads_for_size(CMLBlasContext* ctx, long long flop
 }
 
 CMLBlasContext* cml_blas_init(void) {
-    CMLBlasContext* ctx = calloc(1, sizeof(CMLBlasContext));
+    CMLBlasContext* ctx = cml_calloc(1, sizeof(CMLBlasContext));
     if (!ctx) {
         LOG_ERROR("Failed to allocate BLAS context");
         return NULL;
@@ -248,7 +249,7 @@ CMLBlasContext* cml_blas_init(void) {
     }
 
     fprintf(stderr, "[CML] WARNING: No BLAS library found — using scalar fallback\n");
-    free(ctx);
+    cml_free(ctx);
     return NULL;
 }
 
@@ -266,9 +267,9 @@ void cml_blas_free(CMLBlasContext* ctx) {
     }
     blas_unlock();
 
-    free(ctx->pack_a_buf);
-    free(ctx->pack_b_buf);
-    free(ctx);
+    cml_free(ctx->pack_a_buf);
+    cml_free(ctx->pack_b_buf);
+    cml_free(ctx);
 }
 
 CMLBlasContext* cml_blas_get_context(void) {
@@ -573,12 +574,12 @@ int cml_blas_sgemm(CMLBlasContext* ctx, const float* A, const float* B, float* C
             size_t need_b = (size_t)nc_alloc * PACKED_KC * sizeof(float);
             /* Grow context-resident buffers lazily — amortises alloc across calls */
             if (ctx->pack_a_size < need_a) {
-                free(ctx->pack_a_buf);
+                cml_free(ctx->pack_a_buf);
                 ctx->pack_a_buf  = (float*)aligned_alloc(32, need_a);
                 ctx->pack_a_size = ctx->pack_a_buf ? need_a : 0;
             }
             if (ctx->pack_b_size < need_b) {
-                free(ctx->pack_b_buf);
+                cml_free(ctx->pack_b_buf);
                 ctx->pack_b_buf  = (float*)aligned_alloc(32, need_b);
                 ctx->pack_b_size = ctx->pack_b_buf ? need_b : 0;
             }

--- a/src/backend/device.c
+++ b/src/backend/device.c
@@ -8,6 +8,8 @@
 #include <stdint.h>
 #include <pthread.h>
 
+#include "alloc/cml_allocator.h"
+
 #ifdef __linux__
 #include <dlfcn.h>
 #define CML_DLOPEN(path, mode) dlopen(path, mode)
@@ -465,7 +467,7 @@ void* device_alloc(size_t size, DeviceType device) {
 
     switch (device) {
     case DEVICE_CPU:
-        ptr = malloc(size);
+        ptr = cml_malloc(size);
         if (!ptr) {
             LOG_ERROR("Failed to allocate %zu bytes on CPU", size);
         }
@@ -480,7 +482,7 @@ void* device_alloc(size_t size, DeviceType device) {
             }
         } else {
             LOG_WARNING("CUDA not available, falling back to CPU");
-            ptr = malloc(size);
+            ptr = cml_malloc(size);
         }
         break;
 
@@ -501,11 +503,11 @@ void* device_alloc(size_t size, DeviceType device) {
             }
         } else {
             LOG_WARNING("Metal not available, falling back to CPU");
-            ptr = malloc(size);
+            ptr = cml_malloc(size);
         }
 #else
         LOG_WARNING("Metal not available on this platform, falling back to CPU");
-        ptr = malloc(size);
+        ptr = cml_malloc(size);
 #endif
         break;
 
@@ -523,7 +525,7 @@ void* device_alloc(size_t size, DeviceType device) {
             } else {
                 LOG_WARNING("ROCm library not loaded, falling back to CPU");
             }
-            ptr = malloc(size);
+            ptr = cml_malloc(size);
         }
         break;
 
@@ -535,7 +537,7 @@ void* device_alloc(size_t size, DeviceType device) {
                           g_sim_gpu_current, size, dev->allocated, dev->total_memory);
                 return NULL;
             }
-            ptr = malloc(size);
+            ptr = cml_malloc(size);
             if (ptr) {
                 dev->allocated += size;
                 LOG_DEBUG("SimGPU[%d]: allocated %zu bytes (%zu/%zu used)",
@@ -543,7 +545,7 @@ void* device_alloc(size_t size, DeviceType device) {
             }
         } else {
             LOG_WARNING("SimGPU not available, falling back to CPU");
-            ptr = malloc(size);
+            ptr = cml_malloc(size);
         }
         break;
 
@@ -552,7 +554,7 @@ void* device_alloc(size_t size, DeviceType device) {
 
     default:
         LOG_ERROR("Unknown device type: %d", device);
-        ptr = malloc(size);
+        ptr = cml_malloc(size);
         break;
     }
 
@@ -566,7 +568,7 @@ void device_free(void* ptr, DeviceType device) {
 
     switch (device) {
     case DEVICE_CPU:
-        free(ptr);
+        cml_free(ptr);
         break;
 
     case DEVICE_CUDA:
@@ -576,17 +578,17 @@ void device_free(void* ptr, DeviceType device) {
                 LOG_ERROR("Failed to free CUDA memory");
             }
         } else {
-            free(ptr);
+            cml_free(ptr);
         }
         break;
 
     case DEVICE_METAL:
 #ifdef __APPLE__
         if (ptr) {
-            free(ptr);
+            cml_free(ptr);
                 }
 #else
-        free(ptr);
+        cml_free(ptr);
 #endif
         break;
 
@@ -598,12 +600,12 @@ void device_free(void* ptr, DeviceType device) {
             } else {
             }
         } else {
-            free(ptr);
+            cml_free(ptr);
         }
         break;
 
     case DEVICE_SIM_GPU:
-        free(ptr);
+        cml_free(ptr);
         break;
 
     case DEVICE_AUTO:
@@ -611,7 +613,7 @@ void device_free(void* ptr, DeviceType device) {
         break;
 
     default:
-        free(ptr);
+        cml_free(ptr);
         break;
     }
 }
@@ -700,7 +702,7 @@ int device_copy(void* dst, const void* src, size_t size, DeviceType dst_device,
         memcpy(dst, src, size);
         return 0;
     } else {
-        void* staging = malloc(size);
+        void* staging = cml_malloc(size);
         if (!staging) {
             LOG_ERROR("Failed to allocate staging buffer for device copy");
             return -1;
@@ -708,12 +710,12 @@ int device_copy(void* dst, const void* src, size_t size, DeviceType dst_device,
 
         int result1 = device_copy(staging, src, size, DEVICE_CPU, src_device);
         if (result1 != 0) {
-            free(staging);
+            cml_free(staging);
             return -1;
         }
 
         int result2 = device_copy(dst, staging, size, dst_device, DEVICE_CPU);
-        free(staging);
+        cml_free(staging);
 
         return (result2 == 0) ? 0 : -1;
     }

--- a/src/backend/disk_backend.c
+++ b/src/backend/disk_backend.c
@@ -11,6 +11,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include "alloc/cml_allocator.h"
 #define HAS_MMAP 1
 #else
 #define HAS_MMAP 0
@@ -19,7 +20,7 @@
 /* Helper: construct file path for a tensor */
 static char* make_tensor_path(const CMLDiskBackend* backend, const char* name) {
     size_t len = strlen(backend->base_path) + strlen(name) + 16;
-    char* path = (char*)malloc(len);
+    char* path = (char*)cml_malloc(len);
     if (!path) return NULL;
     snprintf(path, len, "%s/%s.cml_tensor", backend->base_path, name);
     return path;
@@ -37,11 +38,11 @@ typedef struct {
 CMLDiskBackend* cml_disk_backend_create(const char* base_path, CMLDiskIOMode mode) {
     if (!base_path) return NULL;
 
-    CMLDiskBackend* b = (CMLDiskBackend*)calloc(1, sizeof(CMLDiskBackend));
+    CMLDiskBackend* b = (CMLDiskBackend*)cml_calloc(1, sizeof(CMLDiskBackend));
     if (!b) return NULL;
 
-    b->base_path = strdup(base_path);
-    if (!b->base_path) { free(b); return NULL; }
+    b->base_path = cml_strdup(base_path);
+    if (!b->base_path) { cml_free(b); return NULL; }
 
     b->io_mode = mode;
     b->read_only = false;
@@ -52,8 +53,8 @@ CMLDiskBackend* cml_disk_backend_create(const char* base_path, CMLDiskIOMode mod
 
 void cml_disk_backend_free(CMLDiskBackend* backend) {
     if (!backend) return;
-    free(backend->base_path);
-    free(backend);
+    cml_free(backend->base_path);
+    cml_free(backend);
 }
 
 int cml_disk_save_tensor(CMLDiskBackend* backend, const char* name, Tensor* tensor) {
@@ -63,7 +64,7 @@ int cml_disk_save_tensor(CMLDiskBackend* backend, const char* name, Tensor* tens
     if (!path) return -1;
 
     FILE* f = fopen(path, "wb");
-    free(path);
+    cml_free(path);
     if (!f) return -1;
 
     /* Write header */
@@ -100,7 +101,7 @@ Tensor* cml_disk_load_tensor(CMLDiskBackend* backend, const char* name) {
     if (!path) return NULL;
 
     FILE* f = fopen(path, "rb");
-    free(path);
+    cml_free(path);
     if (!f) return NULL;
 
     /* Read header */
@@ -138,25 +139,25 @@ CMLDiskTensor* cml_disk_mmap_tensor(CMLDiskBackend* backend, const char* name) {
     char* path = make_tensor_path(backend, name);
     if (!path) return NULL;
 
-    CMLDiskTensor* dt = (CMLDiskTensor*)calloc(1, sizeof(CMLDiskTensor));
-    if (!dt) { free(path); return NULL; }
+    CMLDiskTensor* dt = (CMLDiskTensor*)cml_calloc(1, sizeof(CMLDiskTensor));
+    if (!dt) { cml_free(path); return NULL; }
     dt->file_path = path;
 
 #if HAS_MMAP
     int fd = open(path, O_RDONLY);
-    if (fd < 0) { free(dt->file_path); free(dt); return NULL; }
+    if (fd < 0) { cml_free(dt->file_path); cml_free(dt); return NULL; }
 
     /* Read header first */
     DiskTensorHeader hdr;
     if (read(fd, &hdr, sizeof(hdr)) != sizeof(hdr)) {
         close(fd);
-        free(dt->file_path); free(dt);
+        cml_free(dt->file_path); cml_free(dt);
         return NULL;
     }
 
     if (memcmp(hdr.magic, "CMLTENS", 8) != 0) {
         close(fd);
-        free(dt->file_path); free(dt);
+        cml_free(dt->file_path); cml_free(dt);
         return NULL;
     }
 
@@ -221,8 +222,8 @@ void cml_disk_tensor_unmap(CMLDiskTensor* dt) {
 void cml_disk_tensor_free(CMLDiskTensor* dt) {
     if (!dt) return;
     cml_disk_tensor_unmap(dt);
-    free(dt->file_path);
-    free(dt);
+    cml_free(dt->file_path);
+    cml_free(dt);
 }
 
 Tensor* cml_disk_tensor_to_tensor(CMLDiskTensor* dt) {
@@ -247,7 +248,7 @@ int cml_disk_async_read(CMLDiskBackend* backend, const char* name,
     if (!path) return -1;
 
     FILE* f = fopen(path, "rb");
-    free(path);
+    cml_free(path);
     if (!f) return -1;
 
     /* Skip header */

--- a/src/backend/null_device.c
+++ b/src/backend/null_device.c
@@ -7,6 +7,7 @@
 
 #ifdef _POSIX_C_SOURCE
 #include <time.h>
+#include "alloc/cml_allocator.h"
 static double get_time_us(void) {
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
@@ -27,7 +28,7 @@ CMLNullDevice* cml_null_device_create(void) {
 CMLNullDevice* cml_null_device_create_with_spec(size_t memory_bytes,
                                                   double bandwidth_gbps,
                                                   double tflops) {
-    CMLNullDevice* dev = (CMLNullDevice*)calloc(1, sizeof(CMLNullDevice));
+    CMLNullDevice* dev = (CMLNullDevice*)cml_calloc(1, sizeof(CMLNullDevice));
     if (!dev) return NULL;
 
     dev->initialized = true;
@@ -40,7 +41,7 @@ CMLNullDevice* cml_null_device_create_with_spec(size_t memory_bytes,
 }
 
 void cml_null_device_free(CMLNullDevice* dev) {
-    free(dev);
+    cml_free(dev);
 }
 
 void* cml_null_device_alloc(CMLNullDevice* dev, size_t size) {

--- a/src/backend/opencl_backend.c
+++ b/src/backend/opencl_backend.c
@@ -14,6 +14,7 @@
 #define CL_TARGET_OPENCL_VERSION 300
 #endif
 #include <CL/cl.h>
+#include "alloc/cml_allocator.h"
 #endif
 
 static pthread_mutex_t g_opencl_lock;
@@ -307,10 +308,10 @@ int opencl_backend_init(void) {
         return -1;
     }
 
-    cl_platform_id* platforms = malloc(num_platforms * sizeof(cl_platform_id));
+    cl_platform_id* platforms = cml_malloc(num_platforms * sizeof(cl_platform_id));
     clGetPlatformIDs(num_platforms, platforms, NULL);
     g_platform = platforms[0];
-    free(platforms);
+    cml_free(platforms);
 
     err = clGetDeviceIDs(g_platform, CL_DEVICE_TYPE_GPU, 1, &g_device, NULL);
     if (err != CL_SUCCESS) {

--- a/src/backend/profiling.c
+++ b/src/backend/profiling.c
@@ -7,13 +7,14 @@
 #include <string.h>
 #include <time.h>
 #include <stdio.h>
+#include "alloc/cml_allocator.h"
 
 static double timespec_to_ms(struct timespec* ts) {
     return (double)ts->tv_sec * 1000.0 + (double)ts->tv_nsec / 1000000.0;
 }
 
 Timer* profiler_timer_create(const char* name) {
-    Timer* timer = malloc(sizeof(Timer));
+    Timer* timer = cml_malloc(sizeof(Timer));
     if (!timer)
         return NULL;
 
@@ -25,7 +26,7 @@ Timer* profiler_timer_create(const char* name) {
     timer->is_running         = false;
     if (name) {
         size_t len  = strlen(name) + 1;
-        timer->name = malloc(len);
+        timer->name = cml_malloc(len);
         if (timer->name) {
             memcpy(timer->name, name, len);
         }
@@ -41,9 +42,9 @@ void profiler_timer_free(Timer* timer) {
         return;
 
     if (timer->name) {
-        free(timer->name);
+        cml_free(timer->name);
     }
-    free(timer);
+    cml_free(timer);
 }
 
 int profiler_timer_start(Timer* timer) {
@@ -108,7 +109,7 @@ void profiler_timer_reset(Timer* timer) {
 }
 
 Profiler* profiler_create(void) {
-    Profiler* profiler = malloc(sizeof(Profiler));
+    Profiler* profiler = cml_malloc(sizeof(Profiler));
     if (!profiler)
         return NULL;
 
@@ -130,10 +131,10 @@ void profiler_free(Profiler* profiler) {
                 profiler_timer_free(profiler->timers[i]);
             }
         }
-        free(profiler->timers);
+        cml_free(profiler->timers);
     }
 
-    free(profiler);
+    cml_free(profiler);
 }
 
 void profiler_set_enabled(Profiler* profiler, bool enabled) {
@@ -149,7 +150,7 @@ int profiler_start(Profiler* profiler, const char* name) {
     // Resize array if needed
     if (profiler->num_timers >= profiler->capacity) {
         int new_capacity   = profiler->capacity == 0 ? 8 : profiler->capacity * 2;
-        Timer** new_timers = realloc(profiler->timers, (size_t)new_capacity * sizeof(Timer*));
+        Timer** new_timers = cml_realloc(profiler->timers, (size_t)new_capacity * sizeof(Timer*));
         if (!new_timers)
             return -1;
 

--- a/src/backend/remote_device.c
+++ b/src/backend/remote_device.c
@@ -16,6 +16,7 @@
 
 #ifdef __linux__
 #include <dlfcn.h>
+#include "alloc/cml_allocator.h"
 #define CML_HAS_DLFCN 1
 #endif
 
@@ -107,7 +108,7 @@ static int send_resp(int fd, uint32_t status, const void* payload, uint32_t payl
 CMLRemoteDevice* cml_remote_connect(const char* host, int port) {
     if (!host || port <= 0) return NULL;
 
-    CMLRemoteDevice* dev = (CMLRemoteDevice*)calloc(1, sizeof(CMLRemoteDevice));
+    CMLRemoteDevice* dev = (CMLRemoteDevice*)cml_calloc(1, sizeof(CMLRemoteDevice));
     if (!dev) return NULL;
 
     strncpy(dev->host, host, sizeof(dev->host) - 1);
@@ -122,7 +123,7 @@ CMLRemoteDevice* cml_remote_connect(const char* host, int port) {
 
     if (getaddrinfo(host, port_str, &hints, &res) != 0 || !res) {
         LOG_ERROR("remote_connect: cannot resolve %s:%d", host, port);
-        free(dev);
+        cml_free(dev);
         return NULL;
     }
 
@@ -130,7 +131,7 @@ CMLRemoteDevice* cml_remote_connect(const char* host, int port) {
     if (dev->sock_fd < 0) {
         LOG_ERROR("remote_connect: socket() failed: %s", strerror(errno));
         freeaddrinfo(res);
-        free(dev);
+        cml_free(dev);
         return NULL;
     }
 
@@ -141,7 +142,7 @@ CMLRemoteDevice* cml_remote_connect(const char* host, int port) {
         LOG_ERROR("remote_connect: connect to %s:%d failed: %s", host, port, strerror(errno));
         close(dev->sock_fd);
         freeaddrinfo(res);
-        free(dev);
+        cml_free(dev);
         return NULL;
     }
     freeaddrinfo(res);
@@ -149,7 +150,7 @@ CMLRemoteDevice* cml_remote_connect(const char* host, int port) {
     if (send_msg(dev->sock_fd, CML_REMOTE_OP_PING, NULL, 0) != 0) {
         LOG_ERROR("remote_connect: ping send failed");
         close(dev->sock_fd);
-        free(dev);
+        cml_free(dev);
         return NULL;
     }
 
@@ -159,7 +160,7 @@ CMLRemoteDevice* cml_remote_connect(const char* host, int port) {
     if (recv_resp(dev->sock_fd, &status, &sid, &psize) != 0 || status != CML_REMOTE_STATUS_OK) {
         LOG_ERROR("remote_connect: ping response failed");
         close(dev->sock_fd);
-        free(dev);
+        cml_free(dev);
         return NULL;
     }
 
@@ -177,7 +178,7 @@ void cml_remote_disconnect(CMLRemoteDevice* dev) {
         dev->sock_fd = -1;
     }
     dev->connected = false;
-    free(dev);
+    cml_free(dev);
 }
 
 bool cml_remote_is_connected(CMLRemoteDevice* dev) {
@@ -216,7 +217,7 @@ int cml_remote_upload(CMLRemoteDevice* dev, uint64_t handle, const void* data, s
 
     size_t hdr_size = sizeof(handle) + sizeof(uint64_t);
     size_t total = hdr_size + n;
-    uint8_t* payload = (uint8_t*)malloc(total);
+    uint8_t* payload = (uint8_t*)cml_malloc(total);
     if (!payload) return -1;
 
     memcpy(payload, &handle, sizeof(handle));
@@ -225,7 +226,7 @@ int cml_remote_upload(CMLRemoteDevice* dev, uint64_t handle, const void* data, s
     memcpy(payload + hdr_size, data, n);
 
     int ret = send_msg(dev->sock_fd, CML_REMOTE_OP_UPLOAD, payload, (uint32_t)total);
-    free(payload);
+    cml_free(payload);
     if (ret != 0) return -1;
 
     uint32_t status, psize = 0;
@@ -279,7 +280,7 @@ int cml_remote_execute(CMLRemoteDevice* dev, const char* kernel_source,
 
     /* payload: [src_len(4)][source][num_buf(4)][handles...][grid(12)][block(12)] */
     size_t total = sizeof(uint32_t) + src_len + sizeof(uint32_t) + handles_size + 24;
-    uint8_t* payload = (uint8_t*)malloc(total);
+    uint8_t* payload = (uint8_t*)cml_malloc(total);
     if (!payload) return -1;
 
     size_t off = 0;
@@ -293,7 +294,7 @@ int cml_remote_execute(CMLRemoteDevice* dev, const char* kernel_source,
     memcpy(payload + off, block, 12);
 
     int ret = send_msg(dev->sock_fd, CML_REMOTE_OP_EXECUTE, payload, (uint32_t)total);
-    free(payload);
+    cml_free(payload);
     if (ret != 0) return -1;
 
     uint32_t status, psize = 0;
@@ -321,7 +322,7 @@ static uint64_t server_alloc(size_t size) {
     DeviceType best = device_get_best_available();
     void* ptr = device_alloc(size, best);
     if (!ptr) {
-        ptr = malloc(size);
+        ptr = cml_malloc(size);
         if (!ptr) return 0;
     }
 
@@ -343,7 +344,7 @@ static AllocEntry* server_find(uint64_t handle) {
 static void server_free_handle(uint64_t handle) {
     for (int i = 0; i < g_num_allocs; i++) {
         if (g_allocs[i].handle == handle) {
-            free(g_allocs[i].ptr);
+            cml_free(g_allocs[i].ptr);
             g_allocs[i] = g_allocs[g_num_allocs - 1];
             g_num_allocs--;
             return;
@@ -353,7 +354,7 @@ static void server_free_handle(uint64_t handle) {
 
 static void server_free_all(void) {
     for (int i = 0; i < g_num_allocs; i++) {
-        free(g_allocs[i].ptr);
+        cml_free(g_allocs[i].ptr);
     }
     g_num_allocs = 0;
 }
@@ -370,10 +371,10 @@ static void handle_client(int client_fd) {
 
         uint8_t* payload = NULL;
         if (psize > 0) {
-            payload = (uint8_t*)malloc(psize);
+            payload = (uint8_t*)cml_malloc(psize);
             if (!payload) break;
             if (recv_all(client_fd, payload, psize) != 0) {
-                free(payload);
+                cml_free(payload);
                 break;
             }
         }
@@ -482,7 +483,7 @@ static void handle_client(int client_fd) {
             /* Resolve handles to buffer pointers */
             float** bufs = NULL;
             if (num_buf2 > 0) {
-                bufs = (float**)malloc((size_t)num_buf2 * sizeof(float*));
+                bufs = (float**)cml_malloc((size_t)num_buf2 * sizeof(float*));
                 if (!bufs) {
                     LOG_ERROR("remote_server: OOM resolving buffer handles");
                     send_resp(client_fd, CML_REMOTE_STATUS_ERROR, NULL, 0);
@@ -500,7 +501,7 @@ static void handle_client(int client_fd) {
                     bufs[bi] = (float*)ae->ptr;
                 }
                 if (!lookup_ok) {
-                    free(bufs);
+                    cml_free(bufs);
                     send_resp(client_fd, CML_REMOTE_STATUS_ERROR, NULL, 0);
                     break;
                 }
@@ -514,7 +515,7 @@ static void handle_client(int client_fd) {
             int src_fd2 = mkstemps(src_path, 2); /* suffix len = 2 for ".c" */
             if (src_fd2 < 0) {
                 LOG_ERROR("remote_server: mkstemps failed: %s", strerror(errno));
-                free(bufs);
+                cml_free(bufs);
                 send_resp(client_fd, CML_REMOTE_STATUS_ERROR, NULL, 0);
                 break;
             }
@@ -550,7 +551,7 @@ static void handle_client(int client_fd) {
             if (compile_ret != 0) {
                 LOG_ERROR("remote_server: kernel compilation failed (exit %d)", compile_ret);
                 unlink(so_path2);
-                free(bufs);
+                cml_free(bufs);
                 send_resp(client_fd, CML_REMOTE_STATUS_ERROR, NULL, 0);
                 break;
             }
@@ -560,7 +561,7 @@ static void handle_client(int client_fd) {
             if (!dl) {
                 LOG_ERROR("remote_server: dlopen failed: %s", dlerror());
                 unlink(so_path2);
-                free(bufs);
+                cml_free(bufs);
                 send_resp(client_fd, CML_REMOTE_STATUS_ERROR, NULL, 0);
                 break;
             }
@@ -571,7 +572,7 @@ static void handle_client(int client_fd) {
                 LOG_ERROR("remote_server: dlsym(cml_kernel) failed: %s", dlerror());
                 dlclose(dl);
                 unlink(so_path2);
-                free(bufs);
+                cml_free(bufs);
                 send_resp(client_fd, CML_REMOTE_STATUS_ERROR, NULL, 0);
                 break;
             }
@@ -580,7 +581,7 @@ static void handle_client(int client_fd) {
 
             dlclose(dl);
             unlink(so_path2);
-            free(bufs);
+            cml_free(bufs);
 
             LOG_INFO("remote_server: kernel executed successfully (%u bufs)", num_buf2);
             send_resp(client_fd, CML_REMOTE_STATUS_OK, NULL, 0);
@@ -596,7 +597,7 @@ static void handle_client(int client_fd) {
             break;
         }
 
-        free(payload);
+        cml_free(payload);
     }
 }
 
@@ -605,14 +606,14 @@ static void handle_client(int client_fd) {
 CMLRemoteServer* cml_remote_server_create(int port) {
     if (port <= 0) return NULL;
 
-    CMLRemoteServer* srv = (CMLRemoteServer*)calloc(1, sizeof(CMLRemoteServer));
+    CMLRemoteServer* srv = (CMLRemoteServer*)cml_calloc(1, sizeof(CMLRemoteServer));
     if (!srv) return NULL;
 
     srv->port = port;
     srv->listen_fd = socket(AF_INET, SOCK_STREAM, 0);
     if (srv->listen_fd < 0) {
         LOG_ERROR("remote_server: socket() failed: %s", strerror(errno));
-        free(srv);
+        cml_free(srv);
         return NULL;
     }
 
@@ -627,14 +628,14 @@ CMLRemoteServer* cml_remote_server_create(int port) {
     if (bind(srv->listen_fd, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
         LOG_ERROR("remote_server: bind() port %d failed: %s", port, strerror(errno));
         close(srv->listen_fd);
-        free(srv);
+        cml_free(srv);
         return NULL;
     }
 
     if (listen(srv->listen_fd, 8) != 0) {
         LOG_ERROR("remote_server: listen() failed: %s", strerror(errno));
         close(srv->listen_fd);
-        free(srv);
+        cml_free(srv);
         return NULL;
     }
 
@@ -691,5 +692,5 @@ void cml_remote_server_free(CMLRemoteServer* srv) {
         close(srv->listen_fd);
     }
     server_free_all();
-    free(srv);
+    cml_free(srv);
 }

--- a/src/backend/threadpool.c
+++ b/src/backend/threadpool.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <time.h>
+#include "alloc/cml_allocator.h"
 
 typedef struct TaskNode {
     Task task;
@@ -93,7 +94,7 @@ static void* worker_thread(void* arg) {
                     pool->task_queue_tail = NULL;
                 }
                 pool->queue_size--;
-                free(task_node);
+                cml_free(task_node);
                 pthread_cond_broadcast(&pool->cond);
             }
             pthread_mutex_unlock(&pool->mutex);
@@ -113,16 +114,16 @@ ThreadPool* threadpool_create(size_t num_threads) {
         }
     }
 
-    ThreadPool* pool = malloc(sizeof(ThreadPool));
+    ThreadPool* pool = cml_malloc(sizeof(ThreadPool));
     if (!pool) {
         LOG_ERROR("Failed to allocate thread pool");
         return NULL;
     }
 
     pool->num_threads = num_threads;
-    pool->workers     = calloc(num_threads, sizeof(Worker));
+    pool->workers     = cml_calloc(num_threads, sizeof(Worker));
     if (!pool->workers) {
-        free(pool);
+        cml_free(pool);
         return NULL;
     }
 
@@ -164,15 +165,15 @@ void threadpool_destroy(ThreadPool* pool) {
     TaskNode* node = pool->task_queue_head;
     while (node) {
         TaskNode* next = node->next;
-        free(node);
+        cml_free(node);
         node = next;
     }
 
     pthread_mutex_destroy(&pool->mutex);
     pthread_cond_destroy(&pool->cond);
     pthread_cond_destroy(&pool->task_cond);
-    free(pool->workers);
-    free(pool);
+    cml_free(pool->workers);
+    cml_free(pool);
 }
 
 int threadpool_submit(ThreadPool* pool, Task* task) {
@@ -180,7 +181,7 @@ int threadpool_submit(ThreadPool* pool, Task* task) {
         return -1;
     }
 
-    TaskNode* task_node = malloc(sizeof(TaskNode));
+    TaskNode* task_node = cml_malloc(sizeof(TaskNode));
     if (!task_node) {
         LOG_ERROR("Failed to allocate task node");
         return -1;

--- a/src/backend/thunder_executor.c
+++ b/src/backend/thunder_executor.c
@@ -4,6 +4,7 @@
 #include "core/logging.h"
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 typedef struct {
     const char* thunder_name;
@@ -63,7 +64,7 @@ static CMLBackendType parse_backend(const char* name) {
 }
 
 CMLThunderExecutor* cml_thunder_create(const char* backend) {
-    CMLThunderExecutor* exec = calloc(1, sizeof(CMLThunderExecutor));
+    CMLThunderExecutor* exec = cml_calloc(1, sizeof(CMLThunderExecutor));
     if (!exec) return NULL;
 
     if (backend)
@@ -73,7 +74,7 @@ CMLThunderExecutor* cml_thunder_create(const char* backend) {
 
     CMLDispatchContext* ctx = cml_dispatch_create();
     if (!ctx) {
-        free(exec);
+        cml_free(exec);
         return NULL;
     }
 
@@ -92,7 +93,7 @@ void cml_thunder_free(CMLThunderExecutor* exec) {
     if (!exec) return;
     if (exec->dispatch_ctx)
         cml_dispatch_free((CMLDispatchContext*)exec->dispatch_ctx);
-    free(exec);
+    cml_free(exec);
 }
 
 int cml_thunder_execute(CMLThunderExecutor* exec, CMLThunderOp* ops, int num_ops) {

--- a/src/backend/usb3_gpu.c
+++ b/src/backend/usb3_gpu.c
@@ -11,6 +11,7 @@
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <linux/usbdevice_fs.h>
+#include "alloc/cml_allocator.h"
 
 #define ASM2464PD_VENDOR     0x174c
 #define ASM2464PD_PRODUCT    0x2362
@@ -145,7 +146,7 @@ CMLUSB3GPU* cml_usb3_gpu_open(void) {
         return NULL;
     }
 
-    CMLUSB3GPU* dev = (CMLUSB3GPU*)calloc(1, sizeof(CMLUSB3GPU));
+    CMLUSB3GPU* dev = (CMLUSB3GPU*)cml_calloc(1, sizeof(CMLUSB3GPU));
     if (!dev) {
         usb3_release_interface(fd, 0);
         close(fd);
@@ -164,11 +165,11 @@ CMLUSB3GPU* cml_usb3_gpu_open(void) {
     dev->ep_out = DEFAULT_EP_OUT;
 
     dev->bulk_buf_size = USB3_BULK_BUF_SIZE;
-    dev->bulk_buf = (uint8_t*)malloc(dev->bulk_buf_size);
+    dev->bulk_buf = (uint8_t*)cml_malloc(dev->bulk_buf_size);
     if (!dev->bulk_buf) {
         usb3_release_interface(fd, 0);
         close(fd);
-        free(dev);
+        cml_free(dev);
         return NULL;
     }
 
@@ -189,8 +190,8 @@ void cml_usb3_gpu_close(CMLUSB3GPU* dev) {
         close(dev->fd);
     }
 
-    free(dev->bulk_buf);
-    free(dev);
+    cml_free(dev->bulk_buf);
+    cml_free(dev);
 }
 
 int cml_usb3_gpu_scsi_cmd(CMLUSB3GPU* dev, const uint8_t* cdb, int cdb_len,

--- a/src/backend/usb_device.c
+++ b/src/backend/usb_device.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <dlfcn.h>
+#include "alloc/cml_allocator.h"
 
 /* libusb descriptor structure (partial, matches libusb_device_descriptor layout) */
 #pragma pack(push, 1)
@@ -188,7 +189,7 @@ int cml_usb_enumerate(CMLUSBDevice** devices, int* num_devices) {
         return 0;
     }
 
-    CMLUSBDevice* devs = (CMLUSBDevice*)calloc((size_t)matched, sizeof(CMLUSBDevice));
+    CMLUSBDevice* devs = (CMLUSBDevice*)cml_calloc((size_t)matched, sizeof(CMLUSBDevice));
     if (!devs) {
         LOG_ERROR("USB enumerate: allocation failed");
         fn_libusb_free_device_list(dev_list, 1);
@@ -424,5 +425,5 @@ void cml_usb_free_devices(CMLUSBDevice* devices, int num_devices) {
         }
     }
 
-    free(devices);
+    cml_free(devices);
 }

--- a/src/cml.c
+++ b/src/cml.c
@@ -72,7 +72,7 @@ void cml_track_module(Module* module) {
 
     if (g_num_modules >= g_modules_capacity) {
         size_t new_capacity  = g_modules_capacity == 0 ? 16 : g_modules_capacity * 2;
-        Module** new_modules = realloc(g_tracked_modules, (size_t)new_capacity * sizeof(Module*));
+        Module** new_modules = cml_realloc(g_tracked_modules, (size_t)new_capacity * sizeof(Module*));
         if (!new_modules)
             return;
         g_tracked_modules  = new_modules;
@@ -100,7 +100,7 @@ void cml_track_optimizer(Optimizer* optimizer) {
     if (g_num_optimizers >= g_optimizers_capacity) {
         size_t new_capacity = g_optimizers_capacity == 0 ? 16 : g_optimizers_capacity * 2;
         Optimizer** new_optimizers =
-            realloc(g_tracked_optimizers, (size_t)new_capacity * sizeof(Optimizer*));
+            cml_realloc(g_tracked_optimizers, (size_t)new_capacity * sizeof(Optimizer*));
         if (!new_optimizers)
             return;
         g_tracked_optimizers  = new_optimizers;
@@ -128,7 +128,7 @@ void cml_track_dataset(Dataset* dataset) {
     if (g_num_datasets >= g_datasets_capacity) {
         size_t new_capacity = g_datasets_capacity == 0 ? 16 : g_datasets_capacity * 2;
         Dataset** new_datasets =
-            realloc(g_tracked_datasets, (size_t)new_capacity * sizeof(Dataset*));
+            cml_realloc(g_tracked_datasets, (size_t)new_capacity * sizeof(Dataset*));
         if (!new_datasets)
             return;
         g_tracked_datasets  = new_datasets;
@@ -152,7 +152,7 @@ static void cml_auto_cleanup(void) {
                 cleanup_context_free(g_cleanup_contexts[i]);
             }
         }
-        free(g_cleanup_contexts);
+        cml_free(g_cleanup_contexts);
         g_cleanup_contexts          = NULL;
         g_num_cleanup_contexts      = 0;
         g_cleanup_contexts_capacity = 0;
@@ -164,7 +164,7 @@ static void cml_auto_cleanup(void) {
                 dataset_free(g_tracked_datasets[i]);
             }
         }
-        free(g_tracked_datasets);
+        cml_free(g_tracked_datasets);
         g_tracked_datasets  = NULL;
         g_num_datasets      = 0;
         g_datasets_capacity = 0;
@@ -176,7 +176,7 @@ static void cml_auto_cleanup(void) {
                 optimizer_free(g_tracked_optimizers[i]);
             }
         }
-        free(g_tracked_optimizers);
+        cml_free(g_tracked_optimizers);
         g_tracked_optimizers  = NULL;
         g_num_optimizers      = 0;
         g_optimizers_capacity = 0;
@@ -188,7 +188,7 @@ static void cml_auto_cleanup(void) {
                 module_free(g_tracked_modules[i]);
             }
         }
-        free(g_tracked_modules);
+        cml_free(g_tracked_modules);
         g_tracked_modules  = NULL;
         g_num_modules      = 0;
         g_modules_capacity = 0;
@@ -226,7 +226,7 @@ void cml_register_cleanup_context(CleanupContext* ctx) {
         size_t new_capacity =
             g_cleanup_contexts_capacity == 0 ? 16 : g_cleanup_contexts_capacity * 2;
         CleanupContext** new_contexts =
-            realloc(g_cleanup_contexts, (size_t)new_capacity * sizeof(CleanupContext*));
+            cml_realloc(g_cleanup_contexts, (size_t)new_capacity * sizeof(CleanupContext*));
         if (!new_contexts)
             return;
         g_cleanup_contexts          = new_contexts;
@@ -447,7 +447,7 @@ int cml_cleanup(void) {
                 g_tracked_datasets[i] = NULL;
             }
         }
-        free(g_tracked_datasets);
+        cml_free(g_tracked_datasets);
         g_tracked_datasets  = NULL;
         g_num_datasets      = 0;
         g_datasets_capacity = 0;
@@ -460,7 +460,7 @@ int cml_cleanup(void) {
                 g_tracked_optimizers[i] = NULL;
             }
         }
-        free(g_tracked_optimizers);
+        cml_free(g_tracked_optimizers);
         g_tracked_optimizers  = NULL;
         g_num_optimizers      = 0;
         g_optimizers_capacity = 0;
@@ -473,7 +473,7 @@ int cml_cleanup(void) {
                 g_tracked_modules[i] = NULL;
             }
         }
-        free(g_tracked_modules);
+        cml_free(g_tracked_modules);
         g_tracked_modules  = NULL;
         g_num_modules      = 0;
         g_modules_capacity = 0;
@@ -608,7 +608,7 @@ void cml_summary(Module* module) {
             }
         }
         if (params)
-            free(params);
+            cml_free(params);
     }
 
     printf("%-5s %-35s %15s\n", "Layer", "Type", "Parameters");

--- a/src/core/augmentation.c
+++ b/src/core/augmentation.c
@@ -5,13 +5,14 @@
 #include <string.h>
 #include <math.h>
 #include <time.h>
+#include "alloc/cml_allocator.h"
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
 #endif
 
 AugmentationConfig* augmentation_config_create(void) {
-    AugmentationConfig* config = malloc(sizeof(AugmentationConfig));
+    AugmentationConfig* config = cml_malloc(sizeof(AugmentationConfig));
     if (!config)
         return NULL;
 
@@ -47,10 +48,10 @@ void augmentation_config_free(AugmentationConfig* config) {
         return;
 
     if (config->mean)
-        free(config->mean);
+        cml_free(config->mean);
     if (config->std)
-        free(config->std);
-    free(config);
+        cml_free(config->std);
+    cml_free(config);
 }
 
 static unsigned int rng_seed = 1;

--- a/src/core/cleanup.c
+++ b/src/core/cleanup.c
@@ -8,11 +8,12 @@
 #include "core/logging.h"
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 #define INITIAL_CAPACITY 16
 
 CleanupContext* cleanup_context_create(void) {
-    CleanupContext* ctx = malloc(sizeof(CleanupContext));
+    CleanupContext* ctx = cml_malloc(sizeof(CleanupContext));
     if (!ctx)
         return NULL;
 
@@ -47,7 +48,7 @@ static int ensure_tensor_capacity(CleanupContext* ctx, size_t needed) {
         new_capacity *= 2;
     }
 
-    Tensor** new_tensors = realloc(ctx->tensors, (size_t)new_capacity * sizeof(Tensor*));
+    Tensor** new_tensors = cml_realloc(ctx->tensors, (size_t)new_capacity * sizeof(Tensor*));
     if (!new_tensors)
         return -1;
 
@@ -110,7 +111,7 @@ void cleanup_clear_all(CleanupContext* ctx) {
     }
 
     if (ctx->params) {
-        free(ctx->params);
+        cml_free(ctx->params);
         ctx->params = NULL;
     }
 
@@ -125,7 +126,7 @@ void cleanup_clear_all(CleanupContext* ctx) {
         }
     }
     if (ctx->tensors) {
-        free(ctx->tensors);
+        cml_free(ctx->tensors);
         ctx->tensors = NULL;
     }
     ctx->num_tensors     = 0;
@@ -137,7 +138,7 @@ void cleanup_clear_all(CleanupContext* ctx) {
         }
     }
     if (ctx->datasets) {
-        free(ctx->datasets);
+        cml_free(ctx->datasets);
         ctx->datasets = NULL;
     }
     ctx->num_datasets     = 0;
@@ -145,11 +146,11 @@ void cleanup_clear_all(CleanupContext* ctx) {
 
     for (size_t i = 0; i < ctx->num_memory_ptrs; i++) {
         if (ctx->memory_ptrs[i]) {
-            free(ctx->memory_ptrs[i]);
+            cml_free(ctx->memory_ptrs[i]);
         }
     }
     if (ctx->memory_ptrs) {
-        free(ctx->memory_ptrs);
+        cml_free(ctx->memory_ptrs);
         ctx->memory_ptrs = NULL;
     }
     ctx->num_memory_ptrs = 0;
@@ -161,5 +162,5 @@ void cleanup_context_free(CleanupContext* ctx) {
         return;
 
     cleanup_clear_all(ctx);
-    free(ctx);
+    cml_free(ctx);
 }

--- a/src/core/computation_graph.c
+++ b/src/core/computation_graph.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include "alloc/cml_allocator.h"
 
 struct CMLGraphNode {
     CMLOpType op_type;
@@ -36,7 +37,7 @@ static void graph_topo_sort(CMLComputationGraph_t graph);
 static void graph_mark_reachable(CMLGraphNode_t node);
 
 CMLComputationGraph_t cml_graph_new(void) {
-    CMLComputationGraph_t graph = malloc(sizeof(struct CMLComputationGraph));
+    CMLComputationGraph_t graph = cml_malloc(sizeof(struct CMLComputationGraph));
     if (!graph)
         return NULL;
 
@@ -59,14 +60,14 @@ void cml_graph_free(CMLComputationGraph_t graph) {
         for (size_t i = 0; i < graph->num_nodes; i++) {
             graph_node_free(graph->nodes[i]);
         }
-        free(graph->nodes);
+        cml_free(graph->nodes);
     }
 
     if (graph->leaf_nodes) {
-        free(graph->leaf_nodes);
+        cml_free(graph->leaf_nodes);
     }
 
-    free(graph);
+    cml_free(graph);
 }
 
 void cml_graph_clear(CMLComputationGraph_t graph) {
@@ -77,11 +78,11 @@ void cml_graph_clear(CMLComputationGraph_t graph) {
         for (size_t i = 0; i < graph->num_nodes; i++) {
             graph_node_free(graph->nodes[i]);
         }
-        free(graph->nodes);
+        cml_free(graph->nodes);
     }
 
     if (graph->leaf_nodes) {
-        free(graph->leaf_nodes);
+        cml_free(graph->leaf_nodes);
     }
 
     graph->nodes         = NULL;
@@ -112,7 +113,7 @@ CMLGraphNode_t cml_graph_get_node_by_index(CMLComputationGraph_t graph, size_t i
 }
 
 static CMLGraphNode_t graph_node_create(CMLOpType op_type, Tensor* tensor) {
-    CMLGraphNode_t node = malloc(sizeof(struct CMLGraphNode));
+    CMLGraphNode_t node = cml_malloc(sizeof(struct CMLGraphNode));
     if (!node)
         return NULL;
 
@@ -134,14 +135,14 @@ static void graph_node_free(CMLGraphNode_t node) {
         return;
 
     if (node->inputs) {
-        free(node->inputs);
+        cml_free(node->inputs);
     }
 
     if (node->op_params) {
-        free(node->op_params);
+        cml_free(node->op_params);
     }
 
-    free(node);
+    cml_free(node);
 }
 
 static void graph_add_node(CMLComputationGraph_t graph, CMLGraphNode_t node) {
@@ -151,7 +152,7 @@ static void graph_add_node(CMLComputationGraph_t graph, CMLGraphNode_t node) {
     if (graph->num_nodes >= graph->capacity) {
         size_t new_capacity = graph->capacity == 0 ? 16 : graph->capacity * 2;
         CMLGraphNode_t* new_nodes =
-            realloc(graph->nodes, (size_t)new_capacity * sizeof(CMLGraphNode_t));
+            cml_realloc(graph->nodes, (size_t)new_capacity * sizeof(CMLGraphNode_t));
         if (!new_nodes) {
             LOG_ERROR("Failed to expand graph node array");
             return;
@@ -177,7 +178,7 @@ CMLGraphNode_t cml_graph_node_input(CMLComputationGraph_t graph, Tensor* tensor)
     if (graph->num_leaves >= graph->leaf_capacity) {
         size_t new_capacity = graph->leaf_capacity == 0 ? 8 : graph->leaf_capacity * 2;
         CMLGraphNode_t* new_leaves =
-            realloc(graph->leaf_nodes, (size_t)new_capacity * sizeof(CMLGraphNode_t));
+            cml_realloc(graph->leaf_nodes, (size_t)new_capacity * sizeof(CMLGraphNode_t));
         if (!new_leaves) {
             graph_node_free(node);
             return NULL;
@@ -211,7 +212,7 @@ CMLGraphNode_t cml_graph_node_op(CMLComputationGraph_t graph, CMLOpType op_type,
     if (!node)
         return NULL;
 
-    node->inputs = malloc((size_t)num_inputs * sizeof(CMLGraphNode_t));
+    node->inputs = cml_malloc((size_t)num_inputs * sizeof(CMLGraphNode_t));
     if (!node->inputs) {
         graph_node_free(node);
         return NULL;
@@ -276,15 +277,15 @@ CMLComputationGraph_t cml_graph_build_backward(CMLComputationGraph_t forward_gra
     if (!backward_graph)
         return NULL;
 
-    bool* visited = calloc(forward_graph->num_nodes, sizeof(bool));
+    bool* visited = cml_calloc(forward_graph->num_nodes, sizeof(bool));
     if (!visited) {
         cml_graph_free(backward_graph);
         return NULL;
     }
 
-    CMLGraphNode_t* stack = malloc(forward_graph->num_nodes * sizeof(CMLGraphNode_t));
+    CMLGraphNode_t* stack = cml_malloc(forward_graph->num_nodes * sizeof(CMLGraphNode_t));
     if (!stack) {
-        free(visited);
+        cml_free(visited);
         cml_graph_free(backward_graph);
         return NULL;
     }
@@ -292,10 +293,10 @@ CMLComputationGraph_t cml_graph_build_backward(CMLComputationGraph_t forward_gra
     int stack_top      = 0;
     stack[stack_top++] = output;
 
-    CMLGraphNode_t* forward_to_backward = calloc(forward_graph->num_nodes, sizeof(CMLGraphNode_t));
+    CMLGraphNode_t* forward_to_backward = cml_calloc(forward_graph->num_nodes, sizeof(CMLGraphNode_t));
     if (!forward_to_backward) {
-        free(stack);
-        free(visited);
+        cml_free(stack);
+        cml_free(visited);
         cml_graph_free(backward_graph);
         return NULL;
     }
@@ -351,7 +352,7 @@ CMLComputationGraph_t cml_graph_build_backward(CMLComputationGraph_t forward_gra
         if (backward_node) {
             if (forward_node->num_inputs > 0) {
                 backward_node->inputs =
-                    malloc((size_t)forward_node->num_inputs * sizeof(CMLGraphNode_t));
+                    cml_malloc((size_t)forward_node->num_inputs * sizeof(CMLGraphNode_t));
                 if (backward_node->inputs) {
                     memcpy(backward_node->inputs, forward_node->inputs,
                            (size_t)forward_node->num_inputs * sizeof(CMLGraphNode_t));
@@ -395,9 +396,9 @@ CMLComputationGraph_t cml_graph_build_backward(CMLComputationGraph_t forward_gra
         }
     }
 
-    free(forward_to_backward);
-    free(stack);
-    free(visited);
+    cml_free(forward_to_backward);
+    cml_free(stack);
+    cml_free(visited);
 
     backward_graph->built = true;
     return backward_graph;
@@ -546,7 +547,7 @@ int cml_graph_fuse_ops(CMLComputationGraph_t graph) {
         return 0;
 
     int fused_count = 0;
-    bool* fused     = calloc(graph->num_nodes, sizeof(bool));
+    bool* fused     = cml_calloc(graph->num_nodes, sizeof(bool));
     if (!fused)
         return -1;
 
@@ -606,9 +607,9 @@ int cml_graph_fuse_ops(CMLComputationGraph_t graph) {
                     fused[consumer_idx] = true;
 
                     if (consumer->num_inputs > 0 && consumer->inputs) {
-                        free(consumer->inputs);
+                        cml_free(consumer->inputs);
                         consumer->inputs =
-                            malloc((size_t)node1->num_inputs * sizeof(CMLGraphNode_t));
+                            cml_malloc((size_t)node1->num_inputs * sizeof(CMLGraphNode_t));
                         if (consumer->inputs) {
                             memcpy(consumer->inputs, node1->inputs,
                                    (size_t)node1->num_inputs * sizeof(CMLGraphNode_t));
@@ -622,7 +623,7 @@ int cml_graph_fuse_ops(CMLComputationGraph_t graph) {
         }
     }
 
-    free(fused);
+    cml_free(fused);
 
     return 0;
 }
@@ -667,7 +668,7 @@ int cml_graph_remove_dead_nodes(CMLComputationGraph_t graph) {
             write_idx++;
         } else {
             if (graph->nodes[i]) {
-                free(graph->nodes[i]);
+                cml_free(graph->nodes[i]);
             }
         }
     }

--- a/src/core/dataset.c
+++ b/src/core/dataset.c
@@ -15,6 +15,7 @@
 #include <pthread.h>
 #include <unistd.h>
 #include <time.h>
+#include "alloc/cml_allocator.h"
 
 typedef struct PrefetchQueue {
     Batch** batches;
@@ -37,18 +38,18 @@ typedef struct WorkerContext {
 } WorkerContext;
 
 static PrefetchQueue* prefetch_queue_create(int capacity) {
-    PrefetchQueue* queue = malloc(sizeof(PrefetchQueue));
+    PrefetchQueue* queue = cml_malloc(sizeof(PrefetchQueue));
     if (!queue)
         return NULL;
 
-    queue->batches       = calloc((size_t)capacity, sizeof(Batch*));
-    queue->batch_indices = calloc((size_t)capacity, sizeof(int));
+    queue->batches       = cml_calloc((size_t)capacity, sizeof(Batch*));
+    queue->batch_indices = cml_calloc((size_t)capacity, sizeof(int));
     if (!queue->batches || !queue->batch_indices) {
         if (queue->batches)
-            free(queue->batches);
+            cml_free(queue->batches);
         if (queue->batch_indices)
-            free(queue->batch_indices);
-        free(queue);
+            cml_free(queue->batch_indices);
+        cml_free(queue);
         return NULL;
     }
 
@@ -82,7 +83,7 @@ static void prefetch_queue_free(PrefetchQueue* queue) {
                 tensor_free(batch->X);
             if (batch->y)
                 tensor_free(batch->y);
-            free(batch);
+            cml_free(batch);
         }
         queue->front = (queue->front + 1) % queue->capacity;
         queue->size--;
@@ -93,10 +94,10 @@ static void prefetch_queue_free(PrefetchQueue* queue) {
     pthread_cond_destroy(&queue->not_full);
 
     if (queue->batches)
-        free(queue->batches);
+        cml_free(queue->batches);
     if (queue->batch_indices)
-        free(queue->batch_indices);
-    free(queue);
+        cml_free(queue->batch_indices);
+    cml_free(queue);
 }
 
 static int prefetch_queue_enqueue(PrefetchQueue* queue, Batch* batch, int batch_idx) {
@@ -169,7 +170,7 @@ static Batch* load_batch_at_index(DataLoader* loader, int batch_idx) {
 
     int actual_batch_size = end_idx - start_idx;
 
-    Batch* batch = malloc(sizeof(Batch));
+    Batch* batch = cml_malloc(sizeof(Batch));
     if (!batch)
         return NULL;
     int batch_X_shape[] = {actual_batch_size, loader->dataset->input_size};
@@ -187,7 +188,7 @@ static Batch* load_batch_at_index(DataLoader* loader, int batch_idx) {
             tensor_free(batch->X);
         if (batch->y)
             tensor_free(batch->y);
-        free(batch);
+        cml_free(batch);
         return NULL;
     }
 
@@ -245,7 +246,7 @@ static void* worker_prefetch_batches(void* arg) {
 }
 
 Dataset* dataset_create(void) {
-    Dataset* dataset = malloc(sizeof(Dataset));
+    Dataset* dataset = cml_malloc(sizeof(Dataset));
     if (!dataset) {
         LOG_ERROR("Failed to allocate memory for Dataset");
         return NULL;
@@ -330,7 +331,7 @@ int dataset_load_arrays(Dataset* dataset, float* X, float* y, int num_samples, i
     dataset->output_size = output_size;
     dataset->is_loaded   = true;
 
-    dataset->indices = malloc((size_t)num_samples * sizeof(int));
+    dataset->indices = cml_malloc((size_t)num_samples * sizeof(int));
     if (!dataset->indices) {
         LOG_WARNING("Failed to allocate indices array, shuffling will be disabled");
     } else {
@@ -361,21 +362,21 @@ int dataset_load_file(Dataset* dataset, const char* filepath, const char* format
         }
 
         int result = dataset_load_arrays(dataset, X, y, num_samples, num_features, 1);
-        free(X);
-        free(y);
+        cml_free(X);
+        cml_free(y);
 
         if (result != 0) {
             if (class_names) {
                 for (int i = 0; i < num_classes; i++)
-                    free(class_names[i]);
-                free(class_names);
+                    cml_free(class_names[i]);
+                cml_free(class_names);
             }
             return -1;
         }
 
         dataset->num_classes = num_classes;
         dataset->class_names = class_names;
-        dataset->filepath = strdup(filepath);
+        dataset->filepath = cml_strdup(filepath);
 
         cml_dataset_compute_stats(dataset);
 
@@ -430,36 +431,36 @@ void dataset_free(Dataset* dataset) {
         tensor_free(dataset->y);
 
     if (dataset->feature_means)
-        free(dataset->feature_means);
+        cml_free(dataset->feature_means);
     if (dataset->feature_stds)
-        free(dataset->feature_stds);
+        cml_free(dataset->feature_stds);
     if (dataset->feature_mins)
-        free(dataset->feature_mins);
+        cml_free(dataset->feature_mins);
     if (dataset->feature_maxs)
-        free(dataset->feature_maxs);
+        cml_free(dataset->feature_maxs);
 
     if (dataset->feature_names) {
         for (int i = 0; i < dataset->input_size; i++) {
             if (dataset->feature_names[i])
-                free(dataset->feature_names[i]);
+                cml_free(dataset->feature_names[i]);
         }
-        free(dataset->feature_names);
+        cml_free(dataset->feature_names);
     }
 
     if (dataset->class_names) {
         for (int i = 0; i < dataset->num_classes; i++) {
             if (dataset->class_names[i])
-                free(dataset->class_names[i]);
+                cml_free(dataset->class_names[i]);
         }
-        free(dataset->class_names);
+        cml_free(dataset->class_names);
     }
 
     if (dataset->indices)
-        free(dataset->indices);
+        cml_free(dataset->indices);
     if (dataset->filepath)
-        free(dataset->filepath);
+        cml_free(dataset->filepath);
 
-    free(dataset);
+    cml_free(dataset);
 }
 
 int dataset_split(Dataset* dataset, float train_ratio, Dataset** train_dataset,
@@ -511,10 +512,10 @@ int dataset_split(Dataset* dataset, float train_ratio, Dataset** train_dataset,
     /* Copy normalization statistics if present */
     if (dataset->feature_mins && dataset->feature_maxs) {
         size_t stat_sz                 = (size_t)dataset->input_size * sizeof(float);
-        (*train_dataset)->feature_mins = malloc(stat_sz);
-        (*train_dataset)->feature_maxs = malloc(stat_sz);
-        (*val_dataset)->feature_mins   = malloc(stat_sz);
-        (*val_dataset)->feature_maxs   = malloc(stat_sz);
+        (*train_dataset)->feature_mins = cml_malloc(stat_sz);
+        (*train_dataset)->feature_maxs = cml_malloc(stat_sz);
+        (*val_dataset)->feature_mins   = cml_malloc(stat_sz);
+        (*val_dataset)->feature_maxs   = cml_malloc(stat_sz);
         if ((*train_dataset)->feature_mins && (*train_dataset)->feature_maxs) {
             memcpy((*train_dataset)->feature_mins, dataset->feature_mins, stat_sz);
             memcpy((*train_dataset)->feature_maxs, dataset->feature_maxs, stat_sz);
@@ -526,10 +527,10 @@ int dataset_split(Dataset* dataset, float train_ratio, Dataset** train_dataset,
     }
     if (dataset->feature_means && dataset->feature_stds) {
         size_t stat_sz                  = (size_t)dataset->input_size * sizeof(float);
-        (*train_dataset)->feature_means = malloc(stat_sz);
-        (*train_dataset)->feature_stds  = malloc(stat_sz);
-        (*val_dataset)->feature_means   = malloc(stat_sz);
-        (*val_dataset)->feature_stds    = malloc(stat_sz);
+        (*train_dataset)->feature_means = cml_malloc(stat_sz);
+        (*train_dataset)->feature_stds  = cml_malloc(stat_sz);
+        (*val_dataset)->feature_means   = cml_malloc(stat_sz);
+        (*val_dataset)->feature_stds    = cml_malloc(stat_sz);
         if ((*train_dataset)->feature_means && (*train_dataset)->feature_stds) {
             memcpy((*train_dataset)->feature_means, dataset->feature_means, stat_sz);
             memcpy((*train_dataset)->feature_stds, dataset->feature_stds, stat_sz);
@@ -555,15 +556,15 @@ int dataset_split(Dataset* dataset, float train_ratio, Dataset** train_dataset,
             *val_dataset   = NULL;
             return -1;
         }
-        float* train_X = malloc((size_t)train_size * (size_t)dataset->input_size * sizeof(float));
-        float* train_y = malloc((size_t)train_size * (size_t)dataset->output_size * sizeof(float));
+        float* train_X = cml_malloc((size_t)train_size * (size_t)dataset->input_size * sizeof(float));
+        float* train_y = cml_malloc((size_t)train_size * (size_t)dataset->output_size * sizeof(float));
 
         if (!train_X || !train_y) {
             LOG_ERROR("Failed to allocate training data");
             if (train_X)
-                free(train_X);
+                cml_free(train_X);
             if (train_y)
-                free(train_y);
+                cml_free(train_y);
             dataset_free(*train_dataset);
             dataset_free(*val_dataset);
             *train_dataset = NULL;
@@ -584,8 +585,8 @@ int dataset_split(Dataset* dataset, float train_ratio, Dataset** train_dataset,
                                      .has_device = true};
         (*train_dataset)->X       = tensor_from_data(train_X, train_input_shape, 2, &train_config);
         (*train_dataset)->y       = tensor_from_data(train_y, train_target_shape, 2, &train_config);
-        free(train_X);
-        free(train_y);
+        cml_free(train_X);
+        cml_free(train_y);
 
         if (!(*train_dataset)->X || !(*train_dataset)->y) {
             LOG_ERROR("Failed to create training tensors");
@@ -595,15 +596,15 @@ int dataset_split(Dataset* dataset, float train_ratio, Dataset** train_dataset,
             *val_dataset   = NULL;
             return -1;
         }
-        float* val_X = malloc((size_t)val_size * (size_t)dataset->input_size * sizeof(float));
-        float* val_y = malloc((size_t)val_size * (size_t)dataset->output_size * sizeof(float));
+        float* val_X = cml_malloc((size_t)val_size * (size_t)dataset->input_size * sizeof(float));
+        float* val_y = cml_malloc((size_t)val_size * (size_t)dataset->output_size * sizeof(float));
 
         if (!val_X || !val_y) {
             LOG_ERROR("Failed to allocate validation data");
             if (val_X)
-                free(val_X);
+                cml_free(val_X);
             if (val_y)
-                free(val_y);
+                cml_free(val_y);
             dataset_free(*train_dataset);
             dataset_free(*val_dataset);
             *train_dataset = NULL;
@@ -627,8 +628,8 @@ int dataset_split(Dataset* dataset, float train_ratio, Dataset** train_dataset,
                                    .has_device = true};
         (*val_dataset)->X       = tensor_from_data(val_X, val_input_shape, 2, &val_config);
         (*val_dataset)->y       = tensor_from_data(val_y, val_target_shape, 2, &val_config);
-        free(val_X);
-        free(val_y);
+        cml_free(val_X);
+        cml_free(val_y);
 
         if (!(*val_dataset)->X || !(*val_dataset)->y) {
             LOG_ERROR("Failed to create validation tensors");
@@ -708,8 +709,8 @@ int dataset_split_three(Dataset* dataset, float train_ratio, float val_ratio,
         float* train_X_data = (float*)tensor_data_ptr(dataset->X);
         float* train_y_data = (float*)tensor_data_ptr(dataset->y);
 
-        float* train_X = malloc((size_t)train_size * (size_t)dataset->input_size * sizeof(float));
-        float* train_y = malloc((size_t)train_size * sizeof(float));
+        float* train_X = cml_malloc((size_t)train_size * (size_t)dataset->input_size * sizeof(float));
+        float* train_y = cml_malloc((size_t)train_size * sizeof(float));
 
         if (!train_X || !train_y) {
             LOG_ERROR("Failed to allocate training data");
@@ -735,13 +736,13 @@ int dataset_split_three(Dataset* dataset, float train_ratio, float val_ratio,
                                      .has_device = true};
         (*train_dataset)->X       = tensor_from_data(train_X, train_input_shape, 2, &train_config);
         (*train_dataset)->y       = tensor_from_data(train_y, train_target_shape, 2, &train_config);
-        free(train_X);
-        free(train_y);
+        cml_free(train_X);
+        cml_free(train_y);
         int val_input_shape[]  = {val_size, dataset->input_size};
         int val_target_shape[] = {val_size, dataset->output_size};
 
-        float* val_X = malloc((size_t)val_size * (size_t)dataset->input_size * sizeof(float));
-        float* val_y = malloc((size_t)val_size * sizeof(float));
+        float* val_X = cml_malloc((size_t)val_size * (size_t)dataset->input_size * sizeof(float));
+        float* val_y = cml_malloc((size_t)val_size * sizeof(float));
 
         if (!val_X || !val_y) {
             LOG_ERROR("Failed to allocate validation data");
@@ -769,13 +770,13 @@ int dataset_split_three(Dataset* dataset, float train_ratio, float val_ratio,
                                    .has_device = true};
         (*val_dataset)->X       = tensor_from_data(val_X, val_input_shape, 2, &val_config);
         (*val_dataset)->y       = tensor_from_data(val_y, val_target_shape, 2, &val_config);
-        free(val_X);
-        free(val_y);
+        cml_free(val_X);
+        cml_free(val_y);
         int test_input_shape[]  = {test_size, dataset->input_size};
         int test_target_shape[] = {test_size, dataset->output_size};
 
-        float* test_X = malloc((size_t)test_size * (size_t)dataset->input_size * sizeof(float));
-        float* test_y = malloc((size_t)test_size * sizeof(float));
+        float* test_X = cml_malloc((size_t)test_size * (size_t)dataset->input_size * sizeof(float));
+        float* test_y = cml_malloc((size_t)test_size * sizeof(float));
 
         if (!test_X || !test_y) {
             LOG_ERROR("Failed to allocate test data");
@@ -803,8 +804,8 @@ int dataset_split_three(Dataset* dataset, float train_ratio, float val_ratio,
                                     .has_device = true};
         (*test_dataset)->X       = tensor_from_data(test_X, test_input_shape, 2, &test_config);
         (*test_dataset)->y       = tensor_from_data(test_y, test_target_shape, 2, &test_config);
-        free(test_X);
-        free(test_y);
+        cml_free(test_X);
+        cml_free(test_y);
     }
     (*train_dataset)->num_samples = train_size;
     (*train_dataset)->input_size  = dataset->input_size;
@@ -1049,7 +1050,7 @@ Dataset* dataset_copy(Dataset* dataset) {
     }
 
     if (dataset->indices) {
-        copy->indices = malloc((size_t)dataset->num_samples * sizeof(int));
+        copy->indices = cml_malloc((size_t)dataset->num_samples * sizeof(int));
         if (copy->indices) {
             memcpy(copy->indices, dataset->indices, (size_t)dataset->num_samples * sizeof(int));
         }
@@ -1065,7 +1066,7 @@ DataLoader* dataloader_create(Dataset* dataset, int batch_size, bool shuffle) {
     }
 
 
-    DataLoader* loader = malloc(sizeof(DataLoader));
+    DataLoader* loader = cml_malloc(sizeof(DataLoader));
     if (!loader)
         return NULL;
 
@@ -1084,9 +1085,9 @@ DataLoader* dataloader_create(Dataset* dataset, int batch_size, bool shuffle) {
     loader->on_batch_start = NULL;
     loader->on_batch_end   = NULL;
 
-    loader->shuffled_indices = malloc((size_t)dataset->num_samples * sizeof(int));
+    loader->shuffled_indices = cml_malloc((size_t)dataset->num_samples * sizeof(int));
     if (!loader->shuffled_indices) {
-        free(loader);
+        cml_free(loader);
         return NULL;
     }
 
@@ -1119,22 +1120,22 @@ void dataloader_free(DataLoader* loader) {
             for (int i = 0; i < loader->num_active_workers; i++) {
                 pthread_join(threads[i], NULL);
             }
-            free(threads);
+            cml_free(threads);
         }
 
         if (loader->worker_contexts) {
-            free(loader->worker_contexts);
+            cml_free(loader->worker_contexts);
         }
     }
 
     if (loader->shuffled_indices) {
-        free(loader->shuffled_indices);
+        cml_free(loader->shuffled_indices);
     }
     if (loader->batch_indices) {
-        free(loader->batch_indices);
+        cml_free(loader->batch_indices);
     }
 
-    free(loader);
+    cml_free(loader);
 }
 
 int dataloader_reset(DataLoader* loader) {
@@ -1222,7 +1223,7 @@ void batch_free(Batch* batch) {
     if (batch->y)
         tensor_free(batch->y);
 
-    free(batch);
+    cml_free(batch);
 }
 
 Tensor* batch_get_input(Batch* batch) {
@@ -1297,14 +1298,14 @@ DataLoader* dataloader_create_with_workers(Dataset* dataset, int batch_size, boo
         }
 
         loader->prefetch_queue = queue;
-        pthread_t* threads      = calloc((size_t)num_workers, sizeof(pthread_t));
-        WorkerContext* contexts = calloc((size_t)num_workers, sizeof(WorkerContext));
+        pthread_t* threads      = cml_calloc((size_t)num_workers, sizeof(pthread_t));
+        WorkerContext* contexts = cml_calloc((size_t)num_workers, sizeof(WorkerContext));
 
         if (!threads || !contexts) {
             if (threads)
-                free(threads);
+                cml_free(threads);
             if (contexts)
-                free(contexts);
+                cml_free(contexts);
             prefetch_queue_free(queue);
             loader->num_workers    = 0;
             loader->prefetch_queue = NULL;
@@ -1344,8 +1345,8 @@ int dataloader_get_batch_tensors(DataLoader* loader, Tensor*** batch_inputs,
     if (!batch) {
         return 0;
     }
-    *batch_inputs  = malloc(sizeof(Tensor*));
-    *batch_targets = malloc(sizeof(Tensor*));
+    *batch_inputs  = cml_malloc(sizeof(Tensor*));
+    *batch_targets = cml_malloc(sizeof(Tensor*));
     if (!*batch_inputs || !*batch_targets) {
         batch_free(batch);
         return 0;
@@ -1362,8 +1363,8 @@ int dataloader_get_batch_tensors(DataLoader* loader, Tensor*** batch_inputs,
         if ((*batch_targets)[0]) {
             tensor_free((*batch_targets)[0]);
         }
-        free(*batch_inputs);
-        free(*batch_targets);
+        cml_free(*batch_inputs);
+        cml_free(*batch_targets);
         *batch_inputs = NULL;
         *batch_targets = NULL;
         batch_free(batch);
@@ -1394,8 +1395,8 @@ int dataloader_for_each(DataLoader* loader, BatchCallback callback, void* user_d
             if (batch_targets && batch_targets[0]) {
                 tensor_free(batch_targets[0]);
             }
-            free(batch_inputs);
-            free(batch_targets);
+            cml_free(batch_inputs);
+            cml_free(batch_targets);
             return -1;
         }
         if (batch_inputs && batch_inputs[0]) {
@@ -1404,8 +1405,8 @@ int dataloader_for_each(DataLoader* loader, BatchCallback callback, void* user_d
         if (batch_targets && batch_targets[0]) {
             tensor_free(batch_targets[0]);
         }
-        free(batch_inputs);
-        free(batch_targets);
+        cml_free(batch_inputs);
+        cml_free(batch_targets);
     }
 
     return 0;
@@ -1414,11 +1415,11 @@ int dataloader_for_each(DataLoader* loader, BatchCallback callback, void* user_d
 Dataset* dataset_xor(void) {
     float X[4][2] = {{0.0f, 0.0f}, {0.0f, 1.0f}, {1.0f, 0.0f}, {1.0f, 1.0f}};
     float y[4]    = {0.0f, 1.0f, 1.0f, 0.0f};
-    float* X_flat = malloc(4 * 2 * sizeof(float));
-    float* y_flat = malloc(4 * sizeof(float));
+    float* X_flat = cml_malloc(4 * 2 * sizeof(float));
+    float* y_flat = cml_malloc(4 * sizeof(float));
     if (!X_flat || !y_flat) {
-        free(X_flat);
-        free(y_flat);
+        cml_free(X_flat);
+        cml_free(y_flat);
         return NULL;
     }
 
@@ -1434,8 +1435,8 @@ Dataset* dataset_xor(void) {
         dataset->name = "XOR";
     }
 
-    free(X_flat);
-    free(y_flat);
+    cml_free(X_flat);
+    cml_free(y_flat);
     return dataset;
 }
 
@@ -1445,11 +1446,11 @@ Dataset* dataset_random_classification(int num_samples, int num_features, int nu
     }
     cml_random_seed();
 
-    float* X = malloc((size_t)num_samples * (size_t)num_features * sizeof(float));
-    float* y = malloc((size_t)num_samples * sizeof(float));
+    float* X = cml_malloc((size_t)num_samples * (size_t)num_features * sizeof(float));
+    float* y = cml_malloc((size_t)num_samples * sizeof(float));
     if (!X || !y) {
-        free(X);
-        free(y);
+        cml_free(X);
+        cml_free(y);
         return NULL;
     }
     for (int i = 0; i < num_samples * num_features; i++) {
@@ -1465,8 +1466,8 @@ Dataset* dataset_random_classification(int num_samples, int num_features, int nu
         dataset->num_classes = num_classes;
     }
 
-    free(X);
-    free(y);
+    cml_free(X);
+    cml_free(y);
     return dataset;
 }
 
@@ -1495,10 +1496,10 @@ int transform_normalize(Dataset* dataset, float* mean, float* std) {
         }
     }
     if (!dataset->feature_means) {
-        dataset->feature_means = malloc((size_t)dataset->input_size * sizeof(float));
+        dataset->feature_means = cml_malloc((size_t)dataset->input_size * sizeof(float));
     }
     if (!dataset->feature_stds) {
-        dataset->feature_stds = malloc((size_t)dataset->input_size * sizeof(float));
+        dataset->feature_stds = cml_malloc((size_t)dataset->input_size * sizeof(float));
     }
 
     if (dataset->feature_means && dataset->feature_stds) {

--- a/src/core/error_stack.c
+++ b/src/core/error_stack.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 #define MAX_ERROR_STACK_SIZE 256
 #define MAX_ERROR_MESSAGE_LEN 512
@@ -23,7 +24,7 @@ void error_stack_init(void) {
     }
 
     g_error_stack_capacity = MAX_ERROR_STACK_SIZE;
-    g_error_stack          = (ErrorEntry*)malloc(sizeof(ErrorEntry) * g_error_stack_capacity);
+    g_error_stack          = (ErrorEntry*)cml_malloc(sizeof(ErrorEntry) * g_error_stack_capacity);
     if (!g_error_stack) {
         fprintf(stderr, "FATAL: Failed to initialize error stack\n");
         return;
@@ -41,7 +42,7 @@ void error_stack_cleanup(void) {
     }
 
     if (g_error_stack) {
-        free(g_error_stack);
+        cml_free(g_error_stack);
         g_error_stack = NULL;
     }
 

--- a/src/core/gguf.c
+++ b/src/core/gguf.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 #define GGUF_VERSION 3
 #define MAX_TENSORS 4096
@@ -59,9 +60,9 @@ static char* read_gguf_string(FILE* f) {
     uint64_t len;
     if (fread(&len, 8, 1, f) != 1) return NULL;
     if (len > 65536) return NULL;
-    char* str = malloc(len + 1);
+    char* str = cml_malloc(len + 1);
     if (!str) return NULL;
-    if (fread(str, 1, len, f) != len) { free(str); return NULL; }
+    if (fread(str, 1, len, f) != len) { cml_free(str); return NULL; }
     str[len] = '\0';
     return str;
 }
@@ -87,7 +88,7 @@ static void skip_gguf_value(FILE* f, uint32_t type) {
         case GGUF_TYPE_FLOAT64: fseek(f, 8, SEEK_CUR); break;
         case GGUF_TYPE_STRING: {
             char* s = read_gguf_string(f);
-            free(s);
+            cml_free(s);
             break;
         }
         case GGUF_TYPE_ARRAY: {
@@ -123,23 +124,23 @@ GGUFContext* gguf_open_read(const char* filepath) {
     if (fread(&num_tensors, 8, 1, f) != 1) { fclose(f); return NULL; }
     if (fread(&num_metadata, 8, 1, f) != 1) { fclose(f); return NULL; }
 
-    GGUFContext* ctx = calloc(1, sizeof(GGUFContext));
+    GGUFContext* ctx = cml_calloc(1, sizeof(GGUFContext));
     if (!ctx) { fclose(f); return NULL; }
     ctx->file = f;
-    ctx->filepath = strdup(filepath);
+    ctx->filepath = cml_strdup(filepath);
     ctx->is_write = false;
     ctx->num_tensors = (int)num_tensors;
     ctx->num_metadata = (int)num_metadata;
 
     for (uint64_t i = 0; i < num_metadata; i++) {
         char* key = read_gguf_string(f);
-        free(key);
+        cml_free(key);
         uint32_t val_type;
         if (fread(&val_type, 4, 1, f) != 1) break;
         skip_gguf_value(f, val_type);
     }
 
-    ctx->tensors = calloc(num_tensors, sizeof(GGUFTensorInfo));
+    ctx->tensors = cml_calloc(num_tensors, sizeof(GGUFTensorInfo));
     if (!ctx->tensors) { gguf_close(ctx); return NULL; }
 
     for (uint64_t i = 0; i < num_tensors; i++) {
@@ -179,13 +180,13 @@ GGUFContext* gguf_open_read(const char* filepath) {
 }
 
 GGUFContext* gguf_open_write(const char* filepath) {
-    GGUFContext* ctx = calloc(1, sizeof(GGUFContext));
+    GGUFContext* ctx = cml_calloc(1, sizeof(GGUFContext));
     if (!ctx) return NULL;
-    ctx->filepath = strdup(filepath);
+    ctx->filepath = cml_strdup(filepath);
     ctx->is_write = true;
-    ctx->tensors = calloc(MAX_TENSORS, sizeof(GGUFTensorInfo));
+    ctx->tensors = cml_calloc(MAX_TENSORS, sizeof(GGUFTensorInfo));
     ctx->write_data_cap = 4096;
-    ctx->write_data = malloc(ctx->write_data_cap);
+    ctx->write_data = cml_malloc(ctx->write_data_cap);
     if (!ctx->tensors || !ctx->write_data) { gguf_close(ctx); return NULL; }
     return ctx;
 }
@@ -231,13 +232,13 @@ void gguf_close(GGUFContext* ctx) {
     if (ctx->file) fclose(ctx->file);
     if (ctx->tensors) {
         for (int i = 0; i < ctx->num_tensors || i < ctx->write_count; i++) {
-            free(ctx->tensors[i].name);
+            cml_free(ctx->tensors[i].name);
         }
-        free(ctx->tensors);
+        cml_free(ctx->tensors);
     }
-    free(ctx->filepath);
-    free(ctx->write_data);
-    free(ctx);
+    cml_free(ctx->filepath);
+    cml_free(ctx->write_data);
+    cml_free(ctx);
 }
 
 int gguf_get_num_tensors(GGUFContext* ctx) {
@@ -270,27 +271,27 @@ Tensor* gguf_read_tensor(GGUFContext* ctx, const char* name) {
 
     if (gguf_type_is_quantized(info->type)) {
         /* Quantized: read raw block data, dequantize to float32 */
-        void* raw = malloc(info->data_size);
+        void* raw = cml_malloc(info->data_size);
         if (!raw) return NULL;
 
         fseek(ctx->file, (long)(ctx->data_offset + info->offset), SEEK_SET);
         if (fread(raw, 1, info->data_size, ctx->file) != info->data_size) {
-            free(raw);
+            cml_free(raw);
             return NULL;
         }
 
         TensorConfig config = {.dtype = DTYPE_FLOAT32, .device = DEVICE_CPU,
                                .has_dtype = true, .has_device = true};
         Tensor* t = tensor_empty(shape, info->ndim, &config);
-        if (!t) { free(raw); return NULL; }
+        if (!t) { cml_free(raw); return NULL; }
         tensor_ensure_executed(t);
 
         if (gguf_dequantize(info->type, raw, (float*)t->data, numel) != 0) {
-            free(raw);
+            cml_free(raw);
             tensor_free(t);
             return NULL;
         }
-        free(raw);
+        cml_free(raw);
         return t;
     }
 
@@ -320,12 +321,12 @@ int gguf_write_tensor(GGUFContext* ctx, const char* name, Tensor* tensor) {
 
     while (ctx->write_data_size + data_size > ctx->write_data_cap) {
         ctx->write_data_cap *= 2;
-        ctx->write_data = realloc(ctx->write_data, ctx->write_data_cap);
+        ctx->write_data = cml_realloc(ctx->write_data, ctx->write_data_cap);
         if (!ctx->write_data) return -1;
     }
 
     GGUFTensorInfo* info = &ctx->tensors[ctx->write_count];
-    info->name = strdup(name);
+    info->name = cml_strdup(name);
     info->ndim = tensor->ndim;
     for (int d = 0; d < tensor->ndim; d++) info->shape[d] = tensor->shape[d];
     info->type = dtype_to_gguf_type(tensor->dtype);

--- a/src/core/hevc.c
+++ b/src/core/hevc.c
@@ -2,6 +2,7 @@
 #include "core/logging.h"
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 #define HEVC_RING_INITIAL_CAP (256 * 1024)
 #define HEVC_START_CODE_3     3
@@ -55,7 +56,7 @@ static uint32_t bs_read_ue(BitstreamReader* bs) {
 }
 
 static uint8_t* rbsp_from_nal(const uint8_t* nal, size_t nal_size, size_t* rbsp_size) {
-    uint8_t* rbsp = (uint8_t*)malloc(nal_size);
+    uint8_t* rbsp = (uint8_t*)cml_malloc(nal_size);
     if (!rbsp) return NULL;
 
     size_t j = 0;
@@ -92,12 +93,12 @@ static int find_start_code(const uint8_t* buf, size_t len, size_t start, size_t*
 }
 
 CMLHEVCParser* cml_hevc_parser_create(void) {
-    CMLHEVCParser* p = (CMLHEVCParser*)calloc(1, sizeof(CMLHEVCParser));
+    CMLHEVCParser* p = (CMLHEVCParser*)cml_calloc(1, sizeof(CMLHEVCParser));
     if (!p) return NULL;
 
-    p->ring = (uint8_t*)malloc(HEVC_RING_INITIAL_CAP);
+    p->ring = (uint8_t*)cml_malloc(HEVC_RING_INITIAL_CAP);
     if (!p->ring) {
-        free(p);
+        cml_free(p);
         return NULL;
     }
     p->ring_cap = HEVC_RING_INITIAL_CAP;
@@ -109,8 +110,8 @@ CMLHEVCParser* cml_hevc_parser_create(void) {
 
 void cml_hevc_parser_free(CMLHEVCParser* parser) {
     if (!parser) return;
-    free(parser->ring);
-    free(parser);
+    cml_free(parser->ring);
+    cml_free(parser);
 }
 
 int cml_hevc_parser_feed(CMLHEVCParser* parser, const uint8_t* data, size_t size) {
@@ -120,7 +121,7 @@ int cml_hevc_parser_feed(CMLHEVCParser* parser, const uint8_t* data, size_t size
     if (needed > parser->ring_cap) {
         size_t new_cap = parser->ring_cap;
         while (new_cap < needed) new_cap *= 2;
-        uint8_t* new_ring = (uint8_t*)realloc(parser->ring, new_cap);
+        uint8_t* new_ring = (uint8_t*)cml_realloc(parser->ring, new_cap);
         if (!new_ring) {
             LOG_ERROR("HEVC: ring buffer realloc failed (%zu bytes)", new_cap);
             return -1;
@@ -155,12 +156,12 @@ CMLHEVCNalUnit* cml_hevc_next_nal(CMLHEVCParser* parser) {
         return NULL;
     }
 
-    CMLHEVCNalUnit* nal = (CMLHEVCNalUnit*)calloc(1, sizeof(CMLHEVCNalUnit));
+    CMLHEVCNalUnit* nal = (CMLHEVCNalUnit*)cml_calloc(1, sizeof(CMLHEVCNalUnit));
     if (!nal) return NULL;
 
-    uint8_t* nal_data = (uint8_t*)malloc(nal_size);
+    uint8_t* nal_data = (uint8_t*)cml_malloc(nal_size);
     if (!nal_data) {
-        free(nal);
+        cml_free(nal);
         return NULL;
     }
     memcpy(nal_data, parser->ring + nal_start, nal_size);
@@ -193,8 +194,8 @@ CMLHEVCNalUnit* cml_hevc_next_nal(CMLHEVCParser* parser) {
 
 void cml_hevc_nal_free(CMLHEVCNalUnit* nal) {
     if (!nal) return;
-    free((void*)nal->data);
-    free(nal);
+    cml_free((void*)nal->data);
+    cml_free(nal);
 }
 
 int cml_hevc_parse_sps(const uint8_t* sps_data, size_t sps_size, int* width, int* height) {
@@ -271,7 +272,7 @@ int cml_hevc_parse_sps(const uint8_t* sps_data, size_t sps_size, int* width, int
     *width = (int)pic_width;
     *height = (int)pic_height;
 
-    free(rbsp);
+    cml_free(rbsp);
     return 0;
 }
 
@@ -295,16 +296,16 @@ CMLHEVCFrame* cml_hevc_decode_iframe(CMLHEVCParser* parser, CMLHEVCNalUnit* nal)
     int w = 64, h = 64;
     int stride = w;
 
-    CMLHEVCFrame* frame = (CMLHEVCFrame*)calloc(1, sizeof(CMLHEVCFrame));
+    CMLHEVCFrame* frame = (CMLHEVCFrame*)cml_calloc(1, sizeof(CMLHEVCFrame));
     if (!frame) {
-        free(rbsp);
+        cml_free(rbsp);
         return NULL;
     }
 
-    frame->data = (uint8_t*)calloc((size_t)(stride * h), 1);
+    frame->data = (uint8_t*)cml_calloc((size_t)(stride * h), 1);
     if (!frame->data) {
-        free(rbsp);
-        free(frame);
+        cml_free(rbsp);
+        cml_free(frame);
         return NULL;
     }
 
@@ -317,12 +318,12 @@ CMLHEVCFrame* cml_hevc_decode_iframe(CMLHEVCParser* parser, CMLHEVCNalUnit* nal)
     frame->pts = parser->frame_count++;
     frame->nal_type = nal->type;
 
-    free(rbsp);
+    cml_free(rbsp);
     return frame;
 }
 
 void cml_hevc_frame_free(CMLHEVCFrame* frame) {
     if (!frame) return;
-    free(frame->data);
-    free(frame);
+    cml_free(frame->data);
+    cml_free(frame);
 }

--- a/src/core/model_architecture.c
+++ b/src/core/model_architecture.c
@@ -9,9 +9,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 ModelArchitecture* model_architecture_create(void) {
-    ModelArchitecture* arch = malloc(sizeof(ModelArchitecture));
+    ModelArchitecture* arch = cml_malloc(sizeof(ModelArchitecture));
     if (!arch)
         return NULL;
 
@@ -82,7 +83,7 @@ static int extract_from_sequential(Sequential* seq, ModelArchitecture* arch) {
         while (new_capacity < (size_t)arch->num_layers + (size_t)num_modules) {
             new_capacity *= 2;
         }
-        LayerInfo* new_layers = realloc(arch->layers, (size_t)new_capacity * sizeof(LayerInfo));
+        LayerInfo* new_layers = cml_realloc(arch->layers, (size_t)new_capacity * sizeof(LayerInfo));
         if (!new_layers) {
             LOG_ERROR("Failed to allocate memory for layers");
             return -1;
@@ -117,7 +118,7 @@ int model_architecture_extract(Module* module, ModelArchitecture* arch) {
     } else {
         if (arch->num_layers >= arch->capacity) {
             size_t new_capacity   = arch->capacity == 0 ? 8 : arch->capacity * 2;
-            LayerInfo* new_layers = realloc(arch->layers, (size_t)new_capacity * sizeof(LayerInfo));
+            LayerInfo* new_layers = cml_realloc(arch->layers, (size_t)new_capacity * sizeof(LayerInfo));
             if (!new_layers)
                 return -1;
             arch->layers   = new_layers;
@@ -144,7 +145,7 @@ int model_architecture_extract(Module* module, ModelArchitecture* arch) {
             }
         }
         if (params)
-            free(params);
+            cml_free(params);
     }
 
     return 0;
@@ -213,11 +214,11 @@ void model_architecture_free(ModelArchitecture* arch) {
     if (arch->layers) {
         for (size_t i = 0; i < arch->num_layers; i++) {
             if (arch->layers[i].details) {
-                free(arch->layers[i].details);
+                cml_free(arch->layers[i].details);
             }
         }
-        free(arch->layers);
+        cml_free(arch->layers);
     }
 
-    free(arch);
+    cml_free(arch);
 }

--- a/src/core/onnx.c
+++ b/src/core/onnx.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 static void copy_pb_string(char *dst, size_t dst_size, const PBField *field)
 {
@@ -24,7 +25,7 @@ static char *dup_pb_string(const PBField *field)
     const char *src = pb_field_string(field, &len);
     if (!src || len == 0) return NULL;
 
-    char *s = (char *)malloc(len + 1);
+    char *s = (char *)cml_malloc(len + 1);
     if (!s) return NULL;
     memcpy(s, src, len);
     s[len] = '\0';
@@ -98,7 +99,7 @@ static void parse_attribute(PBReader *rd, CMLONNXAttribute *attr)
         case 6: /* floats (packed repeated float) */
             if (f.wire_type == PB_WIRE_LEN) {
                 int count = (int)(f.value.bytes.length / sizeof(float));
-                attr->value.floats.data = (float *)malloc(sizeof(float) * (size_t)count);
+                attr->value.floats.data = (float *)cml_malloc(sizeof(float) * (size_t)count);
                 if (attr->value.floats.data) {
                     PBReader sub = pb_reader_sub(&f);
                     for (int i = 0; i < count; i++) {
@@ -121,7 +122,7 @@ static void parse_attribute(PBReader *rd, CMLONNXAttribute *attr)
                     pb_read_varint(&counter);
                     count++;
                 }
-                attr->value.ints.data = (int64_t *)malloc(sizeof(int64_t) * (size_t)count);
+                attr->value.ints.data = (int64_t *)cml_malloc(sizeof(int64_t) * (size_t)count);
                 if (attr->value.ints.data) {
                     for (int i = 0; i < count; i++) {
                         attr->value.ints.data[i] = (int64_t)pb_read_varint(&sub);
@@ -132,7 +133,7 @@ static void parse_attribute(PBReader *rd, CMLONNXAttribute *attr)
             } else if (f.wire_type == PB_WIRE_VARINT) {
                 /* Non-packed single int in repeated field -- append */
                 int cur = attr->value.ints.count;
-                int64_t *tmp = (int64_t *)realloc(attr->value.ints.data,
+                int64_t *tmp = (int64_t *)cml_realloc(attr->value.ints.data,
                                                    sizeof(int64_t) * (size_t)(cur + 1));
                 if (tmp) {
                     tmp[cur] = (int64_t)f.value.varint;
@@ -254,7 +255,7 @@ static void parse_tensor_proto(PBReader *rd, CMLONNXInitializer *init)
         case 5: /* float_data (packed repeated float) */
             if (f.wire_type == PB_WIRE_LEN) {
                 float_count = (int)(f.value.bytes.length / sizeof(float));
-                float_data = (float *)malloc(sizeof(float) * (size_t)float_count);
+                float_data = (float *)cml_malloc(sizeof(float) * (size_t)float_count);
                 if (float_data) {
                     PBReader sub = pb_reader_sub(&f);
                     for (int i = 0; i < float_count; i++) {
@@ -292,7 +293,7 @@ static void parse_tensor_proto(PBReader *rd, CMLONNXInitializer *init)
         init->tensor = tensor_zeros(dims, ndim, &cfg);
     }
 
-    free(float_data);
+    cml_free(float_data);
 }
 
 /*
@@ -408,10 +409,10 @@ static int parse_graph(PBReader *rd, CMLONNXGraph *graph)
 {
     memset(graph, 0, sizeof(*graph));
 
-    graph->nodes        = (CMLONNXNode *)calloc(CML_ONNX_MAX_NODES, sizeof(CMLONNXNode));
-    graph->inputs       = (CMLONNXTensorInfo *)calloc(CML_ONNX_MAX_INPUTS, sizeof(CMLONNXTensorInfo));
-    graph->outputs      = (CMLONNXTensorInfo *)calloc(CML_ONNX_MAX_OUTPUTS, sizeof(CMLONNXTensorInfo));
-    graph->initializers = (CMLONNXInitializer *)calloc(CML_ONNX_MAX_NODES, sizeof(CMLONNXInitializer));
+    graph->nodes        = (CMLONNXNode *)cml_calloc(CML_ONNX_MAX_NODES, sizeof(CMLONNXNode));
+    graph->inputs       = (CMLONNXTensorInfo *)cml_calloc(CML_ONNX_MAX_INPUTS, sizeof(CMLONNXTensorInfo));
+    graph->outputs      = (CMLONNXTensorInfo *)cml_calloc(CML_ONNX_MAX_OUTPUTS, sizeof(CMLONNXTensorInfo));
+    graph->initializers = (CMLONNXInitializer *)cml_calloc(CML_ONNX_MAX_NODES, sizeof(CMLONNXInitializer));
 
     if (!graph->nodes || !graph->inputs || !graph->outputs || !graph->initializers) {
         return -1;
@@ -501,7 +502,7 @@ CMLONNXModel *cml_onnx_load_buffer(const uint8_t *data, size_t length)
         return NULL;
     }
 
-    CMLONNXModel *model = (CMLONNXModel *)calloc(1, sizeof(CMLONNXModel));
+    CMLONNXModel *model = (CMLONNXModel *)cml_calloc(1, sizeof(CMLONNXModel));
     if (!model) return NULL;
 
     PBReader reader;
@@ -578,7 +579,7 @@ CMLONNXModel *cml_onnx_load(const char *filepath)
         return NULL;
     }
 
-    uint8_t *buf = (uint8_t *)malloc((size_t)fsize);
+    uint8_t *buf = (uint8_t *)cml_malloc((size_t)fsize);
     if (!buf) {
         fclose(fp);
         return NULL;
@@ -589,12 +590,12 @@ CMLONNXModel *cml_onnx_load(const char *filepath)
 
     if ((long)n != fsize) {
         LOG_ERROR("onnx: short read on '%s'", filepath);
-        free(buf);
+        cml_free(buf);
         return NULL;
     }
 
     CMLONNXModel *model = cml_onnx_load_buffer(buf, (size_t)fsize);
-    free(buf);
+    cml_free(buf);
     return model;
 }
 
@@ -608,23 +609,23 @@ void cml_onnx_free(CMLONNXModel *model)
         for (int i = 0; i < g->num_nodes; i++) {
             CMLONNXNode *nd = &g->nodes[i];
             for (int j = 0; j < nd->num_inputs; j++) {
-                free(nd->inputs[j]);
+                cml_free(nd->inputs[j]);
             }
             for (int j = 0; j < nd->num_outputs; j++) {
-                free(nd->outputs[j]);
+                cml_free(nd->outputs[j]);
             }
             for (int j = 0; j < nd->num_attrs; j++) {
                 CMLONNXAttribute *a = &nd->attrs[j];
                 if (a->type == CML_ONNX_ATTR_INTS) {
-                    free(a->value.ints.data);
+                    cml_free(a->value.ints.data);
                 } else if (a->type == CML_ONNX_ATTR_FLOATS) {
-                    free(a->value.floats.data);
+                    cml_free(a->value.floats.data);
                 } else if (a->type == CML_ONNX_ATTR_TENSOR && a->value.tensor) {
                     tensor_free(a->value.tensor);
                 }
             }
         }
-        free(g->nodes);
+        cml_free(g->nodes);
     }
 
     if (g->initializers) {
@@ -633,11 +634,11 @@ void cml_onnx_free(CMLONNXModel *model)
                 tensor_free(g->initializers[i].tensor);
             }
         }
-        free(g->initializers);
+        cml_free(g->initializers);
     }
 
-    free(g->inputs);
-    free(g->outputs);
+    cml_free(g->inputs);
+    cml_free(g->outputs);
 
-    free(model);
+    cml_free(model);
 }

--- a/src/core/onnx_ops.c
+++ b/src/core/onnx_ops.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 #define TENSOR_MAP_SIZE 2048
 
@@ -743,12 +744,12 @@ static Tensor *op_constant(const CMLONNXNode *n, TensorMap *m)
     const CMLONNXAttribute *vis = find_attr(n, "value_ints");
     if (vis && vis->type == CML_ONNX_ATTR_INTS && vis->value.ints.count > 0) {
         int count = vis->value.ints.count;
-        float *fdata = (float *)malloc(sizeof(float) * (size_t)count);
+        float *fdata = (float *)cml_malloc(sizeof(float) * (size_t)count);
         if (!fdata) return NULL;
         for (int i = 0; i < count; i++) fdata[i] = (float)vis->value.ints.data[i];
         int shape[1] = { count };
         Tensor *t = tensor_from_data(fdata, shape, 1, NULL);
-        free(fdata);
+        cml_free(fdata);
         return t;
     }
 
@@ -825,7 +826,7 @@ int cml_onnx_run(CMLONNXModel *model, Tensor **inputs, int num_inputs,
 
     CMLONNXGraph *g = &model->graph;
 
-    TensorMap *map = (TensorMap *)calloc(1, sizeof(TensorMap));
+    TensorMap *map = (TensorMap *)cml_calloc(1, sizeof(TensorMap));
     if (!map) return -1;
 
     for (int i = 0; i < g->num_initializers; i++) {
@@ -851,7 +852,7 @@ int cml_onnx_run(CMLONNXModel *model, Tensor **inputs, int num_inputs,
         if (!handler) {
             LOG_ERROR("onnx_ops: unsupported op '%s' (node '%s')",
                       node->op_type, node->name);
-            free(map);
+            cml_free(map);
             return -2;
         }
 
@@ -859,7 +860,7 @@ int cml_onnx_run(CMLONNXModel *model, Tensor **inputs, int num_inputs,
         if (!result) {
             LOG_ERROR("onnx_ops: op '%s' (node '%s') returned NULL",
                       node->op_type, node->name);
-            free(map);
+            cml_free(map);
             return -3;
         }
 
@@ -877,7 +878,7 @@ int cml_onnx_run(CMLONNXModel *model, Tensor **inputs, int num_inputs,
         if (t) copied++;
     }
 
-    free(map);
+    cml_free(map);
 
     if (copied == 0 && num_outputs > 0) {
         LOG_ERROR("onnx_ops: no graph outputs were produced");

--- a/src/core/pth_loader.c
+++ b/src/core/pth_loader.c
@@ -12,6 +12,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdint.h>
+#include "alloc/cml_allocator.h"
 
 #define ZIP_LOCAL_HEADER_SIG 0x04034b50
 #define ZIP_CENTRAL_DIR_SIG  0x02014b50
@@ -50,12 +51,12 @@ typedef struct {
 } PickleScanResult;
 
 static PickleScanResult* scan_pickle_keys(const uint8_t* data, size_t size) {
-    PickleScanResult* result = (PickleScanResult*)calloc(1, sizeof(PickleScanResult));
+    PickleScanResult* result = (PickleScanResult*)cml_calloc(1, sizeof(PickleScanResult));
     if (!result) return NULL;
 
     result->key_capacity = 64;
-    result->keys = (char**)calloc((size_t)result->key_capacity, sizeof(char*));
-    if (!result->keys) { free(result); return NULL; }
+    result->keys = (char**)cml_calloc((size_t)result->key_capacity, sizeof(char*));
+    if (!result->keys) { cml_free(result); return NULL; }
 
     size_t pos = 0;
     while (pos < size) {
@@ -66,7 +67,7 @@ static PickleScanResult* scan_pickle_keys(const uint8_t* data, size_t size) {
             uint8_t len = data[pos++];
             if (pos + len <= size && len > 0) {
                 /* Check if this looks like a parameter key (contains '.weight' or '.bias') */
-                char* str = (char*)malloc(len + 1);
+                char* str = (char*)cml_malloc(len + 1);
                 if (str) {
                     memcpy(str, &data[pos], len);
                     str[len] = '\0';
@@ -78,16 +79,16 @@ static PickleScanResult* scan_pickle_keys(const uint8_t* data, size_t size) {
                         strstr(str, "embedding")) {
                         if (result->num_keys >= result->key_capacity) {
                             result->key_capacity *= 2;
-                            char** new_keys = (char**)realloc(result->keys,
+                            char** new_keys = (char**)cml_realloc(result->keys,
                                 (size_t)result->key_capacity * sizeof(char*));
                             if (new_keys) result->keys = new_keys;
                         }
                         if (result->num_keys < result->key_capacity)
                             result->keys[result->num_keys++] = str;
                         else
-                            free(str);
+                            cml_free(str);
                     } else {
-                        free(str);
+                        cml_free(str);
                     }
                 }
                 pos += len;
@@ -98,7 +99,7 @@ static PickleScanResult* scan_pickle_keys(const uint8_t* data, size_t size) {
             uint32_t len = read_u32_le(&data[pos]);
             pos += 4;
             if (pos + len <= size && len > 0 && len < 1024) {
-                char* str = (char*)malloc(len + 1);
+                char* str = (char*)cml_malloc(len + 1);
                 if (str) {
                     memcpy(str, &data[pos], len);
                     str[len] = '\0';
@@ -106,9 +107,9 @@ static PickleScanResult* scan_pickle_keys(const uint8_t* data, size_t size) {
                         if (result->num_keys < result->key_capacity)
                             result->keys[result->num_keys++] = str;
                         else
-                            free(str);
+                            cml_free(str);
                     } else {
-                        free(str);
+                        cml_free(str);
                     }
                 }
                 pos += len;
@@ -122,11 +123,11 @@ static PickleScanResult* scan_pickle_keys(const uint8_t* data, size_t size) {
 static void free_pickle_result(PickleScanResult* result) {
     if (!result) return;
     for (int i = 0; i < result->num_keys; i++)
-        free(result->keys[i]);
-    free(result->keys);
-    free(result->storage_dtypes);
-    free(result->storage_sizes);
-    free(result);
+        cml_free(result->keys[i]);
+    cml_free(result->keys);
+    cml_free(result->storage_dtypes);
+    cml_free(result->storage_sizes);
+    cml_free(result);
 }
 
 CMLPthStateDict* cml_pth_load(const char* path) {
@@ -144,19 +145,19 @@ CMLPthStateDict* cml_pth_load(const char* path) {
         return NULL;
     }
 
-    uint8_t* file_data = (uint8_t*)malloc((size_t)file_size);
+    uint8_t* file_data = (uint8_t*)cml_malloc((size_t)file_size);
     if (!file_data) { fclose(f); return NULL; }
 
     size_t read_size = fread(file_data, 1, (size_t)file_size, f);
     fclose(f);
-    if (read_size != (size_t)file_size) { free(file_data); return NULL; }
+    if (read_size != (size_t)file_size) { cml_free(file_data); return NULL; }
 
-    CMLPthStateDict* sd = (CMLPthStateDict*)calloc(1, sizeof(CMLPthStateDict));
-    if (!sd) { free(file_data); return NULL; }
+    CMLPthStateDict* sd = (CMLPthStateDict*)cml_calloc(1, sizeof(CMLPthStateDict));
+    if (!sd) { cml_free(file_data); return NULL; }
 
     sd->entry_capacity = 64;
-    sd->entries = (CMLPthEntry*)calloc((size_t)sd->entry_capacity, sizeof(CMLPthEntry));
-    if (!sd->entries) { free(sd); free(file_data); return NULL; }
+    sd->entries = (CMLPthEntry*)cml_calloc((size_t)sd->entry_capacity, sizeof(CMLPthEntry));
+    if (!sd->entries) { cml_free(sd); cml_free(file_data); return NULL; }
 
     PickleScanResult* pickle_keys = NULL;
     int data_file_count = 0;
@@ -212,7 +213,7 @@ CMLPthStateDict* cml_pth_load(const char* path) {
 
             if (sd->num_entries >= sd->entry_capacity) {
                 sd->entry_capacity *= 2;
-                CMLPthEntry* new_entries = (CMLPthEntry*)realloc(
+                CMLPthEntry* new_entries = (CMLPthEntry*)cml_realloc(
                     sd->entries, (size_t)sd->entry_capacity * sizeof(CMLPthEntry));
                 if (!new_entries) break;
                 sd->entries = new_entries;
@@ -239,7 +240,7 @@ CMLPthStateDict* cml_pth_load(const char* path) {
         free_pickle_result(pickle_keys);
     }
 
-    free(file_data);
+    cml_free(file_data);
     return sd;
 }
 
@@ -249,9 +250,9 @@ void cml_pth_free(CMLPthStateDict* sd) {
         if (sd->entries[i].tensor)
             tensor_free(sd->entries[i].tensor);
     }
-    free(sd->entries);
-    free(sd->model_name);
-    free(sd);
+    cml_free(sd->entries);
+    cml_free(sd->model_name);
+    cml_free(sd);
 }
 
 Tensor* cml_pth_get_tensor(const CMLPthStateDict* sd, const char* key) {
@@ -279,7 +280,7 @@ bool cml_pth_has_key(const CMLPthStateDict* sd, const char* key) {
 const char** cml_pth_list_keys(const CMLPthStateDict* sd, int* count) {
     if (!sd || !count) return NULL;
     *count = sd->num_entries;
-    const char** keys = (const char**)malloc((size_t)sd->num_entries * sizeof(char*));
+    const char** keys = (const char**)cml_malloc((size_t)sd->num_entries * sizeof(char*));
     if (!keys) return NULL;
     for (int i = 0; i < sd->num_entries; i++)
         keys[i] = sd->entries[i].key;

--- a/src/core/quantization.c
+++ b/src/core/quantization.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <math.h>
 #include <float.h>
+#include "alloc/cml_allocator.h"
 
 QuantParams cml_quantize_compute_params(Tensor* tensor, bool symmetric) {
     QuantParams params = {.scale = 1.0f, .zero_point = 0};
@@ -64,7 +65,7 @@ Tensor* cml_quantize_int8(Tensor* tensor, const QuantParams* params, QuantParams
     TensorConfig config = {.dtype = DTYPE_INT8, .device = tensor->device,
                            .has_dtype = true, .has_device = true};
     Tensor* quantized = tensor_empty(shape, tensor->ndim, &config);
-    free(shape);
+    cml_free(shape);
     if (!quantized) return NULL;
 
     int8_t* qdata = (int8_t*)quantized->data;
@@ -97,7 +98,7 @@ Tensor* cml_dequantize_int8(Tensor* tensor, const QuantParams* params) {
     TensorConfig config = {.dtype = DTYPE_FLOAT32, .device = tensor->device,
                            .has_dtype = true, .has_device = true};
     Tensor* dequantized = tensor_empty(shape, tensor->ndim, &config);
-    free(shape);
+    cml_free(shape);
     if (!dequantized) return NULL;
 
     int8_t* qdata = (int8_t*)tensor->data;
@@ -146,7 +147,7 @@ Tensor* cml_quantize_uint8(Tensor* tensor, const QuantParams* params, QuantParam
     TensorConfig config = {.dtype = DTYPE_UINT8, .device = tensor->device,
                            .has_dtype = true, .has_device = true};
     Tensor* quantized = tensor_empty(shape, tensor->ndim, &config);
-    free(shape);
+    cml_free(shape);
     if (!quantized) return NULL;
 
     uint8_t* qdata = (uint8_t*)quantized->data;
@@ -179,7 +180,7 @@ Tensor* cml_dequantize_uint8(Tensor* tensor, const QuantParams* params) {
     TensorConfig config = {.dtype = DTYPE_FLOAT32, .device = tensor->device,
                            .has_dtype = true, .has_device = true};
     Tensor* dequantized = tensor_empty(shape, tensor->ndim, &config);
-    free(shape);
+    cml_free(shape);
     if (!dequantized) return NULL;
 
     uint8_t* qdata = (uint8_t*)tensor->data;
@@ -244,7 +245,7 @@ Tensor* cml_quantize_nf4(Tensor* tensor, int block_size,
     /* Compute number of blocks */
     int num_blocks = (int)((numel + (size_t)block_size - 1) / (size_t)block_size);
 
-    float* scales = (float*)calloc((size_t)num_blocks, sizeof(float));
+    float* scales = (float*)cml_calloc((size_t)num_blocks, sizeof(float));
     if (!scales) {
         LOG_ERROR("cml_quantize_nf4: failed to allocate scales");
         return NULL;
@@ -272,7 +273,7 @@ Tensor* cml_quantize_nf4(Tensor* tensor, int block_size,
                            .has_dtype = true, .has_device = true};
     Tensor* packed = tensor_empty(packed_shape, 1, &config);
     if (!packed) {
-        free(scales);
+        cml_free(scales);
         LOG_ERROR("cml_quantize_nf4: failed to allocate packed tensor");
         return NULL;
     }
@@ -281,9 +282,9 @@ Tensor* cml_quantize_nf4(Tensor* tensor, int block_size,
     memset(pdata, 0, packed_size);
 
     /* Quantize: for each element, normalize by block scale, find nearest NF4 index */
-    uint8_t* indices = (uint8_t*)calloc(padded_numel, sizeof(uint8_t));
+    uint8_t* indices = (uint8_t*)cml_calloc(padded_numel, sizeof(uint8_t));
     if (!indices) {
-        free(scales);
+        cml_free(scales);
         tensor_free(packed);
         LOG_ERROR("cml_quantize_nf4: failed to allocate index buffer");
         return NULL;
@@ -304,7 +305,7 @@ Tensor* cml_quantize_nf4(Tensor* tensor, int block_size,
         pdata[i] = (uint8_t)((indices[2 * i] << 4) | (indices[2 * i + 1] & 0x0F));
     }
 
-    free(indices);
+    cml_free(indices);
 
     *out_scales = scales;
     *out_num_scales = num_blocks;

--- a/src/core/safetensors.c
+++ b/src/core/safetensors.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 #define MAX_TENSORS 4096
 
@@ -92,7 +93,7 @@ static char* parse_string(char* p, char** out) {
         p++;
     }
     size_t len = p - start;
-    *out = malloc(len + 1);
+    *out = cml_malloc(len + 1);
     memcpy(*out, start, len);
     (*out)[len] = '\0';
     if (*p == '"') p++;
@@ -122,19 +123,19 @@ SafeTensorsContext* safetensors_open_read(const char* filepath) {
     if (fread(&header_size, 8, 1, f) != 1) { fclose(f); return NULL; }
     if (header_size > 100 * 1024 * 1024) { fclose(f); return NULL; } // Sanity check
 
-    char* header = malloc(header_size + 1);
+    char* header = cml_malloc(header_size + 1);
     if (!header) { fclose(f); return NULL; }
-    if (fread(header, 1, header_size, f) != header_size) { free(header); fclose(f); return NULL; }
+    if (fread(header, 1, header_size, f) != header_size) { cml_free(header); fclose(f); return NULL; }
     header[header_size] = '\0';
 
-    SafeTensorsContext* ctx = calloc(1, sizeof(SafeTensorsContext));
-    if (!ctx) { free(header); fclose(f); return NULL; }
+    SafeTensorsContext* ctx = cml_calloc(1, sizeof(SafeTensorsContext));
+    if (!ctx) { cml_free(header); fclose(f); return NULL; }
     ctx->file = f;
-    ctx->filepath = strdup(filepath);
+    ctx->filepath = cml_strdup(filepath);
     ctx->is_write = false;
     ctx->header_size = header_size;
-    ctx->tensors = calloc(MAX_TENSORS, sizeof(SafeTensorInfo));
-    if (!ctx->tensors) { free(header); safetensors_close(ctx); return NULL; }
+    ctx->tensors = cml_calloc(MAX_TENSORS, sizeof(SafeTensorInfo));
+    if (!ctx->tensors) { cml_free(header); safetensors_close(ctx); return NULL; }
 
     char* p = header;
     p = skip_ws(p);
@@ -151,7 +152,7 @@ SafeTensorsContext* safetensors_open_read(const char* filepath) {
         if (!p || !name) break;
 
         if (strcmp(name, "__metadata__") == 0) {
-            free(name);
+            cml_free(name);
             p = skip_ws(p);
             if (*p == ':') p++;
             int depth = 0;
@@ -170,7 +171,7 @@ SafeTensorsContext* safetensors_open_read(const char* filepath) {
         if (*p == ':') p++;
         p = skip_ws(p);
 
-        if (*p != '{') { free(name); break; }
+        if (*p != '{') { cml_free(name); break; }
         p++;
 
         while (*p && *p != '}') {
@@ -217,24 +218,24 @@ SafeTensorsContext* safetensors_open_read(const char* filepath) {
                 info->data_start = (size_t)start;
                 info->data_end = (size_t)end;
             }
-            free(key);
+            cml_free(key);
         }
         if (*p == '}') p++;
         ctx->num_tensors++;
     }
 
-    free(header);
+    cml_free(header);
     return ctx;
 }
 
 SafeTensorsContext* safetensors_open_write(const char* filepath) {
-    SafeTensorsContext* ctx = calloc(1, sizeof(SafeTensorsContext));
+    SafeTensorsContext* ctx = cml_calloc(1, sizeof(SafeTensorsContext));
     if (!ctx) return NULL;
-    ctx->filepath = strdup(filepath);
+    ctx->filepath = cml_strdup(filepath);
     ctx->is_write = true;
-    ctx->tensors = calloc(MAX_TENSORS, sizeof(SafeTensorInfo));
+    ctx->tensors = cml_calloc(MAX_TENSORS, sizeof(SafeTensorInfo));
     ctx->write_data_cap = 4096;
-    ctx->write_data = malloc(ctx->write_data_cap);
+    ctx->write_data = cml_malloc(ctx->write_data_cap);
     if (!ctx->tensors || !ctx->write_data) { safetensors_close(ctx); return NULL; }
     return ctx;
 }
@@ -244,7 +245,7 @@ void safetensors_close(SafeTensorsContext* ctx) {
 
     if (ctx->is_write && ctx->filepath && ctx->write_count > 0) {
         size_t json_cap = 4096;
-        char* json = malloc(json_cap);
+        char* json = cml_malloc(json_cap);
         if (json) {
             size_t pos = 0;
             json[pos++] = '{';
@@ -253,7 +254,7 @@ void safetensors_close(SafeTensorsContext* ctx) {
                 SafeTensorInfo* info = &ctx->tensors[i];
                 while (pos + 512 > json_cap) {
                     json_cap *= 2;
-                    json = realloc(json, json_cap);
+                    json = cml_realloc(json, json_cap);
                 }
                 if (i > 0) json[pos++] = ',';
                 pos += snprintf(json + pos, json_cap - pos,
@@ -277,7 +278,7 @@ void safetensors_close(SafeTensorsContext* ctx) {
                 fwrite(ctx->write_data, 1, ctx->write_data_size, f);
                 fclose(f);
             }
-            free(json);
+            cml_free(json);
         }
     }
 
@@ -285,14 +286,14 @@ void safetensors_close(SafeTensorsContext* ctx) {
     if (ctx->tensors) {
         int count = ctx->is_write ? ctx->write_count : ctx->num_tensors;
         for (int i = 0; i < count; i++) {
-            free(ctx->tensors[i].name);
-            free(ctx->tensors[i].dtype_str);
+            cml_free(ctx->tensors[i].name);
+            cml_free(ctx->tensors[i].dtype_str);
         }
-        free(ctx->tensors);
+        cml_free(ctx->tensors);
     }
-    free(ctx->filepath);
-    free(ctx->write_data);
-    free(ctx);
+    cml_free(ctx->filepath);
+    cml_free(ctx->write_data);
+    cml_free(ctx);
 }
 
 int safetensors_get_num_tensors(SafeTensorsContext* ctx) {
@@ -344,13 +345,13 @@ int safetensors_write_tensor(SafeTensorsContext* ctx, const char* name, Tensor* 
 
     while (ctx->write_data_size + data_size > ctx->write_data_cap) {
         ctx->write_data_cap *= 2;
-        ctx->write_data = realloc(ctx->write_data, ctx->write_data_cap);
+        ctx->write_data = cml_realloc(ctx->write_data, ctx->write_data_cap);
         if (!ctx->write_data) return -1;
     }
 
     SafeTensorInfo* info = &ctx->tensors[ctx->write_count];
-    info->name = strdup(name);
-    info->dtype_str = strdup(dtype_to_safetensor_str(tensor->dtype));
+    info->name = cml_strdup(name);
+    info->dtype_str = cml_strdup(dtype_to_safetensor_str(tensor->dtype));
     info->ndim = tensor->ndim;
     for (int d = 0; d < tensor->ndim; d++) info->shape[d] = tensor->shape[d];
     info->data_start = ctx->write_data_size;

--- a/src/core/serialization.c
+++ b/src/core/serialization.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
+#include "alloc/cml_allocator.h"
 
 int module_named_parameters(Module* module, NamedParameter** named_params, int* num_params) {
     if (!module || !named_params || !num_params) {
@@ -22,9 +23,9 @@ int module_named_parameters(Module* module, NamedParameter** named_params, int* 
         return -1;
     }
 
-    NamedParameter* np = malloc((size_t)total_params * sizeof(NamedParameter));
+    NamedParameter* np = cml_malloc((size_t)total_params * sizeof(NamedParameter));
     if (!np) {
-        free(params);
+        cml_free(params);
         return -1;
     }
 
@@ -42,11 +43,11 @@ int module_named_parameters(Module* module, NamedParameter** named_params, int* 
                 if (module_collect_parameters(child, &child_params, &child_num_params, true) == 0) {
                     for (int j = 0; j < child_num_params; j++) {
                         snprintf(name_buf, sizeof(name_buf), "%d.%s.%d", i, child->name, j);
-                        np[idx].name      = strdup(name_buf);
+                        np[idx].name      = cml_strdup(name_buf);
                         np[idx].parameter = child_params[j];
                         idx++;
                     }
-                    free(child_params);
+                    cml_free(child_params);
                 }
             }
         }
@@ -54,20 +55,20 @@ int module_named_parameters(Module* module, NamedParameter** named_params, int* 
         Linear* linear = (Linear*)module;
         if (linear->weight) {
             snprintf(name_buf, sizeof(name_buf), "weight");
-            np[idx].name      = strdup(name_buf);
+            np[idx].name      = cml_strdup(name_buf);
             np[idx].parameter = linear->weight;
             idx++;
         }
         if (linear->bias) {
             snprintf(name_buf, sizeof(name_buf), "bias");
-            np[idx].name      = strdup(name_buf);
+            np[idx].name      = cml_strdup(name_buf);
             np[idx].parameter = linear->bias;
             idx++;
         }
     } else {
         for (int i = 0; i < total_params; i++) {
             snprintf(name_buf, sizeof(name_buf), "param_%d", i);
-            np[idx].name      = strdup(name_buf);
+            np[idx].name      = cml_strdup(name_buf);
             np[idx].parameter = params[i];
             idx++;
         }
@@ -85,10 +86,10 @@ void module_named_parameters_free(NamedParameter* named_params, int num_params) 
 
     for (int i = 0; i < num_params; i++) {
         if (named_params[i].name) {
-            free((void*)named_params[i].name);
+            cml_free((void*)named_params[i].name);
         }
     }
-    free(named_params);
+    cml_free(named_params);
 }
 
 // Binary format for model serialization:
@@ -234,7 +235,7 @@ int module_load_stream(Module* module, FILE* file) {
         int name_len = (int)name_len_int;
         char* name = NULL;
         if (name_len > 0) {
-            name = malloc((size_t)name_len + 1);
+            name = cml_malloc((size_t)name_len + 1);
             if (!name) {
                 LOG_ERROR("Failed to allocate name buffer");
                 module_named_parameters_free(module_params, module_num_params);
@@ -244,7 +245,7 @@ int module_load_stream(Module* module, FILE* file) {
             size_t name_len_size = (size_t)name_len;
             if (fread(name, 1, name_len_size, file) != name_len_size) {
                 LOG_ERROR("Failed to read name for parameter %d", i);
-                free(name);
+                cml_free(name);
                 module_named_parameters_free(module_params, module_num_params);
                 return -1;
             }
@@ -254,7 +255,7 @@ int module_load_stream(Module* module, FILE* file) {
         if (!loaded_tensor) {
             LOG_ERROR("Failed to read tensor for parameter %d", i);
             if (name) {
-                free(name);
+                cml_free(name);
             }
             module_named_parameters_free(module_params, module_num_params);
             return -1;
@@ -291,7 +292,7 @@ int module_load_stream(Module* module, FILE* file) {
                     target_param->tensor->device == DEVICE_CPU) {
                     memcpy(target_param->tensor->data, loaded_tensor->data, data_size);
                 } else {
-                    void* cpu_buffer = malloc(data_size);
+                    void* cpu_buffer = cml_malloc(data_size);
                     if (cpu_buffer) {
                         if (loaded_tensor->device == DEVICE_CPU) {
                             memcpy(cpu_buffer, loaded_tensor->data, data_size);
@@ -306,7 +307,7 @@ int module_load_stream(Module* module, FILE* file) {
                             device_copy_to_device(target_param->tensor->data, cpu_buffer, data_size,
                                                   target_param->tensor->device);
                         }
-                        free(cpu_buffer);
+                        cml_free(cpu_buffer);
                     }
                 }
             } else {
@@ -316,7 +317,7 @@ int module_load_stream(Module* module, FILE* file) {
         }
 
         if (name) {
-            free(name);
+            cml_free(name);
         }
         tensor_free(loaded_tensor);
     }
@@ -407,7 +408,7 @@ int tensor_write_stream(Tensor* tensor, FILE* file) {
     size_t data_size = tensor->numel * cml_dtype_size(tensor->dtype);
     void* cpu_data   = NULL;
     if (tensor->device != DEVICE_CPU) {
-        cpu_data = malloc(data_size);
+        cpu_data = cml_malloc(data_size);
         if (!cpu_data) {
             LOG_ERROR("Failed to allocate CPU buffer");
             if (contiguous_tensor != tensor) {
@@ -420,7 +421,7 @@ int tensor_write_stream(Tensor* tensor, FILE* file) {
             device_copy_from_device(cpu_data, contiguous_tensor->data, data_size, tensor->device);
         if (result != 0) {
             LOG_ERROR("Failed to copy tensor data to CPU");
-            free(cpu_data);
+            cml_free(cpu_data);
             if (contiguous_tensor != tensor) {
                 tensor_free(contiguous_tensor);
             }
@@ -432,7 +433,7 @@ int tensor_write_stream(Tensor* tensor, FILE* file) {
     if (fwrite(cpu_data, 1, data_size, file) != data_size) {
         LOG_ERROR("Failed to write tensor data");
         if (cpu_data != contiguous_tensor->data) {
-            free(cpu_data);
+            cml_free(cpu_data);
         }
         if (contiguous_tensor != tensor) {
             tensor_free(contiguous_tensor);
@@ -440,7 +441,7 @@ int tensor_write_stream(Tensor* tensor, FILE* file) {
         return -1;
     }
     if (cpu_data != contiguous_tensor->data) {
-        free(cpu_data);
+        cml_free(cpu_data);
     }
     if (contiguous_tensor != tensor) {
         tensor_free(contiguous_tensor);
@@ -518,7 +519,7 @@ Tensor* tensor_read_stream(FILE* file) {
         LOG_ERROR("Invalid ndim: %d", ndim);
         return NULL;
     }
-    int* shape = malloc((size_t)ndim * sizeof(int));
+    int* shape = cml_malloc((size_t)ndim * sizeof(int));
     if (!shape) {
         LOG_ERROR("Failed to allocate shape array");
         return NULL;
@@ -526,25 +527,25 @@ Tensor* tensor_read_stream(FILE* file) {
 
     if (fread(shape, sizeof(int), (size_t)ndim, file) != (size_t)ndim) {
         LOG_ERROR("Failed to read shape");
-        free(shape);
+        cml_free(shape);
         return NULL;
     }
     size_t numel;
     if (fread(&numel, sizeof(size_t), 1, file) != 1) {
         LOG_ERROR("Failed to read numel");
-        free(shape);
+        cml_free(shape);
         return NULL;
     }
     TensorConfig config = {.dtype = dtype, .device = device, .has_dtype = true, .has_device = true};
     Tensor* tensor      = tensor_empty(shape, ndim, &config);
-    free(shape);
+    cml_free(shape);
 
     if (!tensor) {
         LOG_ERROR("Failed to create tensor");
         return NULL;
     }
     size_t data_size = numel * cml_dtype_size(dtype);
-    void* cpu_data   = malloc(data_size);
+    void* cpu_data   = cml_malloc(data_size);
     if (!cpu_data) {
         LOG_ERROR("Failed to allocate CPU buffer");
         tensor_free(tensor);
@@ -553,7 +554,7 @@ Tensor* tensor_read_stream(FILE* file) {
 
     if (fread(cpu_data, 1, data_size, file) != data_size) {
         LOG_ERROR("Failed to read tensor data");
-        free(cpu_data);
+        cml_free(cpu_data);
         tensor_free(tensor);
         return NULL;
     }
@@ -563,13 +564,13 @@ Tensor* tensor_read_stream(FILE* file) {
         int result = device_copy_to_device(tensor->data, cpu_data, data_size, device);
         if (result != 0) {
             LOG_ERROR("Failed to copy data to device");
-            free(cpu_data);
+            cml_free(cpu_data);
             tensor_free(tensor);
             return NULL;
         }
     }
 
-    free(cpu_data);
+    cml_free(cpu_data);
 
     return tensor;
 }
@@ -848,7 +849,7 @@ int optimizer_load_stream(Optimizer* optimizer, FILE* file) {
     }
     int name_len = (int)name_len_int;
     if (name_len > 0) {
-        char* saved_name = malloc((size_t)name_len + 1);
+        char* saved_name = cml_malloc((size_t)name_len + 1);
         if (!saved_name) {
             LOG_ERROR("Failed to allocate name buffer");
             return -1;
@@ -856,7 +857,7 @@ int optimizer_load_stream(Optimizer* optimizer, FILE* file) {
 
         if (fread(saved_name, 1, (size_t)name_len, file) != (size_t)name_len) {
             LOG_ERROR("Failed to read optimizer name");
-            free(saved_name);
+            cml_free(saved_name);
             return -1;
         }
         saved_name[name_len] = '\0';
@@ -866,7 +867,7 @@ int optimizer_load_stream(Optimizer* optimizer, FILE* file) {
                         optimizer->name);
         }
 
-        free(saved_name);
+        cml_free(saved_name);
     }
     int32_t num_groups_int;
     if (fread(&num_groups_int, sizeof(int32_t), 1, file) != 1) {
@@ -931,7 +932,7 @@ int optimizer_load_stream(Optimizer* optimizer, FILE* file) {
                 if (state_type == OPTIMIZER_STATE_SGD && strcmp(optimizer->name, "SGD") == 0) {
                     if (!group->state) {
                         SGDMomentumState** states =
-                            malloc((size_t)group->num_parameters * sizeof(SGDMomentumState*));
+                            cml_malloc((size_t)group->num_parameters * sizeof(SGDMomentumState*));
                         if (!states) {
                             LOG_ERROR("Failed to allocate SGD state");
                             return -1;
@@ -943,7 +944,7 @@ int optimizer_load_stream(Optimizer* optimizer, FILE* file) {
 
                     SGDMomentumState** states = (SGDMomentumState**)group->state;
                     if (!states[param_idx]) {
-                        states[param_idx] = malloc(sizeof(SGDMomentumState));
+                        states[param_idx] = cml_malloc(sizeof(SGDMomentumState));
                         if (!states[param_idx]) {
                             LOG_ERROR("Failed to allocate SGD state for parameter %d", param_idx);
                             return -1;
@@ -962,7 +963,7 @@ int optimizer_load_stream(Optimizer* optimizer, FILE* file) {
                            strcmp(optimizer->name, "Adam") == 0) {
                     if (!group->state) {
                         AdamState** states =
-                            malloc((size_t)group->num_parameters * sizeof(AdamState*));
+                            cml_malloc((size_t)group->num_parameters * sizeof(AdamState*));
                         if (!states) {
                             LOG_ERROR("Failed to allocate Adam state");
                             return -1;
@@ -973,7 +974,7 @@ int optimizer_load_stream(Optimizer* optimizer, FILE* file) {
 
                     AdamState** states = (AdamState**)group->state;
                     if (!states[param_idx]) {
-                        states[param_idx] = malloc(sizeof(AdamState));
+                        states[param_idx] = cml_malloc(sizeof(AdamState));
                         if (!states[param_idx]) {
                             LOG_ERROR("Failed to allocate Adam state for parameter %d", param_idx);
                             return -1;
@@ -1012,7 +1013,7 @@ int optimizer_load_stream(Optimizer* optimizer, FILE* file) {
                            strcmp(optimizer->name, "RMSprop") == 0) {
                     if (!group->state) {
                         RMSpropState** states =
-                            malloc((size_t)group->num_parameters * sizeof(RMSpropState*));
+                            cml_malloc((size_t)group->num_parameters * sizeof(RMSpropState*));
                         if (!states) {
                             LOG_ERROR("Failed to allocate RMSprop state");
                             return -1;
@@ -1023,7 +1024,7 @@ int optimizer_load_stream(Optimizer* optimizer, FILE* file) {
 
                     RMSpropState** states = (RMSpropState**)group->state;
                     if (!states[param_idx]) {
-                        states[param_idx] = malloc(sizeof(RMSpropState));
+                        states[param_idx] = cml_malloc(sizeof(RMSpropState));
                         if (!states[param_idx]) {
                             LOG_ERROR("Failed to allocate RMSprop state for parameter %d",
                                       param_idx);
@@ -1043,7 +1044,7 @@ int optimizer_load_stream(Optimizer* optimizer, FILE* file) {
                            strcmp(optimizer->name, "Adagrad") == 0) {
                     if (!group->state) {
                         AdagradState** states =
-                            malloc((size_t)group->num_parameters * sizeof(AdagradState*));
+                            cml_malloc((size_t)group->num_parameters * sizeof(AdagradState*));
                         if (!states) {
                             LOG_ERROR("Failed to allocate Adagrad state");
                             return -1;
@@ -1054,7 +1055,7 @@ int optimizer_load_stream(Optimizer* optimizer, FILE* file) {
 
                     AdagradState** states = (AdagradState**)group->state;
                     if (!states[param_idx]) {
-                        states[param_idx] = malloc(sizeof(AdagradState));
+                        states[param_idx] = cml_malloc(sizeof(AdagradState));
                         if (!states[param_idx]) {
                             LOG_ERROR("Failed to allocate Adagrad state for parameter %d",
                                       param_idx);

--- a/src/core/tinyfs.c
+++ b/src/core/tinyfs.c
@@ -2,12 +2,13 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include "alloc/cml_allocator.h"
 
 CMLTinyFS* cml_tinyfs_create(const char* base_path, int num_shards, size_t shard_size) {
     if (!base_path || num_shards < 1 || num_shards > CML_TINYFS_MAX_SHARDS)
         return NULL;
 
-    CMLTinyFS* fs = (CMLTinyFS*)calloc(1, sizeof(CMLTinyFS));
+    CMLTinyFS* fs = (CMLTinyFS*)cml_calloc(1, sizeof(CMLTinyFS));
     if (!fs) return NULL;
 
     strncpy(fs->base_path, base_path, sizeof(fs->base_path) - 1);
@@ -27,7 +28,7 @@ CMLTinyFS* cml_tinyfs_create(const char* base_path, int num_shards, size_t shard
 }
 
 void cml_tinyfs_free(CMLTinyFS* fs) {
-    free(fs);
+    cml_free(fs);
 }
 
 int cml_tinyfs_store(CMLTinyFS* fs, const char* name, Tensor* tensor) {

--- a/src/core/training_loop.c
+++ b/src/core/training_loop.c
@@ -15,13 +15,14 @@
 #include <string.h>
 #include <math.h>
 #include <float.h>
+#include "alloc/cml_allocator.h"
 
 LRScheduler* lr_scheduler_step(Optimizer* optimizer, int step_size, float gamma) {
     if (!optimizer) {
         return NULL;
     }
 
-    LRScheduler* scheduler = calloc(1, sizeof(LRScheduler));
+    LRScheduler* scheduler = cml_calloc(1, sizeof(LRScheduler));
     if (!scheduler) {
         return NULL;
     }
@@ -41,7 +42,7 @@ LRScheduler* lr_scheduler_reduce_on_plateau(Optimizer* optimizer, float factor, 
         return NULL;
     }
 
-    LRScheduler* scheduler = calloc(1, sizeof(LRScheduler));
+    LRScheduler* scheduler = cml_calloc(1, sizeof(LRScheduler));
     if (!scheduler) {
         return NULL;
     }
@@ -61,7 +62,7 @@ LRScheduler* lr_scheduler_exponential(Optimizer* optimizer, float gamma) {
         return NULL;
     }
 
-    LRScheduler* scheduler = calloc(1, sizeof(LRScheduler));
+    LRScheduler* scheduler = cml_calloc(1, sizeof(LRScheduler));
     if (!scheduler) {
         return NULL;
     }
@@ -79,7 +80,7 @@ LRScheduler* lr_scheduler_cosine(Optimizer* optimizer, int T_max, float eta_min)
         return NULL;
     }
 
-    LRScheduler* scheduler = calloc(1, sizeof(LRScheduler));
+    LRScheduler* scheduler = cml_calloc(1, sizeof(LRScheduler));
     if (!scheduler) {
         return NULL;
     }
@@ -105,7 +106,7 @@ LRScheduler* lr_scheduler_polynomial(Optimizer* optimizer, int total_iters, floa
         return NULL;
     }
 
-    LRScheduler* scheduler = calloc(1, sizeof(LRScheduler));
+    LRScheduler* scheduler = cml_calloc(1, sizeof(LRScheduler));
     if (!scheduler) {
         return NULL;
     }
@@ -130,7 +131,7 @@ LRScheduler* lr_scheduler_warmup(LRScheduler* inner, int warmup_steps, float war
         return NULL;
     }
 
-    LRScheduler* scheduler = calloc(1, sizeof(LRScheduler));
+    LRScheduler* scheduler = cml_calloc(1, sizeof(LRScheduler));
     if (!scheduler) {
         return NULL;
     }
@@ -307,12 +308,12 @@ void lr_scheduler_free(LRScheduler* scheduler) {
         return;
     }
     if (scheduler->milestones) {
-        free(scheduler->milestones);
+        cml_free(scheduler->milestones);
     }
     if (scheduler->inner_scheduler) {
         lr_scheduler_free(scheduler->inner_scheduler);
     }
-    free(scheduler);
+    cml_free(scheduler);
 }
 
 void training_callbacks_create(TrainingCallbacks* callbacks) {
@@ -516,7 +517,7 @@ int cml_train(Module* model, DataLoader* train_loader, Optimizer* optimizer,
                         }
                     }
 
-                    free(params);
+                    cml_free(params);
                 }
             }
             optimizer->step(optimizer);
@@ -721,7 +722,7 @@ int cml_train_with_validation(Module* model, DataLoader* train_loader, DataLoade
                         }
                     }
 
-                    free(params);
+                    cml_free(params);
                 }
             }
             optimizer->step(optimizer);

--- a/src/core/training_metrics.c
+++ b/src/core/training_metrics.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <math.h>
 #include <time.h>
+#include "alloc/cml_allocator.h"
 
 static TrainingMetrics* g_global_metrics = NULL;
 static size_t g_current_epoch            = 0;
@@ -40,23 +41,23 @@ static int training_metrics_ensure_capacity(TrainingMetrics* metrics, size_t num
     size_t old_capacity = metrics->num_epochs;
     size_t new_capacity = num_epochs;
     metrics->epoch_training_losses =
-        realloc(metrics->epoch_training_losses, (size_t)new_capacity * sizeof(float));
+        cml_realloc(metrics->epoch_training_losses, (size_t)new_capacity * sizeof(float));
     metrics->epoch_training_accuracies =
-        realloc(metrics->epoch_training_accuracies, (size_t)new_capacity * sizeof(float));
-    metrics->epoch_times = realloc(metrics->epoch_times, (size_t)new_capacity * sizeof(float));
+        cml_realloc(metrics->epoch_training_accuracies, (size_t)new_capacity * sizeof(float));
+    metrics->epoch_times = cml_realloc(metrics->epoch_times, (size_t)new_capacity * sizeof(float));
     metrics->epoch_learning_rates =
-        realloc(metrics->epoch_learning_rates, (size_t)new_capacity * sizeof(float));
+        cml_realloc(metrics->epoch_learning_rates, (size_t)new_capacity * sizeof(float));
     if (metrics->epoch_validation_losses) {
         metrics->epoch_validation_losses =
-            realloc(metrics->epoch_validation_losses, (size_t)new_capacity * sizeof(float));
+            cml_realloc(metrics->epoch_validation_losses, (size_t)new_capacity * sizeof(float));
         metrics->epoch_validation_accuracies =
-            realloc(metrics->epoch_validation_accuracies, (size_t)new_capacity * sizeof(float));
+            cml_realloc(metrics->epoch_validation_accuracies, (size_t)new_capacity * sizeof(float));
     }
     if (metrics->epoch_testing_losses) {
         metrics->epoch_testing_losses =
-            realloc(metrics->epoch_testing_losses, (size_t)new_capacity * sizeof(float));
+            cml_realloc(metrics->epoch_testing_losses, (size_t)new_capacity * sizeof(float));
         metrics->epoch_testing_accuracies =
-            realloc(metrics->epoch_testing_accuracies, (size_t)new_capacity * sizeof(float));
+            cml_realloc(metrics->epoch_testing_accuracies, (size_t)new_capacity * sizeof(float));
     }
 
     if (!metrics->epoch_training_losses || !metrics->epoch_training_accuracies ||
@@ -86,22 +87,22 @@ static int training_metrics_ensure_capacity(TrainingMetrics* metrics, size_t num
 }
 
 TrainingMetrics* training_metrics_create(size_t num_epochs) {
-    TrainingMetrics* metrics = malloc(sizeof(TrainingMetrics));
+    TrainingMetrics* metrics = cml_malloc(sizeof(TrainingMetrics));
     if (!metrics)
         return NULL;
 
     metrics->num_epochs = num_epochs;
-    metrics->epoch_training_losses     = malloc(num_epochs * sizeof(float));
-    metrics->epoch_training_accuracies = malloc(num_epochs * sizeof(float));
+    metrics->epoch_training_losses     = cml_malloc(num_epochs * sizeof(float));
+    metrics->epoch_training_accuracies = cml_malloc(num_epochs * sizeof(float));
     metrics->epoch_testing_losses     = NULL;
     metrics->epoch_testing_accuracies = NULL;
     metrics->epoch_validation_losses     = NULL;
     metrics->epoch_validation_accuracies = NULL;
 
-    metrics->epoch_times      = malloc(num_epochs * sizeof(float));
+    metrics->epoch_times      = cml_malloc(num_epochs * sizeof(float));
     metrics->total_time       = 0.0f;
     metrics->epoch_start_time = 0;
-    metrics->epoch_learning_rates = malloc(num_epochs * sizeof(float));
+    metrics->epoch_learning_rates = cml_malloc(num_epochs * sizeof(float));
 
     metrics->best_loss        = 0.0f;
     metrics->best_accuracy    = 0.0f;
@@ -121,14 +122,14 @@ TrainingMetrics* training_metrics_create(size_t num_epochs) {
     if (!metrics->epoch_training_losses || !metrics->epoch_training_accuracies ||
         !metrics->epoch_times || !metrics->epoch_learning_rates) {
         if (metrics->epoch_training_losses)
-            free(metrics->epoch_training_losses);
+            cml_free(metrics->epoch_training_losses);
         if (metrics->epoch_training_accuracies)
-            free(metrics->epoch_training_accuracies);
+            cml_free(metrics->epoch_training_accuracies);
         if (metrics->epoch_times)
-            free(metrics->epoch_times);
+            cml_free(metrics->epoch_times);
         if (metrics->epoch_learning_rates)
-            free(metrics->epoch_learning_rates);
-        free(metrics);
+            cml_free(metrics->epoch_learning_rates);
+        cml_free(metrics);
         return NULL;
     }
 
@@ -181,8 +182,8 @@ void training_metrics_record_epoch_full(TrainingMetrics* metrics, size_t epoch, 
     if (!isinf(test_loss) && !isinf(test_accuracy) && !isnan(test_loss) && !isnan(test_accuracy) &&
         test_loss >= 0.0f && test_accuracy >= 0.0f) {
         if (!metrics->epoch_testing_losses) {
-            metrics->epoch_testing_losses     = malloc(metrics->num_epochs * sizeof(float));
-            metrics->epoch_testing_accuracies = malloc(metrics->num_epochs * sizeof(float));
+            metrics->epoch_testing_losses     = cml_malloc(metrics->num_epochs * sizeof(float));
+            metrics->epoch_testing_accuracies = cml_malloc(metrics->num_epochs * sizeof(float));
             if (metrics->epoch_testing_losses && metrics->epoch_testing_accuracies) {
                 for (size_t i = 0; i < metrics->num_epochs; i++) {
                     metrics->epoch_testing_losses[i]     = INFINITY;
@@ -199,8 +200,8 @@ void training_metrics_record_epoch_full(TrainingMetrics* metrics, size_t epoch, 
     if (!isinf(val_loss) && !isinf(val_accuracy) && !isnan(val_loss) && !isnan(val_accuracy) &&
         val_loss >= 0.0f && val_accuracy >= 0.0f) {
         if (!metrics->epoch_validation_losses) {
-            metrics->epoch_validation_losses     = malloc(metrics->num_epochs * sizeof(float));
-            metrics->epoch_validation_accuracies = malloc(metrics->num_epochs * sizeof(float));
+            metrics->epoch_validation_losses     = cml_malloc(metrics->num_epochs * sizeof(float));
+            metrics->epoch_validation_accuracies = cml_malloc(metrics->num_epochs * sizeof(float));
             if (metrics->epoch_validation_losses && metrics->epoch_validation_accuracies) {
                 for (size_t i = 0; i < metrics->num_epochs; i++) {
                     metrics->epoch_validation_losses[i]     = INFINITY;
@@ -226,12 +227,12 @@ void training_metrics_set_summary(TrainingMetrics* metrics, const char* summary)
         return;
 
     if (metrics->model_summary) {
-        free(metrics->model_summary);
+        cml_free(metrics->model_summary);
     }
 
     if (summary) {
         size_t len             = strlen(summary);
-        metrics->model_summary = malloc(len + 1);
+        metrics->model_summary = cml_malloc(len + 1);
         if (metrics->model_summary) {
             memcpy(metrics->model_summary, summary, len);
             metrics->model_summary[len] = '\0';
@@ -262,12 +263,12 @@ void training_metrics_set_learning_rate(TrainingMetrics* metrics, float lr, cons
     metrics->learning_rate = lr;
 
     if (metrics->lr_schedule) {
-        free(metrics->lr_schedule);
+        cml_free(metrics->lr_schedule);
     }
 
     if (scheduler) {
         size_t len           = strlen(scheduler);
-        metrics->lr_schedule = malloc(len + 1);
+        metrics->lr_schedule = cml_malloc(len + 1);
         if (metrics->lr_schedule) {
             memcpy(metrics->lr_schedule, scheduler, len);
             metrics->lr_schedule[len] = '\0';
@@ -282,12 +283,12 @@ void training_metrics_set_lr_schedule_params(TrainingMetrics* metrics, const cha
         return;
 
     if (metrics->lr_schedule_params) {
-        free(metrics->lr_schedule_params);
+        cml_free(metrics->lr_schedule_params);
     }
 
     if (params) {
         size_t len                  = strlen(params);
-        metrics->lr_schedule_params = malloc(len + 1);
+        metrics->lr_schedule_params = cml_malloc(len + 1);
         if (metrics->lr_schedule_params) {
             memcpy(metrics->lr_schedule_params, params, len);
             metrics->lr_schedule_params[len] = '\0';
@@ -761,28 +762,28 @@ void training_metrics_free(TrainingMetrics* metrics) {
         return;
 
     if (metrics->epoch_training_losses)
-        free(metrics->epoch_training_losses);
+        cml_free(metrics->epoch_training_losses);
     if (metrics->epoch_training_accuracies)
-        free(metrics->epoch_training_accuracies);
+        cml_free(metrics->epoch_training_accuracies);
     if (metrics->epoch_testing_losses)
-        free(metrics->epoch_testing_losses);
+        cml_free(metrics->epoch_testing_losses);
     if (metrics->epoch_testing_accuracies)
-        free(metrics->epoch_testing_accuracies);
+        cml_free(metrics->epoch_testing_accuracies);
     if (metrics->epoch_validation_losses)
-        free(metrics->epoch_validation_losses);
+        cml_free(metrics->epoch_validation_losses);
     if (metrics->epoch_validation_accuracies)
-        free(metrics->epoch_validation_accuracies);
+        cml_free(metrics->epoch_validation_accuracies);
     if (metrics->epoch_times)
-        free(metrics->epoch_times);
+        cml_free(metrics->epoch_times);
     if (metrics->epoch_learning_rates)
-        free(metrics->epoch_learning_rates);
+        cml_free(metrics->epoch_learning_rates);
     if (metrics->model_summary)
-        free(metrics->model_summary);
+        cml_free(metrics->model_summary);
     if (metrics->lr_schedule)
-        free(metrics->lr_schedule);
+        cml_free(metrics->lr_schedule);
     if (metrics->lr_schedule_params)
-        free(metrics->lr_schedule_params);
-    free(metrics);
+        cml_free(metrics->lr_schedule_params);
+    cml_free(metrics);
 }
 
 int training_metrics_step(Module* model, Tensor* X, Tensor* y, Tensor* (*loss_fn)(Tensor*, Tensor*),
@@ -837,7 +838,7 @@ int training_metrics_step(Module* model, Tensor* X, Tensor* y, Tensor* (*loss_fn
         if (module_collect_parameters(model, &params, &num_params, true) == 0 && params) {
             grad_norm =
                 training_metrics_calculate_gradient_norm(metrics, (void**)params, num_params);
-            free(params);
+            cml_free(params);
         }
     }
     optimizer_step(optimizer);
@@ -954,13 +955,13 @@ void training_metrics_auto_export_architecture(Module* model) {
                 fseek(f, 0, SEEK_SET);
 
                 if (size > 0 && size < 1024 * 1024) { // Limit to 1MB
-                    char* json_str = malloc((size_t)size + 1);
+                    char* json_str = cml_malloc((size_t)size + 1);
                     if (json_str) {
                         size_t read    = fread(json_str, 1, (size_t)size, f);
                         json_str[read] = '\0';
                         training_metrics_set_summary(g_global_metrics, json_str);
 
-                        free(json_str);
+                        cml_free(json_str);
                     }
                 }
                 fclose(f);
@@ -1067,9 +1068,9 @@ void training_metrics_auto_capture_validation(float val_loss, float val_accuracy
         return;
     if (!g_global_metrics->epoch_validation_losses) {
         g_global_metrics->epoch_validation_losses =
-            malloc(g_global_metrics->num_epochs * sizeof(float));
+            cml_malloc(g_global_metrics->num_epochs * sizeof(float));
         g_global_metrics->epoch_validation_accuracies =
-            malloc(g_global_metrics->num_epochs * sizeof(float));
+            cml_malloc(g_global_metrics->num_epochs * sizeof(float));
         if (!g_global_metrics->epoch_validation_losses ||
             !g_global_metrics->epoch_validation_accuracies) {
             return;
@@ -1093,9 +1094,9 @@ void training_metrics_auto_capture_test(float test_loss, float test_accuracy) {
         return;
     if (!g_global_metrics->epoch_testing_losses) {
         g_global_metrics->epoch_testing_losses =
-            malloc(g_global_metrics->num_epochs * sizeof(float));
+            cml_malloc(g_global_metrics->num_epochs * sizeof(float));
         g_global_metrics->epoch_testing_accuracies =
-            malloc(g_global_metrics->num_epochs * sizeof(float));
+            cml_malloc(g_global_metrics->num_epochs * sizeof(float));
         if (!g_global_metrics->epoch_testing_losses ||
             !g_global_metrics->epoch_testing_accuracies) {
             return;

--- a/src/datasets/csv_parser.c
+++ b/src/datasets/csv_parser.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include "alloc/cml_allocator.h"
 
 #define MAX_LINE 8192
 #define MAX_COLS 256
@@ -171,9 +172,9 @@ int cml_csv_parse(const char* filepath, int target_col,
     }
 
     /* Allocate */
-    float* X = malloc(sizeof(float) * line_count * nfeat);
-    float* y = malloc(sizeof(float) * line_count);
-    if (!X || !y) { free(X); free(y); fclose(f); return -1; }
+    float* X = cml_malloc(sizeof(float) * line_count * nfeat);
+    float* y = cml_malloc(sizeof(float) * line_count);
+    if (!X || !y) { cml_free(X); cml_free(y); fclose(f); return -1; }
 
     LabelMap lm = {.count = 0};
     int row = 0;
@@ -245,9 +246,9 @@ int cml_csv_parse(const char* filepath, int target_col,
     *num_classes = lm.count > 0 ? lm.count : 0;
 
     if (class_names_out && lm.count > 0) {
-        char** names = malloc(sizeof(char*) * lm.count);
+        char** names = cml_malloc(sizeof(char*) * lm.count);
         for (int i = 0; i < lm.count; i++) {
-            names[i] = strdup(lm.labels[i]);
+            names[i] = cml_strdup(lm.labels[i]);
         }
         *class_names_out = names;
     } else if (class_names_out) {
@@ -275,6 +276,6 @@ Dataset* cml_dataset_from_csv(const char* filepath, int target_col) {
         ds->class_names = class_names;
         cml_dataset_compute_stats(ds);
     }
-    free(X); free(y);
+    cml_free(X); cml_free(y);
     return ds;
 }

--- a/src/datasets/datasets.c
+++ b/src/datasets/datasets.c
@@ -8,6 +8,7 @@
 #include <sys/stat.h>
 #include <ctype.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 void cml_dataset_compute_stats(Dataset* ds) {
     if (!ds || !ds->X || ds->num_samples == 0 || ds->input_size == 0) return;
@@ -17,10 +18,10 @@ void cml_dataset_compute_stats(Dataset* ds) {
     float* X = (float*)tensor_data_ptr(ds->X);
     if (!X) return;
 
-    ds->feature_means = calloc(nf, sizeof(float));
-    ds->feature_stds  = calloc(nf, sizeof(float));
-    ds->feature_mins  = malloc(sizeof(float) * nf);
-    ds->feature_maxs  = malloc(sizeof(float) * nf);
+    ds->feature_means = cml_calloc(nf, sizeof(float));
+    ds->feature_stds  = cml_calloc(nf, sizeof(float));
+    ds->feature_mins  = cml_malloc(sizeof(float) * nf);
+    ds->feature_maxs  = cml_malloc(sizeof(float) * nf);
     if (!ds->feature_means || !ds->feature_stds || !ds->feature_mins || !ds->feature_maxs)
         return;
 
@@ -162,7 +163,7 @@ static Dataset* load_iris(void) {
         ds->num_classes = nc;
         ds->class_names = class_names;
     }
-    free(X); free(y);
+    cml_free(X); cml_free(y);
     return ds;
 }
 
@@ -182,7 +183,7 @@ static Dataset* load_wine(void) {
         ds->name = "wine";
         ds->num_classes = nc;
     }
-    free(X); free(y);
+    cml_free(X); cml_free(y);
     return ds;
 }
 
@@ -205,9 +206,9 @@ static Dataset* load_breast_cancer(void) {
     }
     rewind(f);
 
-    float* X = malloc(sizeof(float) * n * 30);
-    float* y = malloc(sizeof(float) * n);
-    if (!X || !y) { free(X); free(y); fclose(f); return NULL; }
+    float* X = cml_malloc(sizeof(float) * n * 30);
+    float* y = cml_malloc(sizeof(float) * n);
+    if (!X || !y) { cml_free(X); cml_free(y); fclose(f); return NULL; }
 
     int idx = 0;
     while (fgets(line, sizeof(line), f) && idx < n) {
@@ -238,7 +239,7 @@ static Dataset* load_breast_cancer(void) {
         ds->name = "breast_cancer";
         ds->num_classes = 2;
     }
-    free(X); free(y);
+    cml_free(X); cml_free(y);
     return ds;
 }
 
@@ -258,7 +259,7 @@ static Dataset* load_boston(void) {
         ds->name = "boston";
         ds->num_classes = 0; /* regression */
     }
-    free(X); free(y);
+    cml_free(X); cml_free(y);
     return ds;
 }
 
@@ -319,7 +320,7 @@ static Dataset* load_mnist_dataset(const char* name, const char* base_url) {
     float* train_lbl = cml_idx_load_labels(p_tl, &n_train_lbl);
 
     if (!train_img || !train_lbl) {
-        free(train_img); free(train_lbl);
+        cml_free(train_img); cml_free(train_lbl);
         return NULL;
     }
 
@@ -337,14 +338,14 @@ static Dataset* load_mnist_dataset(const char* name, const char* base_url) {
 
         if (test_img && test_lbl) {
             total_n = n_train + n_test;
-            all_X = malloc(sizeof(float) * total_n * feat);
-            all_y = malloc(sizeof(float) * total_n);
+            all_X = cml_malloc(sizeof(float) * total_n * feat);
+            all_y = cml_malloc(sizeof(float) * total_n);
             memcpy(all_X, train_img, sizeof(float) * n_train * feat);
             memcpy(all_X + n_train * feat, test_img, sizeof(float) * n_test * feat);
             memcpy(all_y, train_lbl, sizeof(float) * n_train);
             memcpy(all_y + n_train, test_lbl, sizeof(float) * n_test);
         }
-        free(test_img); free(test_lbl);
+        cml_free(test_img); cml_free(test_lbl);
     }
 
     if (!all_X) {
@@ -361,8 +362,8 @@ static Dataset* load_mnist_dataset(const char* name, const char* base_url) {
         ds->num_classes = 10;
     }
 
-    if (all_X != train_img) { free(all_X); free(all_y); }
-    free(train_img); free(train_lbl);
+    if (all_X != train_img) { cml_free(all_X); cml_free(all_y); }
+    cml_free(train_img); cml_free(train_lbl);
     return ds;
 }
 
@@ -390,9 +391,9 @@ static Dataset* load_cifar10(void) {
     /* Read 5 training batches + 1 test batch */
     int total = 60000;
     int feat = 3072;
-    float* X = malloc(sizeof(float) * total * feat);
-    float* y = malloc(sizeof(float) * total);
-    if (!X || !y) { free(X); free(y); return NULL; }
+    float* X = cml_malloc(sizeof(float) * total * feat);
+    float* y = cml_malloc(sizeof(float) * total);
+    if (!X || !y) { cml_free(X); cml_free(y); return NULL; }
 
     int offset = 0;
     const char* batch_files[] = {
@@ -434,7 +435,7 @@ static Dataset* load_cifar10(void) {
         ds->name = "cifar10";
         ds->num_classes = 10;
     }
-    free(X); free(y);
+    cml_free(X); cml_free(y);
     return ds;
 }
 
@@ -442,9 +443,9 @@ static Dataset* load_airline(void) {
     int n;
     const float* data = cml_builtin_airline_data(&n);
 
-    float* X = malloc(sizeof(float) * n);
-    float* y = malloc(sizeof(float) * n);
-    if (!X || !y) { free(X); free(y); return NULL; }
+    float* X = cml_malloc(sizeof(float) * n);
+    float* y = cml_malloc(sizeof(float) * n);
+    if (!X || !y) { cml_free(X); cml_free(y); return NULL; }
 
     memcpy(X, data, sizeof(float) * n);
     /* For time series: y is same as X (predict value) */
@@ -455,7 +456,7 @@ static Dataset* load_airline(void) {
         ds->name = "airline";
         ds->num_classes = 0;
     }
-    free(X); free(y);
+    cml_free(X); cml_free(y);
     return ds;
 }
 
@@ -466,9 +467,9 @@ static Dataset* load_digits(void) {
     const float* labels = cml_builtin_digits_labels(&nl);
 
     /* Copy to mutable buffers for dataset_from_arrays */
-    float* X = malloc(sizeof(float) * n * feat);
-    float* y = malloc(sizeof(float) * n);
-    if (!X || !y) { free(X); free(y); return NULL; }
+    float* X = cml_malloc(sizeof(float) * n * feat);
+    float* y = cml_malloc(sizeof(float) * n);
+    if (!X || !y) { cml_free(X); cml_free(y); return NULL; }
 
     memcpy(X, data, sizeof(float) * n * feat);
     memcpy(y, labels, sizeof(float) * n);
@@ -478,7 +479,7 @@ static Dataset* load_digits(void) {
         ds->name = "digits";
         ds->num_classes = 10;
     }
-    free(X); free(y);
+    cml_free(X); cml_free(y);
     return ds;
 }
 

--- a/src/datasets/idx_parser.c
+++ b/src/datasets/idx_parser.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include "alloc/cml_allocator.h"
 
 static uint32_t read_u32_be(FILE* f) {
     uint8_t b[4];
@@ -30,23 +31,23 @@ float* cml_idx_load_images(const char* path, int* n, int* rows, int* cols) {
     *cols = (int)read_u32_be(f);
 
     int px = (*rows) * (*cols);
-    float* data = malloc(sizeof(float) * (*n) * px);
+    float* data = cml_malloc(sizeof(float) * (*n) * px);
     if (!data) { fclose(f); return NULL; }
 
-    uint8_t* buf = malloc(px);
-    if (!buf) { free(data); fclose(f); return NULL; }
+    uint8_t* buf = cml_malloc(px);
+    if (!buf) { cml_free(data); fclose(f); return NULL; }
 
     for (int i = 0; i < *n; i++) {
         if ((int)fread(buf, 1, px, f) != px) {
             LOG_ERROR("[idx] Truncated at image %d", i);
-            free(data); free(buf); fclose(f);
+            cml_free(data); cml_free(buf); fclose(f);
             return NULL;
         }
         for (int j = 0; j < px; j++)
             data[i * px + j] = buf[j] / 255.0f;
     }
 
-    free(buf);
+    cml_free(buf);
     fclose(f);
     LOG_INFO("[idx] Loaded %d images (%dx%d) from %s", *n, *rows, *cols, path);
     return data;
@@ -68,14 +69,14 @@ float* cml_idx_load_labels(const char* path, int* n) {
 
     *n = (int)read_u32_be(f);
 
-    float* data = malloc(sizeof(float) * (*n));
+    float* data = cml_malloc(sizeof(float) * (*n));
     if (!data) { fclose(f); return NULL; }
 
     for (int i = 0; i < *n; i++) {
         uint8_t label;
         if (fread(&label, 1, 1, f) != 1) {
             LOG_ERROR("[idx] Truncated at label %d", i);
-            free(data); fclose(f);
+            cml_free(data); fclose(f);
             return NULL;
         }
         data[i] = (float)label;

--- a/src/datasets/loaders.c
+++ b/src/datasets/loaders.c
@@ -859,7 +859,17 @@ CMLOpenImagesLoader* cml_openimages_open(const char* images_dir, const char* ann
         const char* base = strrchr(files[i], '/');
         base = base ? base + 1 : files[i];
         char* dot = strrchr(base, '.');
-        ids[i] = dot ? strndup(base, dot - base) : cml_strdup(base);
+        /* keep allocator family consistent: always use cml_* so cml_openimages_free is safe */
+        if (dot) {
+            size_t n = (size_t)(dot - base);
+            ids[i] = cml_malloc(n + 1);
+            if (ids[i]) {
+                memcpy(ids[i], base, n);
+                ids[i][n] = '\0';
+            }
+        } else {
+            ids[i] = cml_strdup(base);
+        }
         cml_free(files[i]);
     }
     cml_free(files);

--- a/src/datasets/loaders.c
+++ b/src/datasets/loaders.c
@@ -8,6 +8,7 @@
 #include <sys/stat.h>
 #include <ctype.h>
 #include <strings.h>
+#include "alloc/cml_allocator.h"
 
 static int is_image_file(const char* name) {
     const char* ext = strrchr(name, '.');
@@ -58,7 +59,7 @@ static char** list_subdirs(const char* path, int* count) {
     if (!d) { *count = 0; return NULL; }
 
     int cap = 64;
-    char** dirs = malloc(cap * sizeof(char*));
+    char** dirs = cml_malloc(cap * sizeof(char*));
     *count = 0;
 
     struct dirent* ent;
@@ -69,9 +70,9 @@ static char** list_subdirs(const char* path, int* count) {
         if (!is_directory(full)) continue;
         if (*count >= cap) {
             cap *= 2;
-            dirs = realloc(dirs, cap * sizeof(char*));
+            dirs = cml_realloc(dirs, cap * sizeof(char*));
         }
-        dirs[(*count)++] = strdup(ent->d_name);
+        dirs[(*count)++] = cml_strdup(ent->d_name);
     }
     closedir(d);
     qsort(dirs, *count, sizeof(char*), cmp_str);
@@ -83,7 +84,7 @@ static char** list_files_in_dir(const char* path, int (*filter)(const char*), in
     if (!d) { *count = 0; return NULL; }
 
     int cap = 256;
-    char** files = malloc(cap * sizeof(char*));
+    char** files = cml_malloc(cap * sizeof(char*));
     *count = 0;
 
     struct dirent* ent;
@@ -96,9 +97,9 @@ static char** list_files_in_dir(const char* path, int (*filter)(const char*), in
         if (stat(full, &st) != 0 || !S_ISREG(st.st_mode)) continue;
         if (*count >= cap) {
             cap *= 2;
-            files = realloc(files, cap * sizeof(char*));
+            files = cml_realloc(files, cap * sizeof(char*));
         }
-        files[(*count)++] = strdup(full);
+        files[(*count)++] = cml_strdup(full);
     }
     closedir(d);
     qsort(files, *count, sizeof(char*), cmp_str);
@@ -135,18 +136,18 @@ static float* load_ppm_image(const char* path, int target_size, int* out_channel
     if (w <= 0 || h <= 0 || maxval <= 0) { fclose(f); return NULL; }
 
     size_t pixel_count = (size_t)w * h * channels;
-    unsigned char* raw = malloc(pixel_count);
+    unsigned char* raw = cml_malloc(pixel_count);
     if (!raw) { fclose(f); return NULL; }
     if (fread(raw, 1, pixel_count, f) != pixel_count) {
-        free(raw);
+        cml_free(raw);
         fclose(f);
         return NULL;
     }
     fclose(f);
 
     int ts = target_size > 0 ? target_size : h;
-    float* out = malloc((size_t)ts * ts * channels * sizeof(float));
-    if (!out) { free(raw); return NULL; }
+    float* out = cml_malloc((size_t)ts * ts * channels * sizeof(float));
+    if (!out) { cml_free(raw); return NULL; }
 
     float scale_y = (float)h / ts;
     float scale_x = (float)w / ts;
@@ -164,7 +165,7 @@ static float* load_ppm_image(const char* path, int target_size, int* out_channel
         }
     }
 
-    free(raw);
+    cml_free(raw);
     return out;
 }
 
@@ -187,14 +188,14 @@ CMLImageNetLoader* cml_imagenet_open(const char* dir_path, int image_size) {
 
     if (total == 0) {
         LOG_ERROR("[loaders] No image files found in %s", dir_path);
-        for (int i = 0; i < num_classes; i++) free(class_dirs[i]);
-        free(class_dirs);
+        for (int i = 0; i < num_classes; i++) cml_free(class_dirs[i]);
+        cml_free(class_dirs);
         return NULL;
     }
 
-    CMLImageNetLoader* loader = calloc(1, sizeof(CMLImageNetLoader));
-    loader->image_paths = malloc(total * sizeof(char*));
-    loader->labels = malloc(total * sizeof(int));
+    CMLImageNetLoader* loader = cml_calloc(1, sizeof(CMLImageNetLoader));
+    loader->image_paths = cml_malloc(total * sizeof(char*));
+    loader->labels = cml_malloc(total * sizeof(int));
     loader->num_classes = num_classes;
     loader->image_size = image_size > 0 ? image_size : 224;
     loader->num_samples = 0;
@@ -210,14 +211,14 @@ CMLImageNetLoader* cml_imagenet_open(const char* dir_path, int image_size) {
             loader->image_paths[idx] = files[j];
             loader->labels[idx] = c;
         }
-        free(files);
+        cml_free(files);
     }
 
     LOG_INFO("[loaders] ImageNet: %d samples, %d classes from %s",
              loader->num_samples, num_classes, dir_path);
 
-    for (int i = 0; i < num_classes; i++) free(class_dirs[i]);
-    free(class_dirs);
+    for (int i = 0; i < num_classes; i++) cml_free(class_dirs[i]);
+    cml_free(class_dirs);
     return loader;
 }
 
@@ -232,9 +233,9 @@ Dataset* cml_imagenet_load_batch(CMLImageNetLoader* loader, int offset, int batc
     int channels = 3;
     int feat = channels * img_size * img_size;
 
-    float* X = calloc((size_t)actual_size * feat, sizeof(float));
-    float* y = malloc((size_t)actual_size * sizeof(float));
-    if (!X || !y) { free(X); free(y); return NULL; }
+    float* X = cml_calloc((size_t)actual_size * feat, sizeof(float));
+    float* y = cml_malloc((size_t)actual_size * sizeof(float));
+    if (!X || !y) { cml_free(X); cml_free(y); return NULL; }
 
     int loaded = 0;
     for (int i = 0; i < actual_size; i++) {
@@ -245,7 +246,7 @@ Dataset* cml_imagenet_load_batch(CMLImageNetLoader* loader, int offset, int batc
             int src_feat = ch * img_size * img_size;
             if (src_feat <= feat)
                 memcpy(X + (size_t)loaded * feat, pixels, src_feat * sizeof(float));
-            free(pixels);
+            cml_free(pixels);
         }
         y[loaded] = (float)loader->labels[idx];
         loaded++;
@@ -256,18 +257,18 @@ Dataset* cml_imagenet_load_batch(CMLImageNetLoader* loader, int offset, int batc
         ds->name = "imagenet_batch";
         ds->num_classes = loader->num_classes;
     }
-    free(X);
-    free(y);
+    cml_free(X);
+    cml_free(y);
     return ds;
 }
 
 void cml_imagenet_free(CMLImageNetLoader* loader) {
     if (!loader) return;
     for (int i = 0; i < loader->num_samples; i++)
-        free(loader->image_paths[i]);
-    free(loader->image_paths);
-    free(loader->labels);
-    free(loader);
+        cml_free(loader->image_paths[i]);
+    cml_free(loader->image_paths);
+    cml_free(loader->labels);
+    cml_free(loader);
 }
 
 static void collect_audio_recursive(const char* dir, char*** paths, char*** transcripts,
@@ -293,11 +294,11 @@ static void collect_audio_recursive(const char* dir, char*** paths, char*** tran
 
         if (*count >= *cap) {
             *cap *= 2;
-            *paths = realloc(*paths, *cap * sizeof(char*));
-            *transcripts = realloc(*transcripts, *cap * sizeof(char*));
+            *paths = cml_realloc(*paths, *cap * sizeof(char*));
+            *transcripts = cml_realloc(*transcripts, *cap * sizeof(char*));
         }
 
-        (*paths)[*count] = strdup(full);
+        (*paths)[*count] = cml_strdup(full);
 
         char txt_path[2048];
         snprintf(txt_path, sizeof(txt_path), "%s", full);
@@ -352,7 +353,7 @@ static void collect_audio_recursive(const char* dir, char*** paths, char*** tran
             fclose(tf);
         }
 
-        (*transcripts)[*count] = transcript ? transcript : strdup("");
+        (*transcripts)[*count] = transcript ? transcript : cml_strdup("");
         (*count)++;
     }
     closedir(d);
@@ -363,19 +364,19 @@ CMLLibriSpeechLoader* cml_librispeech_open(const char* dir_path) {
 
     int cap = 1024;
     int count = 0;
-    char** paths = malloc(cap * sizeof(char*));
-    char** transcripts = malloc(cap * sizeof(char*));
+    char** paths = cml_malloc(cap * sizeof(char*));
+    char** transcripts = cml_malloc(cap * sizeof(char*));
 
     collect_audio_recursive(dir_path, &paths, &transcripts, &count, &cap);
 
     if (count == 0) {
         LOG_ERROR("[loaders] No audio files found in %s", dir_path);
-        free(paths);
-        free(transcripts);
+        cml_free(paths);
+        cml_free(transcripts);
         return NULL;
     }
 
-    CMLLibriSpeechLoader* loader = calloc(1, sizeof(CMLLibriSpeechLoader));
+    CMLLibriSpeechLoader* loader = cml_calloc(1, sizeof(CMLLibriSpeechLoader));
     loader->audio_paths = paths;
     loader->transcripts = transcripts;
     loader->num_samples = count;
@@ -388,12 +389,12 @@ CMLLibriSpeechLoader* cml_librispeech_open(const char* dir_path) {
 void cml_librispeech_free(CMLLibriSpeechLoader* loader) {
     if (!loader) return;
     for (int i = 0; i < loader->num_samples; i++) {
-        free(loader->audio_paths[i]);
-        free(loader->transcripts[i]);
+        cml_free(loader->audio_paths[i]);
+        cml_free(loader->transcripts[i]);
     }
-    free(loader->audio_paths);
-    free(loader->transcripts);
-    free(loader);
+    cml_free(loader->audio_paths);
+    cml_free(loader->transcripts);
+    cml_free(loader);
 }
 
 static char* json_skip_ws(char* p) {
@@ -464,10 +465,10 @@ CMLSQuADLoader* cml_squad_open(const char* json_path) {
     long fsize = ftell(f);
     rewind(f);
 
-    char* buf = malloc(fsize + 1);
+    char* buf = cml_malloc(fsize + 1);
     if (!buf) { fclose(f); return NULL; }
     if ((long)fread(buf, 1, fsize, f) != fsize) {
-        free(buf);
+        cml_free(buf);
         fclose(f);
         return NULL;
     }
@@ -476,10 +477,10 @@ CMLSQuADLoader* cml_squad_open(const char* json_path) {
 
     int cap = 4096;
     int count = 0;
-    char** contexts = malloc(cap * sizeof(char*));
-    char** questions = malloc(cap * sizeof(char*));
-    char** answers = malloc(cap * sizeof(char*));
-    int* answer_starts = malloc(cap * sizeof(int));
+    char** contexts = cml_malloc(cap * sizeof(char*));
+    char** questions = cml_malloc(cap * sizeof(char*));
+    char** answers = cml_malloc(cap * sizeof(char*));
+    int* answer_starts = cml_malloc(cap * sizeof(int));
 
     /* Find "data" array */
     char* p = strstr(buf, "\"data\"");
@@ -588,19 +589,19 @@ CMLSQuADLoader* cml_squad_open(const char* json_path) {
                     if (question) {
                         if (count >= cap) {
                             cap *= 2;
-                            contexts = realloc(contexts, cap * sizeof(char*));
-                            questions = realloc(questions, cap * sizeof(char*));
-                            answers = realloc(answers, cap * sizeof(char*));
-                            answer_starts = realloc(answer_starts, cap * sizeof(int));
+                            contexts = cml_realloc(contexts, cap * sizeof(char*));
+                            questions = cml_realloc(questions, cap * sizeof(char*));
+                            answers = cml_realloc(answers, cap * sizeof(char*));
+                            answer_starts = cml_realloc(answer_starts, cap * sizeof(int));
                         }
-                        contexts[count] = strdup(context);
+                        contexts[count] = cml_strdup(context);
                         questions[count] = question;
-                        answers[count] = answer ? answer : strdup("");
+                        answers[count] = answer ? answer : cml_strdup("");
                         answer_starts[count] = ans_start;
                         count++;
                     } else {
-                        free(question);
-                        free(answer);
+                        cml_free(question);
+                        cml_free(answer);
                     }
 
                     /* Skip to end of this qa object */
@@ -613,7 +614,7 @@ CMLSQuADLoader* cml_squad_open(const char* json_path) {
                     }
                 }
             }
-            free(context);
+            cml_free(context);
 
             /* Skip to end of this paragraph object */
             int depth = 1;
@@ -635,15 +636,15 @@ CMLSQuADLoader* cml_squad_open(const char* json_path) {
     }
 
 done:
-    free(buf);
+    cml_free(buf);
 
     if (count == 0) {
         LOG_ERROR("[loaders] No QA pairs found in %s", json_path);
-        free(contexts); free(questions); free(answers); free(answer_starts);
+        cml_free(contexts); cml_free(questions); cml_free(answers); cml_free(answer_starts);
         return NULL;
     }
 
-    CMLSQuADLoader* loader = calloc(1, sizeof(CMLSQuADLoader));
+    CMLSQuADLoader* loader = cml_calloc(1, sizeof(CMLSQuADLoader));
     loader->contexts = contexts;
     loader->questions = questions;
     loader->answers = answers;
@@ -657,15 +658,15 @@ done:
 void cml_squad_free(CMLSQuADLoader* loader) {
     if (!loader) return;
     for (int i = 0; i < loader->num_samples; i++) {
-        free(loader->contexts[i]);
-        free(loader->questions[i]);
-        free(loader->answers[i]);
+        cml_free(loader->contexts[i]);
+        cml_free(loader->questions[i]);
+        cml_free(loader->answers[i]);
     }
-    free(loader->contexts);
-    free(loader->questions);
-    free(loader->answers);
-    free(loader->answer_starts);
-    free(loader);
+    cml_free(loader->contexts);
+    cml_free(loader->questions);
+    cml_free(loader->answers);
+    cml_free(loader->answer_starts);
+    cml_free(loader);
 }
 
 /* NIfTI-1 header (simplified, 348 bytes) */
@@ -712,36 +713,36 @@ static float* nifti_read_volume(const char* path, int* dims_out, int* ndim_out) 
     if (offset < 348) offset = 348;
     fseek(f, offset, SEEK_SET);
 
-    float* data = malloc(nvox * sizeof(float));
+    float* data = cml_malloc(nvox * sizeof(float));
     if (!data) { fclose(f); return NULL; }
 
     if (hdr.datatype == 16) { /* FLOAT32 */
         if (fread(data, sizeof(float), nvox, f) != nvox) {
-            free(data); fclose(f); return NULL;
+            cml_free(data); fclose(f); return NULL;
         }
     } else if (hdr.datatype == 4) { /* INT16 */
-        short* raw = malloc(nvox * sizeof(short));
+        short* raw = cml_malloc(nvox * sizeof(short));
         if (!raw || fread(raw, sizeof(short), nvox, f) != nvox) {
-            free(raw); free(data); fclose(f); return NULL;
+            cml_free(raw); cml_free(data); fclose(f); return NULL;
         }
         for (size_t i = 0; i < nvox; i++) data[i] = (float)raw[i];
-        free(raw);
+        cml_free(raw);
     } else if (hdr.datatype == 2) { /* UINT8 */
-        unsigned char* raw = malloc(nvox);
+        unsigned char* raw = cml_malloc(nvox);
         if (!raw || fread(raw, 1, nvox, f) != nvox) {
-            free(raw); free(data); fclose(f); return NULL;
+            cml_free(raw); cml_free(data); fclose(f); return NULL;
         }
         for (size_t i = 0; i < nvox; i++) data[i] = (float)raw[i];
-        free(raw);
+        cml_free(raw);
     } else if (hdr.datatype == 8) { /* INT32 */
-        int* raw = malloc(nvox * sizeof(int));
+        int* raw = cml_malloc(nvox * sizeof(int));
         if (!raw || fread(raw, sizeof(int), nvox, f) != nvox) {
-            free(raw); free(data); fclose(f); return NULL;
+            cml_free(raw); cml_free(data); fclose(f); return NULL;
         }
         for (size_t i = 0; i < nvox; i++) data[i] = (float)raw[i];
-        free(raw);
+        cml_free(raw);
     } else {
-        free(data); fclose(f); return NULL;
+        cml_free(data); fclose(f); return NULL;
     }
 
     fclose(f);
@@ -756,10 +757,10 @@ CMLKiTS19Loader* cml_kits19_open(const char* data_dir) {
     if (!data_dir) return NULL;
 
     int cap = 256, count = 0;
-    char** dirs = malloc(cap * sizeof(char*));
+    char** dirs = cml_malloc(cap * sizeof(char*));
 
     DIR* d = opendir(data_dir);
-    if (!d) { free(dirs); return NULL; }
+    if (!d) { cml_free(dirs); return NULL; }
 
     struct dirent* ent;
     while ((ent = readdir(d)) != NULL) {
@@ -769,21 +770,21 @@ CMLKiTS19Loader* cml_kits19_open(const char* data_dir) {
         if (!is_directory(full)) continue;
         if (count >= cap) {
             cap *= 2;
-            dirs = realloc(dirs, cap * sizeof(char*));
+            dirs = cml_realloc(dirs, cap * sizeof(char*));
         }
-        dirs[count++] = strdup(full);
+        dirs[count++] = cml_strdup(full);
     }
     closedir(d);
 
     if (count == 0) {
         LOG_ERROR("[loaders] No KiTS19 case directories found in %s", data_dir);
-        free(dirs);
+        cml_free(dirs);
         return NULL;
     }
 
     qsort(dirs, count, sizeof(char*), cmp_str);
 
-    CMLKiTS19Loader* loader = calloc(1, sizeof(CMLKiTS19Loader));
+    CMLKiTS19Loader* loader = cml_calloc(1, sizeof(CMLKiTS19Loader));
     loader->case_dirs = dirs;
     loader->num_cases = count;
 
@@ -794,9 +795,9 @@ CMLKiTS19Loader* cml_kits19_open(const char* data_dir) {
 void cml_kits19_free(CMLKiTS19Loader* loader) {
     if (!loader) return;
     for (int i = 0; i < loader->num_cases; i++)
-        free(loader->case_dirs[i]);
-    free(loader->case_dirs);
-    free(loader);
+        cml_free(loader->case_dirs[i]);
+    cml_free(loader->case_dirs);
+    cml_free(loader);
 }
 
 int cml_kits19_load_case(CMLKiTS19Loader* loader, int case_idx,
@@ -819,15 +820,15 @@ int cml_kits19_load_case(CMLKiTS19Loader* loader, int case_idx,
     float* seg_data = nifti_read_volume(seg_path, seg_dims, &seg_ndim);
     if (!seg_data) {
         LOG_ERROR("[loaders] Failed to load segmentation: %s", seg_path);
-        free(vol_data);
+        cml_free(vol_data);
         return -1;
     }
 
     *volume = tensor_from_data(vol_data, vol_dims, vol_ndim, NULL);
     *segmentation = tensor_from_data(seg_data, seg_dims, seg_ndim, NULL);
 
-    free(vol_data);
-    free(seg_data);
+    cml_free(vol_data);
+    cml_free(seg_data);
 
     if (!*volume || !*segmentation) return -1;
     return 0;
@@ -849,25 +850,25 @@ CMLOpenImagesLoader* cml_openimages_open(const char* images_dir, const char* ann
     char** files = list_files_in_dir(images_dir, is_image_file, &count);
     if (count == 0) {
         LOG_ERROR("[loaders] No images found in %s", images_dir);
-        free(files);
+        cml_free(files);
         return NULL;
     }
 
-    char** ids = malloc(count * sizeof(char*));
+    char** ids = cml_malloc(count * sizeof(char*));
     for (int i = 0; i < count; i++) {
         const char* base = strrchr(files[i], '/');
         base = base ? base + 1 : files[i];
         char* dot = strrchr(base, '.');
-        ids[i] = dot ? strndup(base, dot - base) : strdup(base);
-        free(files[i]);
+        ids[i] = dot ? strndup(base, dot - base) : cml_strdup(base);
+        cml_free(files[i]);
     }
-    free(files);
+    cml_free(files);
 
-    CMLOpenImagesLoader* loader = calloc(1, sizeof(CMLOpenImagesLoader));
+    CMLOpenImagesLoader* loader = cml_calloc(1, sizeof(CMLOpenImagesLoader));
     loader->image_ids = ids;
     loader->num_images = count;
-    loader->images_dir = strdup(images_dir);
-    loader->annotations_path = strdup(annotations_csv);
+    loader->images_dir = cml_strdup(images_dir);
+    loader->annotations_path = cml_strdup(annotations_csv);
 
     LOG_INFO("[loaders] OpenImages: %d images from %s", count, images_dir);
     return loader;
@@ -876,11 +877,11 @@ CMLOpenImagesLoader* cml_openimages_open(const char* images_dir, const char* ann
 void cml_openimages_free(CMLOpenImagesLoader* loader) {
     if (!loader) return;
     for (int i = 0; i < loader->num_images; i++)
-        free(loader->image_ids[i]);
-    free(loader->image_ids);
-    free(loader->images_dir);
-    free(loader->annotations_path);
-    free(loader);
+        cml_free(loader->image_ids[i]);
+    cml_free(loader->image_ids);
+    cml_free(loader->images_dir);
+    cml_free(loader->annotations_path);
+    cml_free(loader);
 }
 
 CMLWikipediaLoader* cml_wikipedia_open(const char* dump_dir) {
@@ -890,7 +891,7 @@ CMLWikipediaLoader* cml_wikipedia_open(const char* dump_dir) {
     char** files = list_files_in_dir(dump_dir, is_text_file, &count);
     if (count == 0) {
         LOG_ERROR("[loaders] No text files found in %s", dump_dir);
-        free(files);
+        cml_free(files);
         return NULL;
     }
 
@@ -901,7 +902,7 @@ CMLWikipediaLoader* cml_wikipedia_open(const char* dump_dir) {
             total += st.st_size;
     }
 
-    CMLWikipediaLoader* loader = calloc(1, sizeof(CMLWikipediaLoader));
+    CMLWikipediaLoader* loader = cml_calloc(1, sizeof(CMLWikipediaLoader));
     loader->article_paths = files;
     loader->num_articles = count;
     loader->total_bytes = total;
@@ -914,9 +915,9 @@ CMLWikipediaLoader* cml_wikipedia_open(const char* dump_dir) {
 void cml_wikipedia_free(CMLWikipediaLoader* loader) {
     if (!loader) return;
     for (int i = 0; i < loader->num_articles; i++)
-        free(loader->article_paths[i]);
-    free(loader->article_paths);
-    free(loader);
+        cml_free(loader->article_paths[i]);
+    cml_free(loader->article_paths);
+    cml_free(loader);
 }
 
 int cml_wikipedia_read_chunk(CMLWikipediaLoader* loader, int article_idx,

--- a/src/distributed/comm_backend.c
+++ b/src/distributed/comm_backend.c
@@ -2,6 +2,7 @@
 #include "distributed/distributed.h"
 #include "core/logging.h"
 #include <stdlib.h>
+#include "alloc/cml_allocator.h"
 
 void cml_dist_free_backend(DistCommOps* ops) {
     if (!ops)
@@ -10,7 +11,7 @@ void cml_dist_free_backend(DistCommOps* ops) {
     if (ops->destroy)
         ops->destroy(NULL);
 
-    free(ops);
+    cml_free(ops);
 }
 
 DistCommOps* cml_dist_auto_select_backend(void) {

--- a/src/distributed/data_parallel.c
+++ b/src/distributed/data_parallel.c
@@ -3,6 +3,7 @@
 #include "core/logging.h"
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 #define DEFAULT_BUCKET_SIZE (25 * 1024 * 1024) /* 25MB in bytes */
 
@@ -27,7 +28,7 @@ CMLDataParallel* cml_ddp_create(Module* module, const DDPConfig* config) {
         return NULL;
     }
 
-    CMLDataParallel* ddp = calloc(1, sizeof(CMLDataParallel));
+    CMLDataParallel* ddp = cml_calloc(1, sizeof(CMLDataParallel));
     if (!ddp)
         return NULL;
 
@@ -40,7 +41,7 @@ CMLDataParallel* cml_ddp_create(Module* module, const DDPConfig* config) {
                                            &ddp->num_params, true);
     if (result != 0 || ddp->num_params == 0) {
         LOG_WARNING("DDP: no parameters found in module");
-        free(ddp);
+        cml_free(ddp);
         return NULL;
     }
 
@@ -65,10 +66,10 @@ CMLDataParallel* cml_ddp_create(Module* module, const DDPConfig* config) {
     if (ddp->num_buckets < 1)
         ddp->num_buckets = 1;
 
-    ddp->buckets = calloc(ddp->num_buckets, sizeof(float*));
-    ddp->bucket_sizes = calloc(ddp->num_buckets, sizeof(size_t));
-    ddp->bucket_ready = calloc(ddp->num_buckets, sizeof(bool));
-    ddp->param_to_bucket = calloc(ddp->num_params, sizeof(int));
+    ddp->buckets = cml_calloc(ddp->num_buckets, sizeof(float*));
+    ddp->bucket_sizes = cml_calloc(ddp->num_buckets, sizeof(size_t));
+    ddp->bucket_ready = cml_calloc(ddp->num_buckets, sizeof(bool));
+    ddp->param_to_bucket = cml_calloc(ddp->num_params, sizeof(int));
 
     if (!ddp->buckets || !ddp->bucket_sizes || !ddp->bucket_ready || !ddp->param_to_bucket) {
         cml_ddp_free(ddp);
@@ -97,7 +98,7 @@ CMLDataParallel* cml_ddp_create(Module* module, const DDPConfig* config) {
     /* Allocate bucket buffers */
     for (int b = 0; b < ddp->num_buckets; b++) {
         if (ddp->bucket_sizes[b] > 0) {
-            ddp->buckets[b] = calloc(ddp->bucket_sizes[b], sizeof(float));
+            ddp->buckets[b] = cml_calloc(ddp->bucket_sizes[b], sizeof(float));
             if (!ddp->buckets[b]) {
                 LOG_ERROR("DDP: failed to allocate bucket %d", b);
             }
@@ -209,13 +210,13 @@ void cml_ddp_free(CMLDataParallel* ddp) {
 
     if (ddp->buckets) {
         for (int b = 0; b < ddp->num_buckets; b++)
-            free(ddp->buckets[b]);
-        free(ddp->buckets);
+            cml_free(ddp->buckets[b]);
+        cml_free(ddp->buckets);
     }
 
-    free(ddp->bucket_sizes);
-    free(ddp->bucket_ready);
-    free(ddp->param_to_bucket);
-    free(ddp->all_params);
-    free(ddp);
+    cml_free(ddp->bucket_sizes);
+    cml_free(ddp->bucket_ready);
+    cml_free(ddp->param_to_bucket);
+    cml_free(ddp->all_params);
+    cml_free(ddp);
 }

--- a/src/distributed/distributed.c
+++ b/src/distributed/distributed.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <pthread.h>
+#include "alloc/cml_allocator.h"
 
 static DistProcessGroup* g_default_group = NULL;
 static pthread_mutex_t g_dist_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -32,7 +33,7 @@ int cml_dist_init(DistBackendType backend, int world_size, int rank) {
         rank = rank_env ? atoi(rank_env) : 0;
     }
 
-    g_default_group = calloc(1, sizeof(DistProcessGroup));
+    g_default_group = cml_calloc(1, sizeof(DistProcessGroup));
     if (!g_default_group) {
         pthread_mutex_unlock(&g_dist_mutex);
         return -1;
@@ -69,7 +70,7 @@ int cml_dist_init(DistBackendType backend, int world_size, int rank) {
 
     if (!ops) {
         LOG_ERROR("Failed to create any communication backend");
-        free(g_default_group);
+        cml_free(g_default_group);
         g_default_group = NULL;
         pthread_mutex_unlock(&g_dist_mutex);
         return -1;
@@ -86,7 +87,7 @@ int cml_dist_init(DistBackendType backend, int world_size, int rank) {
         if (result != 0) {
             LOG_ERROR("Backend initialization failed");
             cml_dist_free_backend(ops);
-            free(g_default_group);
+            cml_free(g_default_group);
             g_default_group = NULL;
             pthread_mutex_unlock(&g_dist_mutex);
             return -1;
@@ -134,7 +135,7 @@ void cml_dist_destroy(void) {
         cml_dist_free_backend(g_default_group->ops);
     }
 
-    free(g_default_group);
+    cml_free(g_default_group);
     g_default_group = NULL;
 
     pthread_mutex_unlock(&g_dist_mutex);
@@ -185,7 +186,7 @@ DistWork* cml_dist_allreduce_async(Tensor* tensor, DistReduceOp op) {
     if (!g_default_group->ops->allreduce_async) {
         /* Fall back to sync allreduce */
         int rc = cml_dist_allreduce(tensor, op);
-        DistWork* work = calloc(1, sizeof(DistWork));
+        DistWork* work = cml_calloc(1, sizeof(DistWork));
         if (work) {
             work->completed = true;
             work->error_code = rc;
@@ -211,6 +212,6 @@ int cml_dist_wait(DistWork* work) {
 void cml_dist_work_free(DistWork* work) {
     if (!work)
         return;
-    free(work->internal);
-    free(work);
+    cml_free(work->internal);
+    cml_free(work);
 }

--- a/src/distributed/gloo_backend.c
+++ b/src/distributed/gloo_backend.c
@@ -9,6 +9,7 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 #include <errno.h>
+#include "alloc/cml_allocator.h"
 
 #define GLOO_DEFAULT_PORT_BASE 29500
 #define GLOO_DEFAULT_MASTER_ADDR "127.0.0.1"
@@ -165,7 +166,7 @@ static int gloo_recv(Tensor* tensor, int src_rank, int tag, void* ctx) {
 
 /* Synchronous fallback; wraps result in a completed DistWork handle */
 static DistWork* gloo_allreduce_async(Tensor* tensor, DistReduceOp op, void* ctx) {
-    DistWork* work = calloc(1, sizeof(DistWork));
+    DistWork* work = cml_calloc(1, sizeof(DistWork));
     if (!work)
         return NULL;
 
@@ -300,7 +301,7 @@ static int gloo_init(void* ctx, int world_size, int rank) {
     }
 
     /* Allocate peer fd array */
-    gctx->peer_fds = calloc((size_t)world_size, sizeof(int));
+    gctx->peer_fds = cml_calloc((size_t)world_size, sizeof(int));
     if (!gctx->peer_fds)
         return -1;
     for (int i = 0; i < world_size; i++)
@@ -318,7 +319,7 @@ static int gloo_init(void* ctx, int world_size, int rank) {
     gctx->listen_fd = socket(AF_INET, SOCK_STREAM, 0);
     if (gctx->listen_fd < 0) {
         LOG_ERROR("Gloo init: failed to create listen socket: %s", strerror(errno));
-        free(gctx->peer_fds);
+        cml_free(gctx->peer_fds);
         gctx->peer_fds = NULL;
         return -1;
     }
@@ -337,7 +338,7 @@ static int gloo_init(void* ctx, int world_size, int rank) {
                   gctx->port_base + rank, strerror(errno));
         close(gctx->listen_fd);
         gctx->listen_fd = -1;
-        free(gctx->peer_fds);
+        cml_free(gctx->peer_fds);
         gctx->peer_fds = NULL;
         return -1;
     }
@@ -346,7 +347,7 @@ static int gloo_init(void* ctx, int world_size, int rank) {
         LOG_ERROR("Gloo init: failed to listen: %s", strerror(errno));
         close(gctx->listen_fd);
         gctx->listen_fd = -1;
-        free(gctx->peer_fds);
+        cml_free(gctx->peer_fds);
         gctx->peer_fds = NULL;
         return -1;
     }
@@ -450,7 +451,7 @@ cleanup_error:
         close(gctx->listen_fd);
         gctx->listen_fd = -1;
     }
-    free(gctx->peer_fds);
+    cml_free(gctx->peer_fds);
     gctx->peer_fds = NULL;
     return -1;
 }
@@ -468,7 +469,7 @@ static void gloo_destroy(void* ctx) {
             if (gctx->peer_fds[i] >= 0)
                 close(gctx->peer_fds[i]);
         }
-        free(gctx->peer_fds);
+        cml_free(gctx->peer_fds);
         gctx->peer_fds = NULL;
     }
 
@@ -477,19 +478,19 @@ static void gloo_destroy(void* ctx) {
         gctx->listen_fd = -1;
     }
 
-    free(gctx);
+    cml_free(gctx);
     g_gloo_ctx = NULL;
     LOG_INFO("Gloo backend destroyed");
 }
 
 DistCommOps* cml_dist_create_gloo_backend(void) {
-    DistCommOps* ops = calloc(1, sizeof(DistCommOps));
+    DistCommOps* ops = cml_calloc(1, sizeof(DistCommOps));
     if (!ops)
         return NULL;
 
-    GlooContext* gctx = calloc(1, sizeof(GlooContext));
+    GlooContext* gctx = cml_calloc(1, sizeof(GlooContext));
     if (!gctx) {
-        free(ops);
+        cml_free(ops);
         return NULL;
     }
     gctx->listen_fd = -1;

--- a/src/distributed/ib_transport.c
+++ b/src/distributed/ib_transport.c
@@ -9,6 +9,7 @@
 #include <arpa/inet.h>
 #include <sys/socket.h>
 #include <netdb.h>
+#include "alloc/cml_allocator.h"
 
 #define IBV_QPT_RC          2
 #define IBV_QPS_INIT        1
@@ -255,7 +256,7 @@ CMLIBTransport* cml_ib_create(int rank, int world_size) {
         return NULL;
     }
 
-    CMLIBTransport* ib = calloc(1, sizeof(CMLIBTransport));
+    CMLIBTransport* ib = cml_calloc(1, sizeof(CMLIBTransport));
     if (!ib) {
         ib_api.destroy_cq(cq);
         ib_api.dealloc_pd(pd);
@@ -273,13 +274,13 @@ CMLIBTransport* cml_ib_create(int rank, int world_size) {
     ib->num_peers = world_size - 1;
     ib->connected = false;
 
-    ib->qps = calloc((size_t)world_size, sizeof(void*));
+    ib->qps = cml_calloc((size_t)world_size, sizeof(void*));
     if (!ib->qps) {
         cml_ib_free(ib);
         return NULL;
     }
 
-    ib->qp_nums = calloc((size_t)world_size, sizeof(uint32_t));
+    ib->qp_nums = cml_calloc((size_t)world_size, sizeof(uint32_t));
     if (!ib->qp_nums) {
         cml_ib_free(ib);
         return NULL;
@@ -501,17 +502,17 @@ void cml_ib_free(CMLIBTransport* ib) {
         for (int i = 0; i < ib->world_size; i++) {
             if (ib->qps[i]) ib_api.destroy_qp(ib->qps[i]);
         }
-        free(ib->qps);
+        cml_free(ib->qps);
     }
 
-    free(ib->qp_nums);
+    cml_free(ib->qp_nums);
 
     if (ib->cq) ib_api.destroy_cq(ib->cq);
     if (ib->pd) ib_api.dealloc_pd(ib->pd);
     if (ib->ib_ctx) ib_api.close_device(ib->ib_ctx);
     if (ib->ib_lib) dlclose(ib->ib_lib);
 
-    free(ib);
+    cml_free(ib);
 }
 
 static int poll_completion(CMLIBTransport* ib, int timeout_ms) {
@@ -627,7 +628,7 @@ int cml_ib_allreduce(CMLIBTransport* ib, void* buf, size_t size, int elem_size) 
     int left  = (rank - 1 + ws) % ws;
     int right = (rank + 1) % ws;
 
-    float* recv_buf = malloc(chunk_bytes);
+    float* recv_buf = cml_malloc(chunk_bytes);
     if (!recv_buf) return -1;
 
     float* data = (float*)buf;
@@ -673,7 +674,7 @@ int cml_ib_allreduce(CMLIBTransport* ib, void* buf, size_t size, int elem_size) 
             cml_ib_recv(ib, left, data + recv_off, rc * (size_t)elem_size);
     }
 
-    free(recv_buf);
+    cml_free(recv_buf);
     return 0;
 }
 
@@ -701,7 +702,7 @@ CMLIBMemReg* cml_ib_register_memory(CMLIBTransport* ib, void* addr, size_t size)
         return NULL;
     }
 
-    CMLIBMemReg* reg = calloc(1, sizeof(CMLIBMemReg));
+    CMLIBMemReg* reg = cml_calloc(1, sizeof(CMLIBMemReg));
     if (!reg) {
         ib_api.dereg_mr(mr);
         return NULL;
@@ -720,5 +721,5 @@ void cml_ib_deregister_memory(CMLIBTransport* ib, CMLIBMemReg* reg) {
     (void)ib;
     if (!reg) return;
     if (reg->mr) ib_api.dereg_mr(reg->mr);
-    free(reg);
+    cml_free(reg);
 }

--- a/src/distributed/mpi_backend.c
+++ b/src/distributed/mpi_backend.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <dlfcn.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 /* MPI constants */
 #define CML_MPI_COMM_WORLD ((void*)0x44000000)
@@ -57,7 +58,7 @@ static int mpi_allreduce(Tensor* tensor, DistReduceOp op, void* ctx) {
     int mpi_op = mpi_op_to_const(op);
 
     float* sendbuf = (float*)tensor->data;
-    float* recvbuf = (float*)malloc(tensor->numel * sizeof(float));
+    float* recvbuf = (float*)cml_malloc(tensor->numel * sizeof(float));
     if (!recvbuf)
         return -1;
 
@@ -67,7 +68,7 @@ static int mpi_allreduce(Tensor* tensor, DistReduceOp op, void* ctx) {
     if (result == 0)
         memcpy(tensor->data, recvbuf, tensor->numel * sizeof(float));
 
-    free(recvbuf);
+    cml_free(recvbuf);
 
     if (op == DIST_REDUCE_AVG && result == 0) {
         float scale = 1.0f / (float)cml_dist_get_world_size();
@@ -104,7 +105,7 @@ static int mpi_allgather(Tensor** output, Tensor* input, void* ctx) {
     int world_size = cml_dist_get_world_size();
     int sendcount = (int)input->numel;
 
-    float* recvbuf = (float*)malloc((size_t)world_size * sendcount * sizeof(float));
+    float* recvbuf = (float*)cml_malloc((size_t)world_size * sendcount * sizeof(float));
     if (!recvbuf)
         return -1;
 
@@ -121,7 +122,7 @@ static int mpi_allgather(Tensor** output, Tensor* input, void* ctx) {
         }
     }
 
-    free(recvbuf);
+    cml_free(recvbuf);
     return result;
 }
 
@@ -135,7 +136,7 @@ static int mpi_reduce_scatter(Tensor* output, Tensor* input, DistReduceOp op, vo
     int chunk_size = (int)(input->numel / (size_t)world_size);
     int mpi_op = mpi_op_to_const(op);
 
-    int* recvcounts = (int*)malloc((size_t)world_size * sizeof(int));
+    int* recvcounts = (int*)cml_malloc((size_t)world_size * sizeof(int));
     if (!recvcounts)
         return -1;
 
@@ -146,7 +147,7 @@ static int mpi_reduce_scatter(Tensor* output, Tensor* input, DistReduceOp op, vo
                                           recvcounts, CML_MPI_FLOAT,
                                           mpi_op, CML_MPI_COMM_WORLD);
 
-    free(recvcounts);
+    cml_free(recvcounts);
 
     if (op == DIST_REDUCE_AVG && result == 0) {
         float scale = 1.0f / (float)world_size;
@@ -181,24 +182,24 @@ static DistWork* mpi_allreduce_async(Tensor* tensor, DistReduceOp op, void* ctx)
     if (!mpi || !tensor || !tensor->data)
         return NULL;
 
-    DistWork* work = calloc(1, sizeof(DistWork));
+    DistWork* work = cml_calloc(1, sizeof(DistWork));
     if (!work)
         return NULL;
 
     int mpi_op = mpi_op_to_const(op);
 
     if (mpi->MPI_Iallreduce) {
-        float* recvbuf = (float*)malloc(tensor->numel * sizeof(float));
+        float* recvbuf = (float*)cml_malloc(tensor->numel * sizeof(float));
         if (!recvbuf) {
-            free(work);
+            cml_free(work);
             return NULL;
         }
 
         /* Allocate MPI_Request handle (opaque, typically pointer-sized) */
-        void* request = calloc(1, 128);
+        void* request = cml_calloc(1, 128);
         if (!request) {
-            free(recvbuf);
-            free(work);
+            cml_free(recvbuf);
+            cml_free(work);
             return NULL;
         }
 
@@ -207,9 +208,9 @@ static DistWork* mpi_allreduce_async(Tensor* tensor, DistReduceOp op, void* ctx)
                                            mpi_op, CML_MPI_COMM_WORLD, request);
 
         if (result != 0) {
-            free(request);
-            free(recvbuf);
-            free(work);
+            cml_free(request);
+            cml_free(recvbuf);
+            cml_free(work);
             return NULL;
         }
 
@@ -267,7 +268,7 @@ static int mpi_wait(DistWork* work) {
         if (recvbuf && tensor && tensor->data && numel > 0)
             memcpy(tensor->data, recvbuf, numel * sizeof(float));
 
-        free(recvbuf);
+        cml_free(recvbuf);
     }
 
     work->completed = true;
@@ -307,7 +308,7 @@ static void mpi_destroy(void* ctx) {
     if (g_mpi_ctx == mpi)
         g_mpi_ctx = NULL;
 
-    free(mpi);
+    cml_free(mpi);
 }
 
 DistCommOps* cml_dist_create_mpi_backend(void) {
@@ -323,7 +324,7 @@ DistCommOps* cml_dist_create_mpi_backend(void) {
         return NULL;
     }
 
-    MPIContext* mpi = calloc(1, sizeof(MPIContext));
+    MPIContext* mpi = cml_calloc(1, sizeof(MPIContext));
     if (!mpi) {
         dlclose(handle);
         return NULL;
@@ -348,17 +349,17 @@ DistCommOps* cml_dist_create_mpi_backend(void) {
     if (!mpi->MPI_Allreduce) {
         LOG_WARNING("MPI loaded but missing MPI_Allreduce");
         dlclose(handle);
-        free(mpi);
+        cml_free(mpi);
         return NULL;
     }
 
     g_mpi_ctx = mpi;
 
-    DistCommOps* ops = calloc(1, sizeof(DistCommOps));
+    DistCommOps* ops = cml_calloc(1, sizeof(DistCommOps));
     if (!ops) {
         g_mpi_ctx = NULL;
         dlclose(handle);
-        free(mpi);
+        cml_free(mpi);
         return NULL;
     }
 

--- a/src/distributed/nccl_backend.c
+++ b/src/distributed/nccl_backend.c
@@ -9,6 +9,7 @@
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
+#include "alloc/cml_allocator.h"
 
 #define NCCL_UNIQUE_ID_BYTES 128
 #define NCCL_BOOTSTRAP_DEFAULT_ADDR "127.0.0.1"
@@ -263,7 +264,7 @@ static int nccl_allgather(Tensor** output, Tensor* input, void* ctx) {
     /* Allocate flat gather buffer: world_size * input->numel elements */
     size_t chunk_size = input->numel;
     size_t total_size = chunk_size * (size_t)world_size;
-    float* gather_buf = (float*)malloc(total_size * sizeof(float));
+    float* gather_buf = (float*)cml_malloc(total_size * sizeof(float));
     if (!gather_buf)
         return -1;
 
@@ -273,7 +274,7 @@ static int nccl_allgather(Tensor** output, Tensor* input, void* ctx) {
                                       nccl->stream);
 
     if (result != 0) {
-        free(gather_buf);
+        cml_free(gather_buf);
         return result;
     }
 
@@ -285,7 +286,7 @@ static int nccl_allgather(Tensor** output, Tensor* input, void* ctx) {
         }
     }
 
-    free(gather_buf);
+    cml_free(gather_buf);
     return 0;
 }
 
@@ -384,7 +385,7 @@ static DistWork* nccl_allreduce_async(Tensor* tensor, DistReduceOp op, void* ctx
                                       0 /* ncclFloat32 */, nccl_op, nccl->comm,
                                       nccl->stream);
 
-    DistWork* work = (DistWork*)calloc(1, sizeof(DistWork));
+    DistWork* work = (DistWork*)cml_calloc(1, sizeof(DistWork));
     if (!work)
         return NULL;
 
@@ -468,7 +469,7 @@ static void nccl_destroy(void* ctx) {
     if (g_nccl_ctx == nccl)
         g_nccl_ctx = NULL;
 
-    free(nccl);
+    cml_free(nccl);
 }
 
 DistCommOps* cml_dist_create_nccl_backend(void) {
@@ -482,7 +483,7 @@ DistCommOps* cml_dist_create_nccl_backend(void) {
         return NULL;
     }
 
-    NCCLContext* nccl = calloc(1, sizeof(NCCLContext));
+    NCCLContext* nccl = cml_calloc(1, sizeof(NCCLContext));
     if (!nccl) {
         dlclose(handle);
         return NULL;
@@ -508,14 +509,14 @@ DistCommOps* cml_dist_create_nccl_backend(void) {
     if (!nccl->ncclAllReduce) {
         LOG_WARNING("NCCL loaded but missing ncclAllReduce");
         dlclose(handle);
-        free(nccl);
+        cml_free(nccl);
         return NULL;
     }
 
-    DistCommOps* ops = calloc(1, sizeof(DistCommOps));
+    DistCommOps* ops = cml_calloc(1, sizeof(DistCommOps));
     if (!ops) {
         dlclose(handle);
-        free(nccl);
+        cml_free(nccl);
         return NULL;
     }
 

--- a/src/distributed/pipeline_parallel.c
+++ b/src/distributed/pipeline_parallel.c
@@ -4,6 +4,7 @@
 #include "core/logging.h"
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 CMLPipelineParallel* cml_pipeline_create(PipelineStage* stages, int num_stages,
                                           const PipelineConfig* config) {
@@ -19,14 +20,14 @@ CMLPipelineParallel* cml_pipeline_create(PipelineStage* stages, int num_stages,
         }
     }
 
-    CMLPipelineParallel* pipeline = calloc(1, sizeof(CMLPipelineParallel));
+    CMLPipelineParallel* pipeline = cml_calloc(1, sizeof(CMLPipelineParallel));
     if (!pipeline)
         return NULL;
 
     pipeline->num_stages = num_stages;
-    pipeline->stages = malloc(num_stages * sizeof(PipelineStage));
+    pipeline->stages = cml_malloc(num_stages * sizeof(PipelineStage));
     if (!pipeline->stages) {
-        free(pipeline);
+        cml_free(pipeline);
         return NULL;
     }
     memcpy(pipeline->stages, stages, num_stages * sizeof(PipelineStage));
@@ -43,21 +44,21 @@ CMLPipelineParallel* cml_pipeline_create(PipelineStage* stages, int num_stages,
     pipeline->group = cml_dist_get_default_group();
 
     /* Allocate micro-batch output buffers: [num_stages][num_micro_batches] */
-    pipeline->micro_batch_outputs = calloc(num_stages, sizeof(Tensor**));
+    pipeline->micro_batch_outputs = cml_calloc(num_stages, sizeof(Tensor**));
     if (!pipeline->micro_batch_outputs) {
-        free(pipeline->stages);
-        free(pipeline);
+        cml_free(pipeline->stages);
+        cml_free(pipeline);
         return NULL;
     }
     for (int s = 0; s < num_stages; s++) {
-        pipeline->micro_batch_outputs[s] = calloc(pipeline->num_micro_batches, sizeof(Tensor*));
+        pipeline->micro_batch_outputs[s] = cml_calloc(pipeline->num_micro_batches, sizeof(Tensor*));
         if (!pipeline->micro_batch_outputs[s]) {
             LOG_ERROR("Pipeline: failed to allocate micro-batch buffer for stage %d", s);
             for (int j = 0; j < s; j++)
-                free(pipeline->micro_batch_outputs[j]);
-            free(pipeline->micro_batch_outputs);
-            free(pipeline->stages);
-            free(pipeline);
+                cml_free(pipeline->micro_batch_outputs[j]);
+            cml_free(pipeline->micro_batch_outputs);
+            cml_free(pipeline->stages);
+            cml_free(pipeline);
             return NULL;
         }
     }
@@ -82,22 +83,22 @@ static Tensor* slice_batch_dim(Tensor* input, int start, int end) {
         return NULL; /* overflow */
     }
 
-    float* slice_data = malloc(slice_elems * sizeof(float));
+    float* slice_data = cml_malloc(slice_elems * sizeof(float));
     if (!slice_data) return NULL;
 
     memcpy(slice_data, src + (size_t)start * row_elems, slice_elems * sizeof(float));
 
     /* Build shape: same as input but dim 0 = slice_rows */
-    int* shape = malloc(input->ndim * sizeof(int));
-    if (!shape) { free(slice_data); return NULL; }
+    int* shape = cml_malloc(input->ndim * sizeof(int));
+    if (!shape) { cml_free(slice_data); return NULL; }
     memcpy(shape, input->shape, input->ndim * sizeof(int));
     shape[0] = slice_rows;
 
     TensorConfig cfg = {.dtype = DTYPE_FLOAT32, .device = DEVICE_CPU,
                         .has_dtype = true, .has_device = true};
     Tensor* result = tensor_from_data(slice_data, shape, input->ndim, &cfg);
-    free(slice_data);
-    free(shape);
+    cml_free(slice_data);
+    cml_free(shape);
     return result;
 }
 
@@ -119,29 +120,29 @@ static Tensor* concat_batch_dim(Tensor** tensors, int count) {
     if (row_elems > 0 && total_elems / row_elems != total_batch) {
         return NULL; /* overflow */
     }
-    float* out_data = malloc(total_elems * sizeof(float));
+    float* out_data = cml_malloc(total_elems * sizeof(float));
     if (!out_data) return NULL;
 
     size_t offset = 0;
     for (int i = 0; i < count; i++) {
         tensor_ensure_executed(tensors[i]);
         const float* src = (const float*)tensor_data_ptr(tensors[i]);
-        if (!src) { free(out_data); return NULL; }
+        if (!src) { cml_free(out_data); return NULL; }
         size_t chunk = tensors[i]->numel * sizeof(float);
         memcpy(out_data + offset, src, chunk);
         offset += tensors[i]->numel;
     }
 
-    int* shape = malloc(ndim * sizeof(int));
-    if (!shape) { free(out_data); return NULL; }
+    int* shape = cml_malloc(ndim * sizeof(int));
+    if (!shape) { cml_free(out_data); return NULL; }
     memcpy(shape, tensors[0]->shape, ndim * sizeof(int));
     shape[0] = (int)total_batch;
 
     TensorConfig cfg = {.dtype = DTYPE_FLOAT32, .device = DEVICE_CPU,
                         .has_dtype = true, .has_device = true};
     Tensor* result = tensor_from_data(out_data, shape, ndim, &cfg);
-    free(out_data);
-    free(shape);
+    cml_free(out_data);
+    cml_free(shape);
     return result;
 }
 
@@ -169,7 +170,7 @@ Tensor* cml_pipeline_forward(CMLPipelineParallel* pipeline, Tensor* input) {
     if (mb_size < 1) mb_size = 1;
 
     /* Split input into micro-batches along dim 0 */
-    Tensor** input_slices = malloc(num_mb * sizeof(Tensor*));
+    Tensor** input_slices = cml_malloc(num_mb * sizeof(Tensor*));
     if (!input_slices) return NULL;
 
     for (int mb = 0; mb < num_mb; mb++) {
@@ -180,7 +181,7 @@ Tensor* cml_pipeline_forward(CMLPipelineParallel* pipeline, Tensor* input) {
             LOG_ERROR("Pipeline forward: failed to slice input for micro-batch %d", mb);
             for (int j = 0; j < mb; j++)
                 tensor_free(input_slices[j]);
-            free(input_slices);
+            cml_free(input_slices);
             return NULL;
         }
     }
@@ -202,7 +203,7 @@ Tensor* cml_pipeline_forward(CMLPipelineParallel* pipeline, Tensor* input) {
                 LOG_ERROR("Pipeline forward: NULL input at stage %d, micro-batch %d", stage, mb);
                 for (int j = 0; j < num_mb; j++)
                     tensor_free(input_slices[j]);
-                free(input_slices);
+                cml_free(input_slices);
                 return NULL;
             }
 
@@ -212,7 +213,7 @@ Tensor* cml_pipeline_forward(CMLPipelineParallel* pipeline, Tensor* input) {
                           stage, mb);
                 for (int j = 0; j < num_mb; j++)
                     tensor_free(input_slices[j]);
-                free(input_slices);
+                cml_free(input_slices);
                 return NULL;
             }
 
@@ -223,7 +224,7 @@ Tensor* cml_pipeline_forward(CMLPipelineParallel* pipeline, Tensor* input) {
     /* Free input slices (not needed after stage 0) */
     for (int mb = 0; mb < num_mb; mb++)
         tensor_free(input_slices[mb]);
-    free(input_slices);
+    cml_free(input_slices);
 
     /* Concatenate the final stage's micro-batch outputs along dim 0 */
     Tensor* final_output = concat_batch_dim(
@@ -253,7 +254,7 @@ int cml_pipeline_backward(CMLPipelineParallel* pipeline, Tensor* grad_output) {
     if (mb_size < 1) mb_size = 1;
 
     /* Split grad_output into micro-batch gradients matching the forward split */
-    Tensor** grad_slices = malloc(num_mb * sizeof(Tensor*));
+    Tensor** grad_slices = cml_malloc(num_mb * sizeof(Tensor*));
     if (!grad_slices) return -1;
 
     for (int mb = 0; mb < num_mb; mb++) {
@@ -264,7 +265,7 @@ int cml_pipeline_backward(CMLPipelineParallel* pipeline, Tensor* grad_output) {
             LOG_ERROR("Pipeline backward: failed to slice grad for micro-batch %d", mb);
             for (int j = 0; j < mb; j++)
                 tensor_free(grad_slices[j]);
-            free(grad_slices);
+            cml_free(grad_slices);
             return -1;
         }
     }
@@ -296,7 +297,7 @@ int cml_pipeline_backward(CMLPipelineParallel* pipeline, Tensor* grad_output) {
         }
     }
 
-    free(grad_slices);
+    cml_free(grad_slices);
 
     LOG_DEBUG("Pipeline backward completed: %d stages, %d micro-batches",
               num_stages, num_mb);
@@ -314,12 +315,12 @@ void cml_pipeline_free(CMLPipelineParallel* pipeline) {
                         tensor_free(pipeline->micro_batch_outputs[s][mb]);
                     }
                 }
-                free(pipeline->micro_batch_outputs[s]);
+                cml_free(pipeline->micro_batch_outputs[s]);
             }
         }
-        free(pipeline->micro_batch_outputs);
+        cml_free(pipeline->micro_batch_outputs);
     }
 
-    free(pipeline->stages);
-    free(pipeline);
+    cml_free(pipeline->stages);
+    cml_free(pipeline);
 }

--- a/src/distributed/ring_allreduce.c
+++ b/src/distributed/ring_allreduce.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 static void apply_reduce_op(float* dst, const float* src, size_t n, DistReduceOp op) {
     for (size_t i = 0; i < n; i++) {
@@ -42,7 +43,7 @@ int cml_ring_allreduce(float* data, size_t count, int world_size, int rank,
         return -1;
 
     size_t chunk_size = (count + (size_t)world_size - 1) / (size_t)world_size;
-    float* recv_buf = (float*)malloc(chunk_size * sizeof(float));
+    float* recv_buf = (float*)cml_malloc(chunk_size * sizeof(float));
     if (!recv_buf) return -1;
 
     int left  = (rank - 1 + world_size) % world_size;
@@ -87,10 +88,10 @@ int cml_ring_allreduce(float* data, size_t count, int world_size, int rank,
 
         /* Send to right neighbor, recv from left neighbor */
         int ret = ops->send(&send_tensor, right, step, ctx);
-        if (ret != 0) { free(recv_buf); return -1; }
+        if (ret != 0) { cml_free(recv_buf); return -1; }
 
         ret = ops->recv(&recv_tensor, left, step, ctx);
-        if (ret != 0) { free(recv_buf); return -1; }
+        if (ret != 0) { cml_free(recv_buf); return -1; }
 
         /* Reduce received data into local chunk */
         if (recv_count > 0) {
@@ -131,10 +132,10 @@ int cml_ring_allreduce(float* data, size_t count, int world_size, int rank,
         recv_tensor.dtype = DTYPE_FLOAT32;
 
         int ret = ops->send(&send_tensor, right, world_size + step, ctx);
-        if (ret != 0) { free(recv_buf); return -1; }
+        if (ret != 0) { cml_free(recv_buf); return -1; }
 
         ret = ops->recv(&recv_tensor, left, world_size + step, ctx);
-        if (ret != 0) { free(recv_buf); return -1; }
+        if (ret != 0) { cml_free(recv_buf); return -1; }
     }
 
     /* Apply averaging if requested */
@@ -144,6 +145,6 @@ int cml_ring_allreduce(float* data, size_t count, int world_size, int rank,
             data[i] *= scale;
     }
 
-    free(recv_buf);
+    cml_free(recv_buf);
     return 0;
 }

--- a/src/distributed/tensor_parallel.c
+++ b/src/distributed/tensor_parallel.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 /* output[i][j] = sum_k input[i][k] * weight[j][k]  (weight stored as [N,K]) */
 static void matmul_weight_transposed(const float* input, int M, int K,
@@ -67,7 +68,7 @@ Tensor* cml_tp_shard_weight(Tensor* weight, int dim, int tp_size, int tp_rank)
         int shard_rows = rows / tp_size;
         int shard_shape[2] = {shard_rows, cols};
         size_t shard_elems = (size_t)shard_rows * cols;
-        float* shard_data = (float*)malloc(shard_elems * sizeof(float));
+        float* shard_data = (float*)cml_malloc(shard_elems * sizeof(float));
         if (!shard_data) {
             LOG_ERROR("cml_tp_shard_weight: allocation failed");
             return NULL;
@@ -76,14 +77,14 @@ Tensor* cml_tp_shard_weight(Tensor* weight, int dim, int tp_size, int tp_rank)
         memcpy(shard_data, src + offset, shard_elems * sizeof(float));
 
         Tensor* shard = tensor_from_data(shard_data, shard_shape, 2, &cfg);
-        free(shard_data);
+        cml_free(shard_data);
         return shard;
     } else {
         /* Column sharding: each rank gets shard_cols consecutive columns */
         int shard_cols = cols / tp_size;
         int shard_shape[2] = {rows, shard_cols};
         size_t shard_elems = (size_t)rows * shard_cols;
-        float* shard_data = (float*)malloc(shard_elems * sizeof(float));
+        float* shard_data = (float*)cml_malloc(shard_elems * sizeof(float));
         if (!shard_data) {
             LOG_ERROR("cml_tp_shard_weight: allocation failed");
             return NULL;
@@ -96,7 +97,7 @@ Tensor* cml_tp_shard_weight(Tensor* weight, int dim, int tp_size, int tp_rank)
         }
 
         Tensor* shard = tensor_from_data(shard_data, shard_shape, 2, &cfg);
-        free(shard_data);
+        cml_free(shard_data);
         return shard;
     }
 }
@@ -130,7 +131,7 @@ CMLColumnParallelLinear* cml_column_parallel_create(Tensor* full_weight,
         return NULL;
     }
 
-    CMLColumnParallelLinear* cp = (CMLColumnParallelLinear*)calloc(1, sizeof(*cp));
+    CMLColumnParallelLinear* cp = (CMLColumnParallelLinear*)cml_calloc(1, sizeof(*cp));
     if (!cp) {
         LOG_ERROR("cml_column_parallel_create: allocation failed");
         return NULL;
@@ -145,7 +146,7 @@ CMLColumnParallelLinear* cml_column_parallel_create(Tensor* full_weight,
     cp->weight = cml_tp_shard_weight(full_weight, 0, tp_size, tp_rank);
     if (!cp->weight) {
         LOG_ERROR("cml_column_parallel_create: failed to shard weight");
-        free(cp);
+        cml_free(cp);
         return NULL;
     }
 
@@ -156,17 +157,17 @@ CMLColumnParallelLinear* cml_column_parallel_create(Tensor* full_weight,
         if (!bias_src) {
             LOG_ERROR("cml_column_parallel_create: failed to get bias data");
             tensor_free(cp->weight);
-            free(cp);
+            cml_free(cp);
             return NULL;
         }
 
         int shard_out = out_features / tp_size;
         int bias_shape[1] = {shard_out};
-        float* bias_data = (float*)malloc((size_t)shard_out * sizeof(float));
+        float* bias_data = (float*)cml_malloc((size_t)shard_out * sizeof(float));
         if (!bias_data) {
             LOG_ERROR("cml_column_parallel_create: bias allocation failed");
             tensor_free(cp->weight);
-            free(cp);
+            cml_free(cp);
             return NULL;
         }
         memcpy(bias_data, bias_src + tp_rank * shard_out, (size_t)shard_out * sizeof(float));
@@ -174,11 +175,11 @@ CMLColumnParallelLinear* cml_column_parallel_create(Tensor* full_weight,
         TensorConfig cfg = {.dtype = DTYPE_FLOAT32, .device = DEVICE_CPU,
                             .has_dtype = true, .has_device = true};
         cp->bias = tensor_from_data(bias_data, bias_shape, 1, &cfg);
-        free(bias_data);
+        cml_free(bias_data);
         if (!cp->bias) {
             LOG_ERROR("cml_column_parallel_create: failed to create bias tensor");
             tensor_free(cp->weight);
-            free(cp);
+            cml_free(cp);
             return NULL;
         }
     } else {
@@ -196,7 +197,7 @@ void cml_column_parallel_free(CMLColumnParallelLinear* cp)
     if (!cp) return;
     if (cp->weight) tensor_free(cp->weight);
     if (cp->bias)   tensor_free(cp->bias);
-    free(cp);
+    cml_free(cp);
 }
 
 Tensor* cml_column_parallel_forward(CMLColumnParallelLinear* cp, Tensor* input)
@@ -231,7 +232,7 @@ Tensor* cml_column_parallel_forward(CMLColumnParallelLinear* cp, Tensor* input)
     }
 
     size_t out_elems = (size_t)batch * local_out;
-    float* out_data = (float*)malloc(out_elems * sizeof(float));
+    float* out_data = (float*)cml_malloc(out_elems * sizeof(float));
     if (!out_data) {
         LOG_ERROR("cml_column_parallel_forward: allocation failed");
         return NULL;
@@ -258,7 +259,7 @@ Tensor* cml_column_parallel_forward(CMLColumnParallelLinear* cp, Tensor* input)
     TensorConfig cfg = {.dtype = DTYPE_FLOAT32, .device = DEVICE_CPU,
                         .has_dtype = true, .has_device = true};
     Tensor* output = tensor_from_data(out_data, out_shape, 2, &cfg);
-    free(out_data);
+    cml_free(out_data);
     return output;
 }
 
@@ -291,7 +292,7 @@ CMLRowParallelLinear* cml_row_parallel_create(Tensor* full_weight,
         return NULL;
     }
 
-    CMLRowParallelLinear* rp = (CMLRowParallelLinear*)calloc(1, sizeof(*rp));
+    CMLRowParallelLinear* rp = (CMLRowParallelLinear*)cml_calloc(1, sizeof(*rp));
     if (!rp) {
         LOG_ERROR("cml_row_parallel_create: allocation failed");
         return NULL;
@@ -306,7 +307,7 @@ CMLRowParallelLinear* cml_row_parallel_create(Tensor* full_weight,
     rp->weight = cml_tp_shard_weight(full_weight, 1, tp_size, tp_rank);
     if (!rp->weight) {
         LOG_ERROR("cml_row_parallel_create: failed to shard weight");
-        free(rp);
+        cml_free(rp);
         return NULL;
     }
 
@@ -317,16 +318,16 @@ CMLRowParallelLinear* cml_row_parallel_create(Tensor* full_weight,
         if (!bias_src) {
             LOG_ERROR("cml_row_parallel_create: failed to get bias data");
             tensor_free(rp->weight);
-            free(rp);
+            cml_free(rp);
             return NULL;
         }
 
         int bias_shape[1] = {out_features};
-        float* bias_data = (float*)malloc((size_t)out_features * sizeof(float));
+        float* bias_data = (float*)cml_malloc((size_t)out_features * sizeof(float));
         if (!bias_data) {
             LOG_ERROR("cml_row_parallel_create: bias allocation failed");
             tensor_free(rp->weight);
-            free(rp);
+            cml_free(rp);
             return NULL;
         }
         memcpy(bias_data, bias_src, (size_t)out_features * sizeof(float));
@@ -334,11 +335,11 @@ CMLRowParallelLinear* cml_row_parallel_create(Tensor* full_weight,
         TensorConfig cfg = {.dtype = DTYPE_FLOAT32, .device = DEVICE_CPU,
                             .has_dtype = true, .has_device = true};
         rp->bias = tensor_from_data(bias_data, bias_shape, 1, &cfg);
-        free(bias_data);
+        cml_free(bias_data);
         if (!rp->bias) {
             LOG_ERROR("cml_row_parallel_create: failed to create bias tensor");
             tensor_free(rp->weight);
-            free(rp);
+            cml_free(rp);
             return NULL;
         }
     } else {
@@ -356,7 +357,7 @@ void cml_row_parallel_free(CMLRowParallelLinear* rp)
     if (!rp) return;
     if (rp->weight) tensor_free(rp->weight);
     if (rp->bias)   tensor_free(rp->bias);
-    free(rp);
+    cml_free(rp);
 }
 
 Tensor* cml_row_parallel_forward(CMLRowParallelLinear* rp, Tensor* input)
@@ -392,7 +393,7 @@ Tensor* cml_row_parallel_forward(CMLRowParallelLinear* rp, Tensor* input)
     }
 
     size_t out_elems = (size_t)batch * out_features;
-    float* out_data = (float*)malloc(out_elems * sizeof(float));
+    float* out_data = (float*)cml_malloc(out_elems * sizeof(float));
     if (!out_data) {
         LOG_ERROR("cml_row_parallel_forward: allocation failed");
         return NULL;
@@ -422,7 +423,7 @@ Tensor* cml_row_parallel_forward(CMLRowParallelLinear* rp, Tensor* input)
     TensorConfig cfg = {.dtype = DTYPE_FLOAT32, .device = DEVICE_CPU,
                         .has_dtype = true, .has_device = true};
     Tensor* output = tensor_from_data(out_data, out_shape, 2, &cfg);
-    free(out_data);
+    cml_free(out_data);
     return output;
 }
 
@@ -459,7 +460,7 @@ Tensor* cml_tp_all_reduce_sum(Tensor** partials, int num_parts)
     }
 
     /* Allocate output and sum all partials */
-    float* sum_data = (float*)calloc(numel, sizeof(float));
+    float* sum_data = (float*)cml_calloc(numel, sizeof(float));
     if (!sum_data) {
         LOG_ERROR("cml_tp_all_reduce_sum: allocation failed");
         return NULL;
@@ -470,7 +471,7 @@ Tensor* cml_tp_all_reduce_sum(Tensor** partials, int num_parts)
         const float* pdata = (const float*)tensor_data_ptr(partials[p]);
         if (!pdata) {
             LOG_ERROR("cml_tp_all_reduce_sum: failed to get data for partials[%d]", p);
-            free(sum_data);
+            cml_free(sum_data);
             return NULL;
         }
         for (size_t i = 0; i < numel; i++) {
@@ -479,10 +480,10 @@ Tensor* cml_tp_all_reduce_sum(Tensor** partials, int num_parts)
     }
 
     /* Copy shape from partials[0] */
-    int* out_shape = (int*)malloc((size_t)ndim * sizeof(int));
+    int* out_shape = (int*)cml_malloc((size_t)ndim * sizeof(int));
     if (!out_shape) {
         LOG_ERROR("cml_tp_all_reduce_sum: shape allocation failed");
-        free(sum_data);
+        cml_free(sum_data);
         return NULL;
     }
     memcpy(out_shape, partials[0]->shape, (size_t)ndim * sizeof(int));
@@ -490,7 +491,7 @@ Tensor* cml_tp_all_reduce_sum(Tensor** partials, int num_parts)
     TensorConfig cfg = {.dtype = DTYPE_FLOAT32, .device = DEVICE_CPU,
                         .has_dtype = true, .has_device = true};
     Tensor* result = tensor_from_data(sum_data, out_shape, ndim, &cfg);
-    free(sum_data);
-    free(out_shape);
+    cml_free(sum_data);
+    cml_free(out_shape);
     return result;
 }

--- a/src/nn.c
+++ b/src/nn.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 void nn_tensor_param_alias(Tensor* t) {
     if (t)
@@ -20,7 +21,7 @@ int module_init(Module* module, const char* name, ForwardFn forward, FreeFn free
     if (!module || !name)
         return -1;
 
-    module->name                = strdup(name);
+    module->name                = cml_strdup(name);
     module->forward             = forward;
     module->free                = free;
     module->parameters          = NULL;
@@ -36,12 +37,12 @@ int module_init(Module* module, const char* name, ForwardFn forward, FreeFn free
 }
 
 Module* module_create(const char* name, ForwardFn forward, FreeFn free) {
-    Module* module = malloc(sizeof(Module));
+    Module* module = cml_malloc(sizeof(Module));
     if (!module)
         return NULL;
 
     if (module_init(module, name, forward, free) != 0) {
-        free(module);
+        cml_free(module);
         return NULL;
     }
 
@@ -63,7 +64,7 @@ void module_free(Module* module) {
     module->free = NULL;
 
     if (module->name) {
-        free(module->name);
+        cml_free(module->name);
         module->name = NULL;
     }
 
@@ -73,18 +74,18 @@ void module_free(Module* module) {
             if (module->parameters[i]) {
                 Parameter* p = module->parameters[i];
                 if (p->name) {
-                    free(p->name);
+                    cml_free(p->name);
                     p->name = NULL;
                 }
                 if (p->tensor) {
                     tensor_free(p->tensor);
                     p->tensor = NULL;
                 }
-                free(p);
+                cml_free(p);
                 module->parameters[i] = NULL;
             }
         }
-        free(module->parameters);
+        cml_free(module->parameters);
         module->parameters = NULL;
     }
 
@@ -96,7 +97,7 @@ void module_free(Module* module) {
         specialized_free(module);
     } else {
         
-        free(module);
+        cml_free(module);
     }
 }
 
@@ -123,7 +124,7 @@ int module_add_parameter(Module* module, Tensor* tensor, const char* name, bool 
     if (module->num_parameters >= module->parameters_capacity) {
         int new_capacity = module->parameters_capacity == 0 ? 8 : module->parameters_capacity * 2;
         Parameter** new_params =
-            realloc(module->parameters, (size_t)new_capacity * sizeof(Parameter*));
+            cml_realloc(module->parameters, (size_t)new_capacity * sizeof(Parameter*));
         if (!new_params) {
             LOG_ERROR("Failed to allocate memory for parameters");
             return -1;
@@ -132,7 +133,7 @@ int module_add_parameter(Module* module, Tensor* tensor, const char* name, bool 
         module->parameters_capacity = new_capacity;
     }
 
-    Parameter* param = malloc(sizeof(Parameter));
+    Parameter* param = cml_malloc(sizeof(Parameter));
     if (!param) {
         LOG_ERROR("Failed to allocate memory for parameter");
         return -1;
@@ -140,11 +141,11 @@ int module_add_parameter(Module* module, Tensor* tensor, const char* name, bool 
 
     param->tensor        = tensor;
     param->requires_grad = requires_grad;
-    param->name          = strdup(name);
+    param->name          = cml_strdup(name);
 
     if (!param->name) {
         LOG_ERROR("Failed to duplicate parameter name");
-        free(param);
+        cml_free(param);
         return -1;
     }
 
@@ -314,7 +315,7 @@ int module_collect_parameters(Module* module, Parameter*** params_out, int* num_
         return 0;
     }
 
-    Parameter** params = malloc((size_t)total_params * sizeof(Parameter*));
+    Parameter** params = cml_malloc((size_t)total_params * sizeof(Parameter*));
     if (!params) {
         LOG_ERROR("Failed to allocate memory for parameter collection");
         return -1;
@@ -368,12 +369,12 @@ int module_to_device(Module* module, DeviceType device) {
     for (int i = 0; i < num_params; i++) {
         if (params[i] && params[i]->tensor) {
             if (device_move_tensor(params[i]->tensor, device) != 0) {
-                free(params);
+                cml_free(params);
                 return -1;
             }
         }
     }
 
-    free(params);
+    cml_free(params);
     return 0;
 }

--- a/src/nn/layers/activations.c
+++ b/src/nn/layers/activations.c
@@ -50,10 +50,15 @@ static void leaky_relu_free(Module* module) { cml_free(module); }
 
 LeakyReLU* nn_leaky_relu(float negative_slope, bool inplace) {
     LeakyReLU* leaky_relu = cml_malloc(sizeof(LeakyReLU));
-    if (!leaky_relu)
+    if (!leaky_relu) {
+        error_stack_push(CM_MEMORY_ALLOCATION_ERROR, "Failed to allocate memory for LeakyReLU layer",
+                         __FILE__, __LINE__, __func__);
         return NULL;
+    }
 
     if (module_init((Module*)leaky_relu, "LeakyReLU", leaky_relu_forward, leaky_relu_free) != 0) {
+        error_stack_push(CM_OPERATION_FAILED, "Failed to initialize LeakyReLU module", __FILE__,
+                         __LINE__, __func__);
         cml_free(leaky_relu);
         return NULL;
     }
@@ -202,10 +207,15 @@ static void gelu_free(Module* module) { cml_free(module); }
 
 GELU* nn_gelu(bool approximate) {
     GELU* gelu = cml_malloc(sizeof(GELU));
-    if (!gelu)
+    if (!gelu) {
+        error_stack_push(CM_MEMORY_ALLOCATION_ERROR, "Failed to allocate memory for GELU layer",
+                         __FILE__, __LINE__, __func__);
         return NULL;
+    }
 
     if (module_init((Module*)gelu, "GELU", gelu_forward, gelu_free) != 0) {
+        error_stack_push(CM_OPERATION_FAILED, "Failed to initialize GELU module", __FILE__,
+                         __LINE__, __func__);
         cml_free(gelu);
         return NULL;
     }
@@ -227,10 +237,15 @@ static void softmax_free(Module* module) { cml_free(module); }
 
 Softmax* nn_softmax(int dim) {
     Softmax* softmax = cml_malloc(sizeof(Softmax));
-    if (!softmax)
+    if (!softmax) {
+        error_stack_push(CM_MEMORY_ALLOCATION_ERROR, "Failed to allocate memory for Softmax layer",
+                         __FILE__, __LINE__, __func__);
         return NULL;
+    }
 
     if (module_init((Module*)softmax, "Softmax", softmax_forward, softmax_free) != 0) {
+        error_stack_push(CM_OPERATION_FAILED, "Failed to initialize Softmax module", __FILE__,
+                         __LINE__, __func__);
         cml_free(softmax);
         return NULL;
     }
@@ -259,11 +274,16 @@ static void log_softmax_free(Module* module) { cml_free(module); }
 
 LogSoftmax* nn_log_softmax(int dim) {
     LogSoftmax* log_softmax = cml_malloc(sizeof(LogSoftmax));
-    if (!log_softmax)
+    if (!log_softmax) {
+        error_stack_push(CM_MEMORY_ALLOCATION_ERROR, "Failed to allocate memory for LogSoftmax layer",
+                         __FILE__, __LINE__, __func__);
         return NULL;
+    }
 
     if (module_init((Module*)log_softmax, "LogSoftmax", log_softmax_forward, log_softmax_free) !=
         0) {
+        error_stack_push(CM_OPERATION_FAILED, "Failed to initialize LogSoftmax module", __FILE__,
+                         __LINE__, __func__);
         cml_free(log_softmax);
         return NULL;
     }

--- a/src/nn/layers/activations.c
+++ b/src/nn/layers/activations.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include <stdio.h>
+#include "alloc/cml_allocator.h"
 
 static Tensor* relu_forward(Module* module, Tensor* input) {
     (void)module;
@@ -18,10 +19,10 @@ static Tensor* relu_forward(Module* module, Tensor* input) {
     return uop_relu(input);
 }
 
-static void relu_free(Module* module) { free(module); }
+static void relu_free(Module* module) { cml_free(module); }
 
 ReLU* nn_relu(bool inplace) {
-    ReLU* relu = malloc(sizeof(ReLU));
+    ReLU* relu = cml_malloc(sizeof(ReLU));
     if (!relu) {
         error_stack_push(CM_MEMORY_ALLOCATION_ERROR, "Failed to allocate memory for ReLU layer",
                          __FILE__, __LINE__, __func__);
@@ -31,7 +32,7 @@ ReLU* nn_relu(bool inplace) {
     if (module_init((Module*)relu, "ReLU", relu_forward, relu_free) != 0) {
         error_stack_push(CM_OPERATION_FAILED, "Failed to initialize ReLU module", __FILE__,
                          __LINE__, __func__);
-        free(relu);
+        cml_free(relu);
         return NULL;
     }
 
@@ -45,15 +46,15 @@ static Tensor* leaky_relu_forward(Module* module, Tensor* input) {
     return uop_leaky_relu(input, leaky_relu->negative_slope);
 }
 
-static void leaky_relu_free(Module* module) { free(module); }
+static void leaky_relu_free(Module* module) { cml_free(module); }
 
 LeakyReLU* nn_leaky_relu(float negative_slope, bool inplace) {
-    LeakyReLU* leaky_relu = malloc(sizeof(LeakyReLU));
+    LeakyReLU* leaky_relu = cml_malloc(sizeof(LeakyReLU));
     if (!leaky_relu)
         return NULL;
 
     if (module_init((Module*)leaky_relu, "LeakyReLU", leaky_relu_forward, leaky_relu_free) != 0) {
-        free(leaky_relu);
+        cml_free(leaky_relu);
         return NULL;
     }
 
@@ -69,10 +70,10 @@ static Tensor* sigmoid_forward(Module* module, Tensor* input) {
     return uop_sigmoid(input);
 }
 
-static void sigmoid_free(Module* module) { free(module); }
+static void sigmoid_free(Module* module) { cml_free(module); }
 
 Sigmoid* nn_sigmoid(void) {
-    Sigmoid* sigmoid = malloc(sizeof(Sigmoid));
+    Sigmoid* sigmoid = cml_malloc(sizeof(Sigmoid));
     if (!sigmoid) {
         error_stack_push(CM_MEMORY_ALLOCATION_ERROR, "Failed to allocate memory for Sigmoid layer",
                          __FILE__, __LINE__, __func__);
@@ -82,7 +83,7 @@ Sigmoid* nn_sigmoid(void) {
     if (module_init((Module*)sigmoid, "Sigmoid", sigmoid_forward, sigmoid_free) != 0) {
         error_stack_push(CM_OPERATION_FAILED, "Failed to initialize Sigmoid module", __FILE__,
                          __LINE__, __func__);
-        free(sigmoid);
+        cml_free(sigmoid);
         return NULL;
     }
 
@@ -96,10 +97,10 @@ static Tensor* tanh_forward(Module* module, Tensor* input) {
     return uop_tanh(input);
 }
 
-static void tanh_free(Module* module) { free(module); }
+static void tanh_free(Module* module) { cml_free(module); }
 
 Tanh* nn_tanh(void) {
-    Tanh* tanh = malloc(sizeof(Tanh));
+    Tanh* tanh = cml_malloc(sizeof(Tanh));
     if (!tanh) {
         error_stack_push(CM_MEMORY_ALLOCATION_ERROR, "Failed to allocate memory for Tanh layer",
                          __FILE__, __LINE__, __func__);
@@ -109,7 +110,7 @@ Tanh* nn_tanh(void) {
     if (module_init((Module*)tanh, "Tanh", tanh_forward, tanh_free) != 0) {
         error_stack_push(CM_OPERATION_FAILED, "Failed to initialize Tanh module", __FILE__,
                          __LINE__, __func__);
-        free(tanh);
+        cml_free(tanh);
         return NULL;
     }
 
@@ -197,15 +198,15 @@ static Tensor* gelu_forward(Module* module, Tensor* input) {
     return output;
 }
 
-static void gelu_free(Module* module) { free(module); }
+static void gelu_free(Module* module) { cml_free(module); }
 
 GELU* nn_gelu(bool approximate) {
-    GELU* gelu = malloc(sizeof(GELU));
+    GELU* gelu = cml_malloc(sizeof(GELU));
     if (!gelu)
         return NULL;
 
     if (module_init((Module*)gelu, "GELU", gelu_forward, gelu_free) != 0) {
-        free(gelu);
+        cml_free(gelu);
         return NULL;
     }
 
@@ -222,15 +223,15 @@ static Tensor* softmax_forward(Module* module, Tensor* input) {
     return tensor_softmax(input, softmax->dim);
 }
 
-static void softmax_free(Module* module) { free(module); }
+static void softmax_free(Module* module) { cml_free(module); }
 
 Softmax* nn_softmax(int dim) {
-    Softmax* softmax = malloc(sizeof(Softmax));
+    Softmax* softmax = cml_malloc(sizeof(Softmax));
     if (!softmax)
         return NULL;
 
     if (module_init((Module*)softmax, "Softmax", softmax_forward, softmax_free) != 0) {
-        free(softmax);
+        cml_free(softmax);
         return NULL;
     }
 
@@ -254,16 +255,16 @@ static Tensor* log_softmax_forward(Module* module, Tensor* input) {
     return output;
 }
 
-static void log_softmax_free(Module* module) { free(module); }
+static void log_softmax_free(Module* module) { cml_free(module); }
 
 LogSoftmax* nn_log_softmax(int dim) {
-    LogSoftmax* log_softmax = malloc(sizeof(LogSoftmax));
+    LogSoftmax* log_softmax = cml_malloc(sizeof(LogSoftmax));
     if (!log_softmax)
         return NULL;
 
     if (module_init((Module*)log_softmax, "LogSoftmax", log_softmax_forward, log_softmax_free) !=
         0) {
-        free(log_softmax);
+        cml_free(log_softmax);
         return NULL;
     }
 
@@ -349,10 +350,10 @@ static Tensor* elu_forward(Module* module, Tensor* input) {
     return uop_where(&wp);
 }
 
-static void elu_free(Module* module) { free(module); }
+static void elu_free(Module* module) { cml_free(module); }
 
 ELU* nn_elu(float alpha, bool inplace) {
-    ELU* elu = malloc(sizeof(ELU));
+    ELU* elu = cml_malloc(sizeof(ELU));
     if (!elu) {
         error_stack_push(CM_MEMORY_ALLOCATION_ERROR, "Failed to allocate memory for ELU layer",
                          __FILE__, __LINE__, __func__);
@@ -362,7 +363,7 @@ ELU* nn_elu(float alpha, bool inplace) {
     if (module_init((Module*)elu, "ELU", elu_forward, elu_free) != 0) {
         error_stack_push(CM_OPERATION_FAILED, "Failed to initialize ELU module", __FILE__, __LINE__,
                          __func__);
-        free(elu);
+        cml_free(elu);
         return NULL;
     }
 
@@ -403,10 +404,10 @@ static Tensor* selu_forward(Module* module, Tensor* input) {
     return uop_mul(lambda_tensor, elu_result);
 }
 
-static void selu_free(Module* module) { free(module); }
+static void selu_free(Module* module) { cml_free(module); }
 
 SELU* nn_selu(void) {
-    SELU* selu = malloc(sizeof(SELU));
+    SELU* selu = cml_malloc(sizeof(SELU));
     if (!selu) {
         error_stack_push(CM_MEMORY_ALLOCATION_ERROR, "Failed to allocate memory for SELU layer",
                          __FILE__, __LINE__, __func__);
@@ -416,7 +417,7 @@ SELU* nn_selu(void) {
     if (module_init((Module*)selu, "SELU", selu_forward, selu_free) != 0) {
         error_stack_push(CM_OPERATION_FAILED, "Failed to initialize SELU module", __FILE__,
                          __LINE__, __func__);
-        free(selu);
+        cml_free(selu);
         return NULL;
     }
 
@@ -430,10 +431,10 @@ static Tensor* silu_forward(Module* module, Tensor* input) {
     return uop_mul(input, uop_sigmoid(input));
 }
 
-static void silu_free(Module* module) { free(module); }
+static void silu_free(Module* module) { cml_free(module); }
 
 SiLU* nn_silu(void) {
-    SiLU* silu = malloc(sizeof(SiLU));
+    SiLU* silu = cml_malloc(sizeof(SiLU));
     if (!silu) {
         error_stack_push(CM_MEMORY_ALLOCATION_ERROR, "Failed to allocate memory for SiLU layer",
                          __FILE__, __LINE__, __func__);
@@ -443,7 +444,7 @@ SiLU* nn_silu(void) {
     if (module_init((Module*)silu, "SiLU", silu_forward, silu_free) != 0) {
         error_stack_push(CM_OPERATION_FAILED, "Failed to initialize SiLU module", __FILE__,
                          __LINE__, __func__);
-        free(silu);
+        cml_free(silu);
         return NULL;
     }
 
@@ -466,10 +467,10 @@ static Tensor* mish_forward(Module* module, Tensor* input) {
     return uop_mul(input, tanh_sp);
 }
 
-static void mish_free(Module* module) { free(module); }
+static void mish_free(Module* module) { cml_free(module); }
 
 Mish* nn_mish(void) {
-    Mish* mish = malloc(sizeof(Mish));
+    Mish* mish = cml_malloc(sizeof(Mish));
     if (!mish) {
         error_stack_push(CM_MEMORY_ALLOCATION_ERROR, "Failed to allocate memory for Mish layer",
                          __FILE__, __LINE__, __func__);
@@ -479,7 +480,7 @@ Mish* nn_mish(void) {
     if (module_init((Module*)mish, "Mish", mish_forward, mish_free) != 0) {
         error_stack_push(CM_OPERATION_FAILED, "Failed to initialize Mish module", __FILE__,
                          __LINE__, __func__);
-        free(mish);
+        cml_free(mish);
         return NULL;
     }
 
@@ -509,10 +510,10 @@ static Tensor* hardswish_forward(Module* module, Tensor* input) {
     return uop_mul(input, scaled);
 }
 
-static void hardswish_free(Module* module) { free(module); }
+static void hardswish_free(Module* module) { cml_free(module); }
 
 HardSwish* nn_hardswish(void) {
-    HardSwish* hardswish = malloc(sizeof(HardSwish));
+    HardSwish* hardswish = cml_malloc(sizeof(HardSwish));
     if (!hardswish) {
         error_stack_push(CM_MEMORY_ALLOCATION_ERROR,
                          "Failed to allocate memory for HardSwish layer", __FILE__, __LINE__,
@@ -523,7 +524,7 @@ HardSwish* nn_hardswish(void) {
     if (module_init((Module*)hardswish, "HardSwish", hardswish_forward, hardswish_free) != 0) {
         error_stack_push(CM_OPERATION_FAILED, "Failed to initialize HardSwish module", __FILE__,
                          __LINE__, __func__);
-        free(hardswish);
+        cml_free(hardswish);
         return NULL;
     }
 

--- a/src/nn/layers/batchnorm1d.c
+++ b/src/nn/layers/batchnorm1d.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 static Tensor* batchnorm1d_forward(Module* module, Tensor* input) {
     BatchNorm1d* bn = (BatchNorm1d*)module;
@@ -152,16 +153,16 @@ static void batchnorm1d_free(Module* module) {
     if (bn->running_var)  tensor_free(bn->running_var);
     if (bn->current_mean) tensor_free(bn->current_mean);
     if (bn->current_var)  tensor_free(bn->current_var);
-    free(bn);
+    cml_free(bn);
 }
 
 BatchNorm1d* nn_batchnorm1d(int num_features, float eps, float momentum, bool affine,
                              bool track_running_stats, DType dtype, DeviceType device) {
-    BatchNorm1d* bn = malloc(sizeof(BatchNorm1d));
+    BatchNorm1d* bn = cml_malloc(sizeof(BatchNorm1d));
     if (!bn) return NULL;
 
     if (module_init((Module*)bn, "BatchNorm1d", batchnorm1d_forward, batchnorm1d_free) != 0) {
-        free(bn);
+        cml_free(bn);
         return NULL;
     }
 

--- a/src/nn/layers/batchnorm2d.c
+++ b/src/nn/layers/batchnorm2d.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 static Tensor* batchnorm2d_forward(Module* module, Tensor* input) {
     BatchNorm2d* bn = (BatchNorm2d*)module;
@@ -239,17 +240,17 @@ static void batchnorm2d_free(Module* module) {
         tensor_free(bn->current_mean);
     if (bn->current_var)
         tensor_free(bn->current_var);
-    free(bn);
+    cml_free(bn);
 }
 
 BatchNorm2d* nn_batchnorm2d(int num_features, float eps, float momentum, bool affine,
                             bool track_running_stats, DType dtype, DeviceType device) {
-    BatchNorm2d* bn = malloc(sizeof(BatchNorm2d));
+    BatchNorm2d* bn = cml_malloc(sizeof(BatchNorm2d));
     if (!bn)
         return NULL;
 
     if (module_init((Module*)bn, "BatchNorm2d", batchnorm2d_forward, batchnorm2d_free) != 0) {
-        free(bn);
+        cml_free(bn);
         return NULL;
     }
 

--- a/src/nn/layers/batchnorm3d.c
+++ b/src/nn/layers/batchnorm3d.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 static Tensor* batchnorm3d_forward(Module* module, Tensor* input) {
     BatchNorm3d* bn = (BatchNorm3d*)module;
@@ -244,17 +245,17 @@ static void batchnorm3d_free(Module* module) {
     if (bn->current_var)
         tensor_free(bn->current_var);
 
-    free(bn);
+    cml_free(bn);
 }
 
 BatchNorm3d* nn_batchnorm3d(int num_features, float eps, float momentum, bool affine,
                             bool track_running_stats, DType dtype, DeviceType device) {
-    BatchNorm3d* bn = malloc(sizeof(BatchNorm3d));
+    BatchNorm3d* bn = cml_malloc(sizeof(BatchNorm3d));
     if (!bn)
         return NULL;
 
     if (module_init((Module*)bn, "BatchNorm3d", batchnorm3d_forward, batchnorm3d_free) != 0) {
-        free(bn);
+        cml_free(bn);
         return NULL;
     }
 

--- a/src/nn/layers/containers.c
+++ b/src/nn/layers/containers.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 static Tensor* module_list_forward(Module* module, Tensor* input) {
     (void)module;
@@ -21,14 +22,14 @@ static void module_list_free(Module* module) {
                 module_free(list->modules[i]);
             }
         }
-        free(list->modules);
+        cml_free(list->modules);
     }
 
-    free(list);
+    cml_free(list);
 }
 
 ModuleList* nn_module_list(void) {
-    ModuleList* list = malloc(sizeof(ModuleList));
+    ModuleList* list = cml_malloc(sizeof(ModuleList));
     if (!list) {
         error_stack_push(CM_MEMORY_ALLOCATION_ERROR,
                          "Failed to allocate memory for ModuleList", __FILE__, __LINE__,
@@ -39,7 +40,7 @@ ModuleList* nn_module_list(void) {
     if (module_init((Module*)list, "ModuleList", module_list_forward, module_list_free) != 0) {
         error_stack_push(CM_OPERATION_FAILED, "Failed to initialize ModuleList module", __FILE__,
                          __LINE__, __func__);
-        free(list);
+        cml_free(list);
         return NULL;
     }
 
@@ -57,7 +58,7 @@ int module_list_append(ModuleList* list, Module* module) {
 
     if (list->num_modules >= list->capacity) {
         int new_cap = list->capacity == 0 ? 8 : list->capacity * 2;
-        Module** new_mods = realloc(list->modules, (size_t)new_cap * sizeof(Module*));
+        Module** new_mods = cml_realloc(list->modules, (size_t)new_cap * sizeof(Module*));
         if (!new_mods) return -1;
         list->modules  = new_mods;
         list->capacity = new_cap;
@@ -85,7 +86,7 @@ int module_list_append(ModuleList* list, Module* module) {
                     pt->ref_count--;
             }
         }
-        if (params) free(params);
+        if (params) cml_free(params);
     }
 
     return 0;
@@ -97,7 +98,7 @@ int module_list_insert(ModuleList* list, int index, Module* module) {
     /* Ensure capacity */
     if (list->num_modules >= list->capacity) {
         int new_cap = list->capacity == 0 ? 8 : list->capacity * 2;
-        Module** new_mods = realloc(list->modules, (size_t)new_cap * sizeof(Module*));
+        Module** new_mods = cml_realloc(list->modules, (size_t)new_cap * sizeof(Module*));
         if (!new_mods) return -1;
         list->modules  = new_mods;
         list->capacity = new_cap;
@@ -128,7 +129,7 @@ int module_list_insert(ModuleList* list, int index, Module* module) {
                     pt->ref_count--;
             }
         }
-        if (params) free(params);
+        if (params) cml_free(params);
     }
 
     return 0;
@@ -165,19 +166,19 @@ static void module_dict_free(Module* module) {
 
     if (dict->entries) {
         for (int i = 0; i < dict->num_entries; i++) {
-            free(dict->entries[i].key);
+            cml_free(dict->entries[i].key);
             if (dict->entries[i].module) {
                 module_free(dict->entries[i].module);
             }
         }
-        free(dict->entries);
+        cml_free(dict->entries);
     }
 
-    free(dict);
+    cml_free(dict);
 }
 
 ModuleDict* nn_module_dict(void) {
-    ModuleDict* dict = malloc(sizeof(ModuleDict));
+    ModuleDict* dict = cml_malloc(sizeof(ModuleDict));
     if (!dict) {
         error_stack_push(CM_MEMORY_ALLOCATION_ERROR,
                          "Failed to allocate memory for ModuleDict", __FILE__, __LINE__,
@@ -188,7 +189,7 @@ ModuleDict* nn_module_dict(void) {
     if (module_init((Module*)dict, "ModuleDict", module_dict_forward, module_dict_free) != 0) {
         error_stack_push(CM_OPERATION_FAILED, "Failed to initialize ModuleDict module", __FILE__,
                          __LINE__, __func__);
-        free(dict);
+        cml_free(dict);
         return NULL;
     }
 
@@ -217,14 +218,14 @@ int module_dict_add(ModuleDict* dict, const char* key, Module* module) {
     }
     if (dict->num_entries >= dict->capacity) {
         int new_cap = dict->capacity == 0 ? 8 : dict->capacity * 2;
-        ModuleDictEntry* new_entries = realloc(dict->entries,
+        ModuleDictEntry* new_entries = cml_realloc(dict->entries,
                                                (size_t)new_cap * sizeof(ModuleDictEntry));
         if (!new_entries) return -1;
         dict->entries  = new_entries;
         dict->capacity = new_cap;
     }
 
-    dict->entries[dict->num_entries].key    = strdup(key);
+    dict->entries[dict->num_entries].key    = cml_strdup(key);
     dict->entries[dict->num_entries].module = module;
     if (!dict->entries[dict->num_entries].key) return -1;
     dict->num_entries++;
@@ -243,7 +244,7 @@ int module_dict_add(ModuleDict* dict, const char* key, Module* module) {
                     pt->ref_count--;
             }
         }
-        if (params) free(params);
+        if (params) cml_free(params);
     }
 
     return 0;
@@ -264,7 +265,7 @@ int module_dict_remove(ModuleDict* dict, const char* key) {
 
     for (int i = 0; i < dict->num_entries; i++) {
         if (strcmp(dict->entries[i].key, key) == 0) {
-            free(dict->entries[i].key);
+            cml_free(dict->entries[i].key);
             /* Don't free module - caller's responsibility */
             for (int j = i; j < dict->num_entries - 1; j++) {
                 dict->entries[j] = dict->entries[j + 1];
@@ -285,7 +286,7 @@ const char** module_dict_keys(ModuleDict* dict, int* num_keys) {
     *num_keys = dict->num_entries;
     if (dict->num_entries == 0) return NULL;
 
-    const char** keys = malloc((size_t)dict->num_entries * sizeof(const char*));
+    const char** keys = cml_malloc((size_t)dict->num_entries * sizeof(const char*));
     if (!keys) return NULL;
 
     for (int i = 0; i < dict->num_entries; i++) {

--- a/src/nn/layers/conv1d.c
+++ b/src/nn/layers/conv1d.c
@@ -5,6 +5,7 @@
 #include "core/logging.h"
 #include <stdlib.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 static Tensor* conv1d_forward(Module* module, Tensor* input) {
     Conv1d* conv = (Conv1d*)module;
@@ -93,7 +94,7 @@ static void conv1d_free(Module* module) {
     if (!conv)
         return;
 
-    free(conv);
+    cml_free(conv);
 }
 
 static void kaiming_init_1d(Tensor* tensor, int in_channels, int kernel_size) {
@@ -113,12 +114,12 @@ static void kaiming_init_1d(Tensor* tensor, int in_channels, int kernel_size) {
 
 Conv1d* nn_conv1d(int in_channels, int out_channels, int kernel_size, int stride, int padding,
                   int dilation, bool use_bias, DType dtype, DeviceType device) {
-    Conv1d* conv = malloc(sizeof(Conv1d));
+    Conv1d* conv = cml_malloc(sizeof(Conv1d));
     if (!conv)
         return NULL;
 
     if (module_init((Module*)conv, "Conv1d", conv1d_forward, conv1d_free) != 0) {
-        free(conv);
+        cml_free(conv);
         return NULL;
     }
 

--- a/src/nn/layers/conv2d.c
+++ b/src/nn/layers/conv2d.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 static Tensor* conv2d_forward(Module* module, Tensor* input) {
     Conv2d* conv2d = (Conv2d*)module;
@@ -75,7 +76,7 @@ static void conv2d_free(Module* module) {
     if (!conv2d)
         return;
 
-    free(conv2d);
+    cml_free(conv2d);
 }
 
 static void kaiming_init(Tensor* tensor, int in_channels, int out_channels, int kernel_size) {
@@ -96,12 +97,12 @@ static void kaiming_init(Tensor* tensor, int in_channels, int out_channels, int 
 
 Conv2d* nn_conv2d(int in_channels, int out_channels, int kernel_size, int stride, int padding,
                   int dilation, bool use_bias, DType dtype, DeviceType device) {
-    Conv2d* conv2d = malloc(sizeof(Conv2d));
+    Conv2d* conv2d = cml_malloc(sizeof(Conv2d));
     if (!conv2d)
         return NULL;
 
     if (module_init((Module*)conv2d, "Conv2d", conv2d_forward, conv2d_free) != 0) {
-        free(conv2d);
+        cml_free(conv2d);
         return NULL;
     }
 

--- a/src/nn/layers/conv3d.c
+++ b/src/nn/layers/conv3d.c
@@ -5,6 +5,7 @@
 #include "core/logging.h"
 #include <stdlib.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 static Tensor* conv3d_forward(Module* module, Tensor* input) {
     Conv3d* conv = (Conv3d*)module;
@@ -32,7 +33,7 @@ static void conv3d_free(Module* module) {
     if (!conv3d)
         return;
 
-    free(conv3d);
+    cml_free(conv3d);
 }
 
 static void kaiming_init_3d(Tensor* tensor, int in_channels, int kernel_size) {
@@ -52,12 +53,12 @@ static void kaiming_init_3d(Tensor* tensor, int in_channels, int kernel_size) {
 
 Conv3d* nn_conv3d(int in_channels, int out_channels, int kernel_size, int stride, int padding,
                   int dilation, bool use_bias, DType dtype, DeviceType device) {
-    Conv3d* conv3d = malloc(sizeof(Conv3d));
+    Conv3d* conv3d = cml_malloc(sizeof(Conv3d));
     if (!conv3d)
         return NULL;
 
     if (module_init((Module*)conv3d, "Conv3d", conv3d_forward, conv3d_free) != 0) {
-        free(conv3d);
+        cml_free(conv3d);
         return NULL;
     }
 

--- a/src/nn/layers/conv_transpose1d.c
+++ b/src/nn/layers/conv_transpose1d.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 static Tensor* conv_transpose1d_forward(Module* module, Tensor* input) {
     ConvTranspose1d* layer = (ConvTranspose1d*)module;
@@ -106,19 +107,19 @@ static void conv_transpose1d_free(Module* module) {
     ConvTranspose1d* layer = (ConvTranspose1d*)module;
     if (!layer)
         return;
-    free(layer);
+    cml_free(layer);
 }
 
 ConvTranspose1d* nn_conv_transpose1d(int in_channels, int out_channels, int kernel_size,
                                       int stride, int padding, int output_padding,
                                       bool use_bias, DType dtype, DeviceType device) {
-    ConvTranspose1d* layer = malloc(sizeof(ConvTranspose1d));
+    ConvTranspose1d* layer = cml_malloc(sizeof(ConvTranspose1d));
     if (!layer)
         return NULL;
 
     if (module_init((Module*)layer, "ConvTranspose1d", conv_transpose1d_forward,
                     conv_transpose1d_free) != 0) {
-        free(layer);
+        cml_free(layer);
         return NULL;
     }
 

--- a/src/nn/layers/conv_transpose2d.c
+++ b/src/nn/layers/conv_transpose2d.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 static Tensor* conv_transpose2d_forward(Module* module, Tensor* input) {
     ConvTranspose2d* layer = (ConvTranspose2d*)module;
@@ -47,7 +48,7 @@ static void conv_transpose2d_free(Module* module) {
     ConvTranspose2d* layer = (ConvTranspose2d*)module;
     if (!layer)
         return;
-    free(layer);
+    cml_free(layer);
 }
 
 static void kaiming_init_transpose(Tensor* tensor, int in_channels, int kernel_size) {
@@ -69,13 +70,13 @@ static void kaiming_init_transpose(Tensor* tensor, int in_channels, int kernel_s
 ConvTranspose2d* nn_conv_transpose2d(int in_channels, int out_channels, int kernel_size,
                                       int stride, int padding, int output_padding,
                                       bool use_bias, DType dtype, DeviceType device) {
-    ConvTranspose2d* layer = malloc(sizeof(ConvTranspose2d));
+    ConvTranspose2d* layer = cml_malloc(sizeof(ConvTranspose2d));
     if (!layer)
         return NULL;
 
     if (module_init((Module*)layer, "ConvTranspose2d", conv_transpose2d_forward,
                     conv_transpose2d_free) != 0) {
-        free(layer);
+        cml_free(layer);
         return NULL;
     }
 

--- a/src/nn/layers/conv_transpose3d.c
+++ b/src/nn/layers/conv_transpose3d.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 Tensor* conv_transpose3d_forward(Module* module, Tensor* input) {
     ConvTranspose3d* layer = (ConvTranspose3d*)module;
@@ -48,7 +49,7 @@ static void conv_transpose3d_free(Module* module) {
     ConvTranspose3d* layer = (ConvTranspose3d*)module;
     if (!layer)
         return;
-    free(layer);
+    cml_free(layer);
 }
 
 static void kaiming_init_transpose3d(Tensor* tensor, int in_channels,
@@ -72,7 +73,7 @@ static void kaiming_init_transpose3d(Tensor* tensor, int in_channels,
 ConvTranspose3d* nn_conv_transpose3d(int in_channels, int out_channels, int kernel_size,
                                       int stride, int padding, int output_padding,
                                       bool use_bias, DType dtype, DeviceType device) {
-    ConvTranspose3d* layer = calloc(1, sizeof(ConvTranspose3d));
+    ConvTranspose3d* layer = cml_calloc(1, sizeof(ConvTranspose3d));
     if (!layer) {
         LOG_ERROR("ConvTranspose3d: failed to allocate memory");
         return NULL;
@@ -80,7 +81,7 @@ ConvTranspose3d* nn_conv_transpose3d(int in_channels, int out_channels, int kern
 
     if (module_init((Module*)layer, "ConvTranspose3d", conv_transpose3d_forward,
                     conv_transpose3d_free) != 0) {
-        free(layer);
+        cml_free(layer);
         return NULL;
     }
 

--- a/src/nn/layers/dropout.c
+++ b/src/nn/layers/dropout.c
@@ -5,6 +5,7 @@
 #include "core/logging.h"
 #include <stdlib.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 static Tensor* dropout_forward(Module* module, Tensor* input) {
     Dropout* dropout = (Dropout*)module;
@@ -65,15 +66,15 @@ static Tensor* dropout_forward(Module* module, Tensor* input) {
     return out;
 }
 
-static void dropout_free(Module* module) { free(module); }
+static void dropout_free(Module* module) { cml_free(module); }
 
 Dropout* nn_dropout(float p, bool inplace) {
-    Dropout* dropout = malloc(sizeof(Dropout));
+    Dropout* dropout = cml_malloc(sizeof(Dropout));
     if (!dropout)
         return NULL;
 
     if (module_init((Module*)dropout, "Dropout", dropout_forward, dropout_free) != 0) {
-        free(dropout);
+        cml_free(dropout);
         return NULL;
     }
 

--- a/src/nn/layers/embedding.c
+++ b/src/nn/layers/embedding.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 static Tensor* embedding_forward(Module* module, Tensor* input) {
     Embedding* emb = (Embedding*)module;
@@ -63,7 +64,7 @@ static Tensor* embedding_forward(Module* module, Tensor* input) {
     }
 
     int out_ndim = input->ndim + 1;
-    int* out_shape = malloc((size_t)out_ndim * sizeof(int));
+    int* out_shape = cml_malloc((size_t)out_ndim * sizeof(int));
     if (!out_shape)
         return NULL;
     for (int i = 0; i < input->ndim; i++)
@@ -72,20 +73,20 @@ static Tensor* embedding_forward(Module* module, Tensor* input) {
 
     ReshapeParams rout = {.new_shape = out_shape, .new_ndim = out_ndim};
     Tensor* out        = uop_reshape(out_body, &rout);
-    free(out_shape);
+    cml_free(out_shape);
     return out;
 }
 
-static void embedding_free(Module* module) { free(module); }
+static void embedding_free(Module* module) { cml_free(module); }
 
 Embedding* nn_embedding(int num_embeddings, int embedding_dim, int padding_idx,
                         DType dtype, DeviceType device) {
-    Embedding* emb = malloc(sizeof(Embedding));
+    Embedding* emb = cml_malloc(sizeof(Embedding));
     if (!emb)
         return NULL;
 
     if (module_init((Module*)emb, "Embedding", embedding_forward, embedding_free) != 0) {
-        free(emb);
+        cml_free(emb);
         return NULL;
     }
 

--- a/src/nn/layers/flatten.c
+++ b/src/nn/layers/flatten.c
@@ -3,6 +3,7 @@
 #include "ops/uops.h"
 #include "core/logging.h"
 #include <stdlib.h>
+#include "alloc/cml_allocator.h"
 
 static Tensor* flatten_forward(Module* module, Tensor* input) {
     Flatten* fl = (Flatten*)module;
@@ -40,15 +41,15 @@ static Tensor* flatten_forward(Module* module, Tensor* input) {
 }
 
 static void flatten_free(Module* module) {
-    free(module);
+    cml_free(module);
 }
 
 Flatten* nn_flatten(int start_dim, int end_dim) {
-    Flatten* fl = malloc(sizeof(Flatten));
+    Flatten* fl = cml_malloc(sizeof(Flatten));
     if (!fl) return NULL;
 
     if (module_init((Module*)fl, "Flatten", flatten_forward, flatten_free) != 0) {
-        free(fl);
+        cml_free(fl);
         return NULL;
     }
 

--- a/src/nn/layers/groupnorm.c
+++ b/src/nn/layers/groupnorm.c
@@ -5,6 +5,7 @@
 #include "core/logging.h"
 #include <stdlib.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 static Tensor* groupnorm_forward(Module* module, Tensor* input) {
     GroupNorm* gn = (GroupNorm*)module;
@@ -112,13 +113,13 @@ static Tensor* groupnorm_forward(Module* module, Tensor* input) {
         return NULL;
     ReshapeParams rback = {.new_shape = back_shape, .new_ndim = input->ndim};
     Tensor* output      = uop_reshape(normalized2, &rback);
-    free(back_shape);
+    cml_free(back_shape);
     if (!output)
         return NULL;
 
     if (gn->affine && gn->weight && gn->bias) {
         int nd = input->ndim;
-        int* stat_shape = malloc((size_t)nd * sizeof(int));
+        int* stat_shape = cml_malloc((size_t)nd * sizeof(int));
         if (!stat_shape)
             return NULL;
         stat_shape[0] = 1;
@@ -129,7 +130,7 @@ static Tensor* groupnorm_forward(Module* module, Tensor* input) {
         ReshapeParams rw = {.new_shape = stat_shape, .new_ndim = nd};
         Tensor* w_r      = uop_reshape(gn->weight->tensor, &rw);
         Tensor* b_r      = uop_reshape(gn->bias->tensor, &rw);
-        free(stat_shape);
+        cml_free(stat_shape);
         if (!w_r || !b_r)
             return NULL;
 
@@ -141,7 +142,7 @@ static Tensor* groupnorm_forward(Module* module, Tensor* input) {
 
         Tensor* wb = uop_expand(w_r, &ex);
         Tensor* bb = uop_expand(b_r, &ex);
-        free(ex.new_shape);
+        cml_free(ex.new_shape);
         if (!wb || !bb)
             return NULL;
 
@@ -156,7 +157,7 @@ static Tensor* groupnorm_forward(Module* module, Tensor* input) {
     return output;
 }
 
-static void groupnorm_free(Module* module) { free(module); }
+static void groupnorm_free(Module* module) { cml_free(module); }
 
 GroupNorm* nn_groupnorm(int num_groups, int num_channels, float eps, bool affine,
                         DType dtype, DeviceType device) {
@@ -166,12 +167,12 @@ GroupNorm* nn_groupnorm(int num_groups, int num_channels, float eps, bool affine
         return NULL;
     }
 
-    GroupNorm* gn = malloc(sizeof(GroupNorm));
+    GroupNorm* gn = cml_malloc(sizeof(GroupNorm));
     if (!gn)
         return NULL;
 
     if (module_init((Module*)gn, "GroupNorm", groupnorm_forward, groupnorm_free) != 0) {
-        free(gn);
+        cml_free(gn);
         return NULL;
     }
 

--- a/src/nn/layers/identity.c
+++ b/src/nn/layers/identity.c
@@ -1,6 +1,7 @@
 #include "nn/layers/identity.h"
 #include "nn.h"
 #include <stdlib.h>
+#include "alloc/cml_allocator.h"
 
 static Tensor* identity_forward(Module* module, Tensor* input) {
     (void)module;
@@ -8,15 +9,15 @@ static Tensor* identity_forward(Module* module, Tensor* input) {
 }
 
 static void identity_free(Module* module) {
-    free(module);
+    cml_free(module);
 }
 
 Identity* nn_identity(void) {
-    Identity* id = malloc(sizeof(Identity));
+    Identity* id = cml_malloc(sizeof(Identity));
     if (!id) return NULL;
 
     if (module_init((Module*)id, "Identity", identity_forward, identity_free) != 0) {
-        free(id);
+        cml_free(id);
         return NULL;
     }
     return id;

--- a/src/nn/layers/instancenorm.c
+++ b/src/nn/layers/instancenorm.c
@@ -5,6 +5,7 @@
 #include "core/logging.h"
 #include <stdlib.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 static Tensor* instancenorm2d_forward(Module* module, Tensor* input) {
     InstanceNorm2d* in = (InstanceNorm2d*)module;
@@ -142,18 +143,18 @@ static void instancenorm2d_free(Module* module) {
     InstanceNorm2d* in = (InstanceNorm2d*)module;
     if (!in)
         return;
-    free(in);
+    cml_free(in);
 }
 
 InstanceNorm2d* nn_instancenorm2d(int num_features, float eps, bool affine, DType dtype,
                                   DeviceType device) {
-    InstanceNorm2d* in = malloc(sizeof(InstanceNorm2d));
+    InstanceNorm2d* in = cml_malloc(sizeof(InstanceNorm2d));
     if (!in)
         return NULL;
 
     if (module_init((Module*)in, "InstanceNorm2d", instancenorm2d_forward, instancenorm2d_free) !=
         0) {
-        free(in);
+        cml_free(in);
         return NULL;
     }
 

--- a/src/nn/layers/layernorm.c
+++ b/src/nn/layers/layernorm.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 static Tensor* layernorm_forward(Module* module, Tensor* input) {
     LayerNorm* ln = (LayerNorm*)module;
@@ -129,11 +130,11 @@ LayerNorm* nn_layernorm(int normalized_shape, float eps, bool affine, DType dtyp
         return NULL;
     }
 
-    LayerNorm* ln = malloc(sizeof(LayerNorm));
+    LayerNorm* ln = cml_malloc(sizeof(LayerNorm));
     if (!ln)
         return NULL;
     if (module_init((Module*)ln, "LayerNorm", layernorm_forward, layernorm_free) != 0) {
-        free(ln);
+        cml_free(ln);
         return NULL;
     }
     ln->normalized_shape = normalized_shape;

--- a/src/nn/layers/layernorm2d.c
+++ b/src/nn/layers/layernorm2d.c
@@ -5,6 +5,7 @@
 #include "core/logging.h"
 #include <stdlib.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 static Tensor* layernorm2d_forward(Module* module, Tensor* input) {
     LayerNorm2d* ln = (LayerNorm2d*)module;
@@ -143,17 +144,17 @@ static void layernorm2d_free(Module* module) {
     LayerNorm2d* ln = (LayerNorm2d*)module;
     if (!ln)
         return;
-    free(ln);
+    cml_free(ln);
 }
 
 LayerNorm2d* nn_layernorm2d(int num_channels, float eps, bool affine, DType dtype,
                             DeviceType device) {
-    LayerNorm2d* ln = malloc(sizeof(LayerNorm2d));
+    LayerNorm2d* ln = cml_malloc(sizeof(LayerNorm2d));
     if (!ln)
         return NULL;
 
     if (module_init((Module*)ln, "LayerNorm2d", layernorm2d_forward, layernorm2d_free) != 0) {
-        free(ln);
+        cml_free(ln);
         return NULL;
     }
 

--- a/src/nn/layers/linear.c
+++ b/src/nn/layers/linear.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 Tensor* linear_forward(Module* module, Tensor* input) {
     Linear* linear = (Linear*)module;
@@ -45,7 +46,7 @@ static void linear_free_fn(Module* module) {
     if (!linear)
         return;
 
-    free(linear);
+    cml_free(linear);
 }
 
 static void xavier_init(Tensor* tensor, int in_features, int out_features) {
@@ -89,7 +90,7 @@ Linear* nn_linear(int in_features, int out_features, DType dtype, DeviceType dev
 Linear* nn_linear_with_init(int in_features, int out_features, DType dtype, DeviceType device,
                             bool use_bias, void (*weight_init)(Tensor*, int, int),
                             void (*bias_init)(Tensor*, int)) {
-    Linear* linear = malloc(sizeof(Linear));
+    Linear* linear = cml_malloc(sizeof(Linear));
     if (!linear) {
         LOG_ERROR("Failed to allocate memory for Linear layer");
         error_stack_push(CM_MEMORY_ALLOCATION_ERROR, "Failed to allocate memory for Linear layer",
@@ -99,7 +100,7 @@ Linear* nn_linear_with_init(int in_features, int out_features, DType dtype, Devi
     if (module_init((Module*)linear, "Linear", linear_forward, linear_free_fn) != 0) {
         error_stack_push(CM_OPERATION_FAILED, "Failed to initialize Linear module", __FILE__,
                          __LINE__, __func__);
-        free(linear);
+        cml_free(linear);
         return NULL;
     }
 

--- a/src/nn/layers/pixel_shuffle.c
+++ b/src/nn/layers/pixel_shuffle.c
@@ -4,6 +4,7 @@
 #include "core/logging.h"
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 Tensor* f_pixel_shuffle(Tensor* input, int upscale_factor) {
     if (!input) {
@@ -169,14 +170,14 @@ static void pixel_shuffle_free(Module* module) {
     PixelShuffle* layer = (PixelShuffle*)module;
     if (!layer)
         return;
-    free(layer);
+    cml_free(layer);
 }
 
 static void pixel_unshuffle_free(Module* module) {
     PixelUnshuffle* layer = (PixelUnshuffle*)module;
     if (!layer)
         return;
-    free(layer);
+    cml_free(layer);
 }
 
 PixelShuffle* nn_pixel_shuffle(int upscale_factor) {
@@ -185,7 +186,7 @@ PixelShuffle* nn_pixel_shuffle(int upscale_factor) {
         return NULL;
     }
 
-    PixelShuffle* layer = calloc(1, sizeof(PixelShuffle));
+    PixelShuffle* layer = cml_calloc(1, sizeof(PixelShuffle));
     if (!layer) {
         LOG_ERROR("PixelShuffle: failed to allocate memory");
         return NULL;
@@ -193,7 +194,7 @@ PixelShuffle* nn_pixel_shuffle(int upscale_factor) {
 
     if (module_init((Module*)layer, "PixelShuffle", pixel_shuffle_forward,
                     pixel_shuffle_free) != 0) {
-        free(layer);
+        cml_free(layer);
         return NULL;
     }
 
@@ -208,7 +209,7 @@ PixelUnshuffle* nn_pixel_unshuffle(int downscale_factor) {
         return NULL;
     }
 
-    PixelUnshuffle* layer = calloc(1, sizeof(PixelUnshuffle));
+    PixelUnshuffle* layer = cml_calloc(1, sizeof(PixelUnshuffle));
     if (!layer) {
         LOG_ERROR("PixelUnshuffle: failed to allocate memory");
         return NULL;
@@ -216,7 +217,7 @@ PixelUnshuffle* nn_pixel_unshuffle(int downscale_factor) {
 
     if (module_init((Module*)layer, "PixelUnshuffle", pixel_unshuffle_forward,
                     pixel_unshuffle_free) != 0) {
-        free(layer);
+        cml_free(layer);
         return NULL;
     }
 

--- a/src/nn/layers/pooling.c
+++ b/src/nn/layers/pooling.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include <float.h>
+#include "alloc/cml_allocator.h"
 
 static int pool2d_out_dim(int in_size, int kernel, int stride, int padding,
                           int dilation, bool ceil_mode) {
@@ -62,15 +63,15 @@ static Tensor* maxpool2d_forward(Module* module, Tensor* input) {
     return uop_maxpool2d(input, &params);
 }
 
-static void maxpool2d_free(Module* module) { free(module); }
+static void maxpool2d_free(Module* module) { cml_free(module); }
 
 MaxPool2d* nn_maxpool2d(int kernel_size, int stride, int padding, int dilation, bool ceil_mode) {
-    MaxPool2d* pool = malloc(sizeof(MaxPool2d));
+    MaxPool2d* pool = cml_malloc(sizeof(MaxPool2d));
     if (!pool)
         return NULL;
 
     if (module_init((Module*)pool, "MaxPool2d", maxpool2d_forward, maxpool2d_free) != 0) {
-        free(pool);
+        cml_free(pool);
         return NULL;
     }
 
@@ -123,16 +124,16 @@ static Tensor* avgpool2d_forward(Module* module, Tensor* input) {
     return uop_avgpool2d(input, &params);
 }
 
-static void avgpool2d_free(Module* module) { free(module); }
+static void avgpool2d_free(Module* module) { cml_free(module); }
 
 AvgPool2d* nn_avgpool2d(int kernel_size, int stride, int padding, bool ceil_mode,
                         bool count_include_pad) {
-    AvgPool2d* pool = malloc(sizeof(AvgPool2d));
+    AvgPool2d* pool = cml_malloc(sizeof(AvgPool2d));
     if (!pool)
         return NULL;
 
     if (module_init((Module*)pool, "AvgPool2d", avgpool2d_forward, avgpool2d_free) != 0) {
-        free(pool);
+        cml_free(pool);
         return NULL;
     }
 
@@ -205,13 +206,13 @@ static Tensor* maxpool3d_forward(Module* module, Tensor* input) {
     return output;
 }
 
-static void maxpool3d_free(Module* module) { free(module); }
+static void maxpool3d_free(Module* module) { cml_free(module); }
 
 MaxPool3d* nn_maxpool3d(int kernel_size, int stride, int padding, int dilation, bool ceil_mode) {
-    MaxPool3d* pool = malloc(sizeof(MaxPool3d));
+    MaxPool3d* pool = cml_malloc(sizeof(MaxPool3d));
     if (!pool) return NULL;
     if (module_init((Module*)pool, "MaxPool3d", maxpool3d_forward, maxpool3d_free) != 0) {
-        free(pool); return NULL;
+        cml_free(pool); return NULL;
     }
     for (int i = 0; i < 3; i++) {
         pool->kernel_size[i] = kernel_size;
@@ -282,13 +283,13 @@ static Tensor* avgpool3d_forward(Module* module, Tensor* input) {
     return output;
 }
 
-static void avgpool3d_free(Module* module) { free(module); }
+static void avgpool3d_free(Module* module) { cml_free(module); }
 
 AvgPool3d* nn_avgpool3d(int kernel_size, int stride, int padding, bool ceil_mode, bool count_include_pad) {
-    AvgPool3d* pool = malloc(sizeof(AvgPool3d));
+    AvgPool3d* pool = cml_malloc(sizeof(AvgPool3d));
     if (!pool) return NULL;
     if (module_init((Module*)pool, "AvgPool3d", avgpool3d_forward, avgpool3d_free) != 0) {
-        free(pool); return NULL;
+        cml_free(pool); return NULL;
     }
     for (int i = 0; i < 3; i++) {
         pool->kernel_size[i] = kernel_size;
@@ -340,13 +341,13 @@ static Tensor* maxpool1d_forward(Module* module, Tensor* input) {
     return output;
 }
 
-static void maxpool1d_free(Module* module) { free(module); }
+static void maxpool1d_free(Module* module) { cml_free(module); }
 
 MaxPool1d* nn_maxpool1d(int kernel_size, int stride, int padding, int dilation, bool ceil_mode) {
-    MaxPool1d* pool = malloc(sizeof(MaxPool1d));
+    MaxPool1d* pool = cml_malloc(sizeof(MaxPool1d));
     if (!pool) return NULL;
     if (module_init((Module*)pool, "MaxPool1d", maxpool1d_forward, maxpool1d_free) != 0) {
-        free(pool); return NULL;
+        cml_free(pool); return NULL;
     }
     pool->kernel_size = kernel_size;
     pool->stride = stride > 0 ? stride : kernel_size;
@@ -399,13 +400,13 @@ static Tensor* avgpool1d_forward(Module* module, Tensor* input) {
     return output;
 }
 
-static void avgpool1d_free(Module* module) { free(module); }
+static void avgpool1d_free(Module* module) { cml_free(module); }
 
 AvgPool1d* nn_avgpool1d(int kernel_size, int stride, int padding, bool ceil_mode, bool count_include_pad) {
-    AvgPool1d* pool = malloc(sizeof(AvgPool1d));
+    AvgPool1d* pool = cml_malloc(sizeof(AvgPool1d));
     if (!pool) return NULL;
     if (module_init((Module*)pool, "AvgPool1d", avgpool1d_forward, avgpool1d_free) != 0) {
-        free(pool); return NULL;
+        cml_free(pool); return NULL;
     }
     pool->kernel_size = kernel_size;
     pool->stride = stride > 0 ? stride : kernel_size;
@@ -459,13 +460,13 @@ static Tensor* adaptive_avgpool2d_forward(Module* module, Tensor* input) {
     return output;
 }
 
-static void adaptive_avgpool2d_free(Module* module) { free(module); }
+static void adaptive_avgpool2d_free(Module* module) { cml_free(module); }
 
 AdaptiveAvgPool2d* nn_adaptive_avgpool2d(int output_h, int output_w) {
-    AdaptiveAvgPool2d* pool = malloc(sizeof(AdaptiveAvgPool2d));
+    AdaptiveAvgPool2d* pool = cml_malloc(sizeof(AdaptiveAvgPool2d));
     if (!pool) return NULL;
     if (module_init((Module*)pool, "AdaptiveAvgPool2d", adaptive_avgpool2d_forward, adaptive_avgpool2d_free) != 0) {
-        free(pool); return NULL;
+        cml_free(pool); return NULL;
     }
     pool->output_size[0] = output_h;
     pool->output_size[1] = output_w;
@@ -505,13 +506,13 @@ static Tensor* adaptive_avgpool1d_forward(Module* module, Tensor* input) {
     return output;
 }
 
-static void adaptive_avgpool1d_free(Module* module) { free(module); }
+static void adaptive_avgpool1d_free(Module* module) { cml_free(module); }
 
 AdaptiveAvgPool1d* nn_adaptive_avgpool1d(int output_size) {
-    AdaptiveAvgPool1d* pool = malloc(sizeof(AdaptiveAvgPool1d));
+    AdaptiveAvgPool1d* pool = cml_malloc(sizeof(AdaptiveAvgPool1d));
     if (!pool) return NULL;
     if (module_init((Module*)pool, "AdaptiveAvgPool1d", adaptive_avgpool1d_forward, adaptive_avgpool1d_free) != 0) {
-        free(pool); return NULL;
+        cml_free(pool); return NULL;
     }
     pool->output_size = output_size;
     return pool;
@@ -559,13 +560,13 @@ static Tensor* adaptive_maxpool2d_forward(Module* module, Tensor* input) {
     return output;
 }
 
-static void adaptive_maxpool2d_free(Module* module) { free(module); }
+static void adaptive_maxpool2d_free(Module* module) { cml_free(module); }
 
 AdaptiveMaxPool2d* nn_adaptive_maxpool2d(int output_h, int output_w) {
-    AdaptiveMaxPool2d* pool = malloc(sizeof(AdaptiveMaxPool2d));
+    AdaptiveMaxPool2d* pool = cml_malloc(sizeof(AdaptiveMaxPool2d));
     if (!pool) return NULL;
     if (module_init((Module*)pool, "AdaptiveMaxPool2d", adaptive_maxpool2d_forward, adaptive_maxpool2d_free) != 0) {
-        free(pool); return NULL;
+        cml_free(pool); return NULL;
     }
     pool->output_size[0] = output_h;
     pool->output_size[1] = output_w;
@@ -607,13 +608,13 @@ static Tensor* adaptive_maxpool1d_forward(Module* module, Tensor* input) {
     return output;
 }
 
-static void adaptive_maxpool1d_free(Module* module) { free(module); }
+static void adaptive_maxpool1d_free(Module* module) { cml_free(module); }
 
 AdaptiveMaxPool1d* nn_adaptive_maxpool1d(int output_size) {
-    AdaptiveMaxPool1d* pool = malloc(sizeof(AdaptiveMaxPool1d));
+    AdaptiveMaxPool1d* pool = cml_malloc(sizeof(AdaptiveMaxPool1d));
     if (!pool) return NULL;
     if (module_init((Module*)pool, "AdaptiveMaxPool1d", adaptive_maxpool1d_forward, adaptive_maxpool1d_free) != 0) {
-        free(pool); return NULL;
+        cml_free(pool); return NULL;
     }
     pool->output_size = output_size;
     return pool;

--- a/src/nn/layers/prelu.c
+++ b/src/nn/layers/prelu.c
@@ -3,6 +3,7 @@
 #include "tensor/tensor.h"
 #include "ops/uops.h"
 #include <stdlib.h>
+#include "alloc/cml_allocator.h"
 
 static Tensor* prelu_forward(Module* module, Tensor* input) {
     PReLU* prelu = (PReLU*)module;
@@ -25,18 +26,18 @@ static Tensor* prelu_forward(Module* module, Tensor* input) {
 }
 
 static void prelu_free(Module* module) {
-    free(module);
+    cml_free(module);
 }
 
 PReLU* nn_prelu(int num_parameters, float init, DType dtype, DeviceType device) {
     if (num_parameters <= 0) num_parameters = 1;
     if (init == 0.0f) init = 0.25f;
 
-    PReLU* prelu = malloc(sizeof(PReLU));
+    PReLU* prelu = cml_malloc(sizeof(PReLU));
     if (!prelu) return NULL;
 
     if (module_init((Module*)prelu, "PReLU", prelu_forward, prelu_free) != 0) {
-        free(prelu);
+        cml_free(prelu);
         return NULL;
     }
 

--- a/src/nn/layers/rmsnorm.c
+++ b/src/nn/layers/rmsnorm.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 static Tensor* rmsnorm_forward(Module* module, Tensor* input) {
     RMSNorm* rn = (RMSNorm*)module;
@@ -94,12 +95,12 @@ RMSNorm* nn_rmsnorm(int normalized_shape, float eps, DType dtype, DeviceType dev
         return NULL;
     }
 
-    RMSNorm* rn = malloc(sizeof(RMSNorm));
+    RMSNorm* rn = cml_malloc(sizeof(RMSNorm));
     if (!rn)
         return NULL;
 
     if (module_init((Module*)rn, "RMSNorm", rmsnorm_forward, rmsnorm_free) != 0) {
-        free(rn);
+        cml_free(rn);
         return NULL;
     }
 

--- a/src/nn/layers/rnn.c
+++ b/src/nn/layers/rnn.c
@@ -8,6 +8,7 @@
 #include <math.h>
 #include <string.h>
 #include <stdio.h>
+#include "alloc/cml_allocator.h"
 
 
 static Tensor* rnn_cell_module_forward(Module* module, Tensor* input) {
@@ -25,19 +26,19 @@ static void rnn_cell_free(Module* module) {
             if (!p)
                 continue;
             if (p->name)
-                free(p->name);
+                cml_free(p->name);
             if (p->tensor)
                 tensor_free(p->tensor);
-            free(p);
+            cml_free(p);
         }
-        free(module->parameters);
+        cml_free(module->parameters);
         module->parameters = NULL;
     }
     if (module->name) {
-        free(module->name);
+        cml_free(module->name);
         module->name = NULL;
     }
-    free(module);
+    cml_free(module);
 }
 
 Tensor* rnn_cell_forward(RNNCell* cell, Tensor* input, Tensor* hidden) {
@@ -74,12 +75,12 @@ Tensor* rnn_cell_forward(RNNCell* cell, Tensor* input, Tensor* hidden) {
 
 RNNCell* nn_rnn_cell(int input_size, int hidden_size, bool use_bias,
                      DType dtype, DeviceType device) {
-    RNNCell* cell = malloc(sizeof(RNNCell));
+    RNNCell* cell = cml_malloc(sizeof(RNNCell));
     if (!cell) return NULL;
 
     if (module_init((Module*)cell, "RNNCell",
                     rnn_cell_module_forward, rnn_cell_free) != 0) {
-        free(cell);
+        cml_free(cell);
         return NULL;
     }
 
@@ -143,19 +144,19 @@ static void lstm_cell_free(Module* module) {
             if (!p)
                 continue;
             if (p->name)
-                free(p->name);
+                cml_free(p->name);
             if (p->tensor)
                 tensor_free(p->tensor);
-            free(p);
+            cml_free(p);
         }
-        free(module->parameters);
+        cml_free(module->parameters);
         module->parameters = NULL;
     }
     if (module->name) {
-        free(module->name);
+        cml_free(module->name);
         module->name = NULL;
     }
-    free(module);
+    cml_free(module);
 }
 
 void lstm_cell_forward(LSTMCell* cell, Tensor* input,
@@ -227,12 +228,12 @@ void lstm_cell_forward(LSTMCell* cell, Tensor* input,
 
 LSTMCell* nn_lstm_cell(int input_size, int hidden_size, bool use_bias,
                        DType dtype, DeviceType device) {
-    LSTMCell* cell = malloc(sizeof(LSTMCell));
+    LSTMCell* cell = cml_malloc(sizeof(LSTMCell));
     if (!cell) return NULL;
 
     if (module_init((Module*)cell, "LSTMCell",
                     lstm_cell_module_forward, lstm_cell_free) != 0) {
-        free(cell);
+        cml_free(cell);
         return NULL;
     }
 
@@ -297,19 +298,19 @@ static void gru_cell_free(Module* module) {
             if (!p)
                 continue;
             if (p->name)
-                free(p->name);
+                cml_free(p->name);
             if (p->tensor)
                 tensor_free(p->tensor);
-            free(p);
+            cml_free(p);
         }
-        free(module->parameters);
+        cml_free(module->parameters);
         module->parameters = NULL;
     }
     if (module->name) {
-        free(module->name);
+        cml_free(module->name);
         module->name = NULL;
     }
-    free(module);
+    cml_free(module);
 }
 
 Tensor* gru_cell_forward(GRUCell* cell, Tensor* input, Tensor* hidden) {
@@ -368,12 +369,12 @@ Tensor* gru_cell_forward(GRUCell* cell, Tensor* input, Tensor* hidden) {
 
 GRUCell* nn_gru_cell(int input_size, int hidden_size, bool use_bias,
                      DType dtype, DeviceType device) {
-    GRUCell* cell = malloc(sizeof(GRUCell));
+    GRUCell* cell = cml_malloc(sizeof(GRUCell));
     if (!cell) return NULL;
 
     if (module_init((Module*)cell, "GRUCell",
                     gru_cell_module_forward, gru_cell_free) != 0) {
-        free(cell);
+        cml_free(cell);
         return NULL;
     }
 
@@ -443,7 +444,7 @@ static void register_cell_params(Module* parent, Module* cell,
                     pt->ref_count--;
             }
         }
-        if (params) free(params);
+        if (params) cml_free(params);
     }
 }
 
@@ -489,19 +490,19 @@ static void rnn_free(Module* module) {
                 rnn_cell_free((Module*)rnn->cells[i]);
             }
         }
-        free(rnn->cells);
+        cml_free(rnn->cells);
     }
-    free(rnn);
+    cml_free(rnn);
 }
 
 RNN* nn_rnn(int input_size, int hidden_size, int num_layers, bool bidirectional,
             bool batch_first, float dropout, bool use_bias,
             DType dtype, DeviceType device) {
-    RNN* rnn = malloc(sizeof(RNN));
+    RNN* rnn = cml_malloc(sizeof(RNN));
     if (!rnn) return NULL;
 
     if (module_init((Module*)rnn, "RNN", rnn_module_forward, rnn_free) != 0) {
-        free(rnn);
+        cml_free(rnn);
         return NULL;
     }
 
@@ -517,8 +518,8 @@ RNN* nn_rnn(int input_size, int hidden_size, int num_layers, bool bidirectional,
     rnn->num_directions = bidirectional ? 2 : 1;
 
     int total = num_layers * rnn->num_directions;
-    rnn->cells = calloc((size_t)total, sizeof(RNNCell*));
-    if (!rnn->cells) { free(rnn); return NULL; }
+    rnn->cells = cml_calloc((size_t)total, sizeof(RNNCell*));
+    if (!rnn->cells) { cml_free(rnn); return NULL; }
 
     for (int l = 0; l < num_layers; l++) {
         int cell_input = (l == 0) ? input_size
@@ -548,14 +549,14 @@ void rnn_forward(RNN* rnn, Tensor* input, Tensor* h_0,
     int seq_len = x->shape[0];
     int total_dirs = rnn->num_layers * nd;
 
-    Tensor** final_h = calloc((size_t)total_dirs, sizeof(Tensor*));
+    Tensor** final_h = cml_calloc((size_t)total_dirs, sizeof(Tensor*));
     Tensor* layer_input = x;
 
     for (int l = 0; l < rnn->num_layers; l++) {
         RNNCell* fwd_cell = rnn->cells[l * nd + 0];
 
         Tensor* h_fwd = h_0 ? slice_timestep(h_0, l * nd + 0) : NULL;
-        Tensor** fwd_steps = malloc((size_t)seq_len * sizeof(Tensor*));
+        Tensor** fwd_steps = cml_malloc((size_t)seq_len * sizeof(Tensor*));
 
         for (int t = 0; t < seq_len; t++) {
             Tensor* xt = slice_timestep(layer_input, t);
@@ -565,13 +566,13 @@ void rnn_forward(RNN* rnn, Tensor* input, Tensor* h_0,
         final_h[l * nd + 0] = h_fwd;
 
         Tensor* fwd_out = uop_stack(fwd_steps, seq_len, 0);
-        free(fwd_steps);
+        cml_free(fwd_steps);
 
         Tensor* layer_output;
         if (nd == 2) {
             RNNCell* rev_cell = rnn->cells[l * nd + 1];
             Tensor* h_rev = h_0 ? slice_timestep(h_0, l * nd + 1) : NULL;
-            Tensor** rev_steps = malloc((size_t)seq_len * sizeof(Tensor*));
+            Tensor** rev_steps = cml_malloc((size_t)seq_len * sizeof(Tensor*));
 
             for (int t = seq_len - 1; t >= 0; t--) {
                 Tensor* xt = slice_timestep(layer_input, t);
@@ -581,7 +582,7 @@ void rnn_forward(RNN* rnn, Tensor* input, Tensor* h_0,
             final_h[l * nd + 1] = h_rev;
 
             Tensor* rev_out = uop_stack(rev_steps, seq_len, 0);
-            free(rev_steps);
+            cml_free(rev_steps);
 
             layer_output = concat_features(fwd_out, rev_out);
         } else {
@@ -592,7 +593,7 @@ void rnn_forward(RNN* rnn, Tensor* input, Tensor* h_0,
     }
 
     Tensor* hn = uop_stack(final_h, total_dirs, 0);
-    free(final_h);
+    cml_free(final_h);
 
     if (rnn->batch_first)
         layer_input = transpose_01(layer_input);
@@ -615,19 +616,19 @@ static void lstm_free(Module* module) {
                 lstm_cell_free((Module*)lstm->cells[i]);
             }
         }
-        free(lstm->cells);
+        cml_free(lstm->cells);
     }
-    free(lstm);
+    cml_free(lstm);
 }
 
 LSTM* nn_lstm(int input_size, int hidden_size, int num_layers, bool bidirectional,
               bool batch_first, float dropout, bool use_bias,
               DType dtype, DeviceType device) {
-    LSTM* lstm = malloc(sizeof(LSTM));
+    LSTM* lstm = cml_malloc(sizeof(LSTM));
     if (!lstm) return NULL;
 
     if (module_init((Module*)lstm, "LSTM", lstm_module_forward, lstm_free) != 0) {
-        free(lstm);
+        cml_free(lstm);
         return NULL;
     }
 
@@ -643,8 +644,8 @@ LSTM* nn_lstm(int input_size, int hidden_size, int num_layers, bool bidirectiona
     lstm->num_directions = bidirectional ? 2 : 1;
 
     int total = num_layers * lstm->num_directions;
-    lstm->cells = calloc((size_t)total, sizeof(LSTMCell*));
-    if (!lstm->cells) { free(lstm); return NULL; }
+    lstm->cells = cml_calloc((size_t)total, sizeof(LSTMCell*));
+    if (!lstm->cells) { cml_free(lstm); return NULL; }
 
     for (int l = 0; l < num_layers; l++) {
         int cell_input = (l == 0) ? input_size
@@ -674,8 +675,8 @@ void lstm_forward(LSTM* lstm, Tensor* input, Tensor* h_0, Tensor* c_0,
 
     int seq_len = x->shape[0];
 
-    Tensor** final_h = calloc((size_t)total_dirs, sizeof(Tensor*));
-    Tensor** final_c = calloc((size_t)total_dirs, sizeof(Tensor*));
+    Tensor** final_h = cml_calloc((size_t)total_dirs, sizeof(Tensor*));
+    Tensor** final_c = cml_calloc((size_t)total_dirs, sizeof(Tensor*));
     Tensor* layer_input = x;
 
     for (int l = 0; l < lstm->num_layers; l++) {
@@ -683,7 +684,7 @@ void lstm_forward(LSTM* lstm, Tensor* input, Tensor* h_0, Tensor* c_0,
 
         Tensor* h_fwd = h_0 ? slice_timestep(h_0, l * nd + 0) : NULL;
         Tensor* c_fwd = c_0 ? slice_timestep(c_0, l * nd + 0) : NULL;
-        Tensor** fwd_steps = malloc((size_t)seq_len * sizeof(Tensor*));
+        Tensor** fwd_steps = cml_malloc((size_t)seq_len * sizeof(Tensor*));
 
         for (int t = 0; t < seq_len; t++) {
             Tensor* xt = slice_timestep(layer_input, t);
@@ -698,14 +699,14 @@ void lstm_forward(LSTM* lstm, Tensor* input, Tensor* h_0, Tensor* c_0,
         final_c[l * nd + 0] = c_fwd;
 
         Tensor* fwd_out = uop_stack(fwd_steps, seq_len, 0);
-        free(fwd_steps);
+        cml_free(fwd_steps);
 
         Tensor* layer_output;
         if (nd == 2) {
             LSTMCell* rev_cell = lstm->cells[l * nd + 1];
             Tensor* h_rev = h_0 ? slice_timestep(h_0, l * nd + 1) : NULL;
             Tensor* c_rev = c_0 ? slice_timestep(c_0, l * nd + 1) : NULL;
-            Tensor** rev_steps = malloc((size_t)seq_len * sizeof(Tensor*));
+            Tensor** rev_steps = cml_malloc((size_t)seq_len * sizeof(Tensor*));
 
             for (int t = seq_len - 1; t >= 0; t--) {
                 Tensor* xt = slice_timestep(layer_input, t);
@@ -720,7 +721,7 @@ void lstm_forward(LSTM* lstm, Tensor* input, Tensor* h_0, Tensor* c_0,
             final_c[l * nd + 1] = c_rev;
 
             Tensor* rev_out = uop_stack(rev_steps, seq_len, 0);
-            free(rev_steps);
+            cml_free(rev_steps);
 
             layer_output = concat_features(fwd_out, rev_out);
         } else {
@@ -732,8 +733,8 @@ void lstm_forward(LSTM* lstm, Tensor* input, Tensor* h_0, Tensor* c_0,
 
     Tensor* hn = uop_stack(final_h, total_dirs, 0);
     Tensor* cn = uop_stack(final_c, total_dirs, 0);
-    free(final_h);
-    free(final_c);
+    cml_free(final_h);
+    cml_free(final_c);
 
     if (lstm->batch_first)
         layer_input = transpose_01(layer_input);
@@ -757,19 +758,19 @@ static void gru_free(Module* module) {
                 gru_cell_free((Module*)gru->cells[i]);
             }
         }
-        free(gru->cells);
+        cml_free(gru->cells);
     }
-    free(gru);
+    cml_free(gru);
 }
 
 GRU* nn_gru(int input_size, int hidden_size, int num_layers, bool bidirectional,
             bool batch_first, float dropout, bool use_bias,
             DType dtype, DeviceType device) {
-    GRU* gru = malloc(sizeof(GRU));
+    GRU* gru = cml_malloc(sizeof(GRU));
     if (!gru) return NULL;
 
     if (module_init((Module*)gru, "GRU", gru_module_forward, gru_free) != 0) {
-        free(gru);
+        cml_free(gru);
         return NULL;
     }
 
@@ -785,8 +786,8 @@ GRU* nn_gru(int input_size, int hidden_size, int num_layers, bool bidirectional,
     gru->num_directions = bidirectional ? 2 : 1;
 
     int total = num_layers * gru->num_directions;
-    gru->cells = calloc((size_t)total, sizeof(GRUCell*));
-    if (!gru->cells) { free(gru); return NULL; }
+    gru->cells = cml_calloc((size_t)total, sizeof(GRUCell*));
+    if (!gru->cells) { cml_free(gru); return NULL; }
 
     for (int l = 0; l < num_layers; l++) {
         int cell_input = (l == 0) ? input_size
@@ -816,14 +817,14 @@ void gru_forward(GRU* gru, Tensor* input, Tensor* h_0,
 
     int seq_len = x->shape[0];
 
-    Tensor** final_h = calloc((size_t)total_dirs, sizeof(Tensor*));
+    Tensor** final_h = cml_calloc((size_t)total_dirs, sizeof(Tensor*));
     Tensor* layer_input = x;
 
     for (int l = 0; l < gru->num_layers; l++) {
         GRUCell* fwd_cell = gru->cells[l * nd + 0];
 
         Tensor* h_fwd = h_0 ? slice_timestep(h_0, l * nd + 0) : NULL;
-        Tensor** fwd_steps = malloc((size_t)seq_len * sizeof(Tensor*));
+        Tensor** fwd_steps = cml_malloc((size_t)seq_len * sizeof(Tensor*));
 
         for (int t = 0; t < seq_len; t++) {
             Tensor* xt = slice_timestep(layer_input, t);
@@ -833,13 +834,13 @@ void gru_forward(GRU* gru, Tensor* input, Tensor* h_0,
         final_h[l * nd + 0] = h_fwd;
 
         Tensor* fwd_out = uop_stack(fwd_steps, seq_len, 0);
-        free(fwd_steps);
+        cml_free(fwd_steps);
 
         Tensor* layer_output;
         if (nd == 2) {
             GRUCell* rev_cell = gru->cells[l * nd + 1];
             Tensor* h_rev = h_0 ? slice_timestep(h_0, l * nd + 1) : NULL;
-            Tensor** rev_steps = malloc((size_t)seq_len * sizeof(Tensor*));
+            Tensor** rev_steps = cml_malloc((size_t)seq_len * sizeof(Tensor*));
 
             for (int t = seq_len - 1; t >= 0; t--) {
                 Tensor* xt = slice_timestep(layer_input, t);
@@ -849,7 +850,7 @@ void gru_forward(GRU* gru, Tensor* input, Tensor* h_0,
             final_h[l * nd + 1] = h_rev;
 
             Tensor* rev_out = uop_stack(rev_steps, seq_len, 0);
-            free(rev_steps);
+            cml_free(rev_steps);
 
             layer_output = concat_features(fwd_out, rev_out);
         } else {
@@ -860,7 +861,7 @@ void gru_forward(GRU* gru, Tensor* input, Tensor* h_0,
     }
 
     Tensor* hn = uop_stack(final_h, total_dirs, 0);
-    free(final_h);
+    cml_free(final_h);
 
     if (gru->batch_first)
         layer_input = transpose_01(layer_input);

--- a/src/nn/layers/rnn.c
+++ b/src/nn/layers/rnn.c
@@ -550,6 +550,7 @@ void rnn_forward(RNN* rnn, Tensor* input, Tensor* h_0,
     int total_dirs = rnn->num_layers * nd;
 
     Tensor** final_h = cml_calloc((size_t)total_dirs, sizeof(Tensor*));
+    if (!final_h) return;
     Tensor* layer_input = x;
 
     for (int l = 0; l < rnn->num_layers; l++) {
@@ -557,6 +558,10 @@ void rnn_forward(RNN* rnn, Tensor* input, Tensor* h_0,
 
         Tensor* h_fwd = h_0 ? slice_timestep(h_0, l * nd + 0) : NULL;
         Tensor** fwd_steps = cml_malloc((size_t)seq_len * sizeof(Tensor*));
+        if (!fwd_steps) {
+            cml_free(final_h);
+            return;
+        }
 
         for (int t = 0; t < seq_len; t++) {
             Tensor* xt = slice_timestep(layer_input, t);
@@ -573,6 +578,10 @@ void rnn_forward(RNN* rnn, Tensor* input, Tensor* h_0,
             RNNCell* rev_cell = rnn->cells[l * nd + 1];
             Tensor* h_rev = h_0 ? slice_timestep(h_0, l * nd + 1) : NULL;
             Tensor** rev_steps = cml_malloc((size_t)seq_len * sizeof(Tensor*));
+            if (!rev_steps) {
+                cml_free(final_h);
+                return;
+            }
 
             for (int t = seq_len - 1; t >= 0; t--) {
                 Tensor* xt = slice_timestep(layer_input, t);
@@ -818,6 +827,7 @@ void gru_forward(GRU* gru, Tensor* input, Tensor* h_0,
     int seq_len = x->shape[0];
 
     Tensor** final_h = cml_calloc((size_t)total_dirs, sizeof(Tensor*));
+    if (!final_h) return;
     Tensor* layer_input = x;
 
     for (int l = 0; l < gru->num_layers; l++) {
@@ -825,6 +835,10 @@ void gru_forward(GRU* gru, Tensor* input, Tensor* h_0,
 
         Tensor* h_fwd = h_0 ? slice_timestep(h_0, l * nd + 0) : NULL;
         Tensor** fwd_steps = cml_malloc((size_t)seq_len * sizeof(Tensor*));
+        if (!fwd_steps) {
+            cml_free(final_h);
+            return;
+        }
 
         for (int t = 0; t < seq_len; t++) {
             Tensor* xt = slice_timestep(layer_input, t);
@@ -841,6 +855,10 @@ void gru_forward(GRU* gru, Tensor* input, Tensor* h_0,
             GRUCell* rev_cell = gru->cells[l * nd + 1];
             Tensor* h_rev = h_0 ? slice_timestep(h_0, l * nd + 1) : NULL;
             Tensor** rev_steps = cml_malloc((size_t)seq_len * sizeof(Tensor*));
+            if (!rev_steps) {
+                cml_free(final_h);
+                return;
+            }
 
             for (int t = seq_len - 1; t >= 0; t--) {
                 Tensor* xt = slice_timestep(layer_input, t);

--- a/src/nn/layers/sequential.c
+++ b/src/nn/layers/sequential.c
@@ -19,6 +19,7 @@
 #include <stdbool.h>
 #if defined(__AVX2__)
 #include <immintrin.h>
+#include "alloc/cml_allocator.h"
 #endif
 
 static size_t alloc_size_aligned(size_t size, size_t alignment);
@@ -77,15 +78,15 @@ static void fast_path_free(SequentialFastPath* fp) {
     }
     for (int i = 0; i < fp->num_ops; i++) {
         if (fp->ops[i].weight_transposed)
-            free(fp->ops[i].weight_transposed);
+            cml_free(fp->ops[i].weight_transposed);
         if (fp->ops[i].out_buf &&
             (i == 0 || fp->ops[i].out_buf != fp->ops[i - 1].out_buf)) {
-            free(fp->ops[i].out_buf);
+            cml_free(fp->ops[i].out_buf);
         }
     }
-    free(fp->ops);
-    free(fp->input_shape);
-    free(fp);
+    cml_free(fp->ops);
+    cml_free(fp->input_shape);
+    cml_free(fp);
 }
 
 /* Build a SequentialFastPath from the module list and a sample input tensor.
@@ -95,14 +96,14 @@ static SequentialFastPath* fast_path_build(Sequential* seq, Tensor* input) {
     /* Only build when NOT in training mode (weights must be frozen). */
     if (((Module*)seq)->training) return NULL;
 
-    SequentialFastPath* fp = calloc(1, sizeof(SequentialFastPath));
+    SequentialFastPath* fp = cml_calloc(1, sizeof(SequentialFastPath));
     if (!fp) return NULL;
 
-    fp->ops = calloc((size_t)seq->num_modules, sizeof(FastOp));
-    if (!fp->ops) { free(fp); return NULL; }
+    fp->ops = cml_calloc((size_t)seq->num_modules, sizeof(FastOp));
+    if (!fp->ops) { cml_free(fp); return NULL; }
 
-    fp->input_shape = malloc(sizeof(int) * input->ndim);
-    if (!fp->input_shape) { free(fp->ops); free(fp); return NULL; }
+    fp->input_shape = cml_malloc(sizeof(int) * input->ndim);
+    if (!fp->input_shape) { cml_free(fp->ops); cml_free(fp); return NULL; }
     memcpy(fp->input_shape, input->shape, sizeof(int) * input->ndim);
     fp->input_ndim  = input->ndim;
     fp->input_numel = input->numel;
@@ -133,7 +134,7 @@ static SequentialFastPath* fast_path_build(Sequential* seq, Tensor* input) {
 
             /* Pre-transpose weight from (out×in) → (in×out) so the BLAS call
              * is NoTrans/NoTrans — enables our AVX2 microkernel for small sizes. */
-            op->weight_transposed = malloc(
+            op->weight_transposed = cml_malloc(
                 (size_t)lin->in_features * lin->out_features * sizeof(float));
             if (!op->weight_transposed) { fast_path_free(fp); return NULL; }
             {
@@ -193,7 +194,7 @@ static SequentialFastPath* fast_path_build(Sequential* seq, Tensor* input) {
     fp->output_tensor = tensor_empty(out_shape, out_ndim, NULL);
     if (!fp->output_tensor) { fast_path_free(fp); return NULL; }
     if (fp->output_tensor->owns_data && fp->output_tensor->data)
-        free(fp->output_tensor->data);
+        cml_free(fp->output_tensor->data);
     fp->output_tensor->data      = fp->result_buf;
     fp->output_tensor->owns_data = false;
     fp->output_tensor->is_executed = true;
@@ -296,15 +297,15 @@ static void free_cached_graph(CachedModelGraph* cache) {
         cml_free_execution_plan(cache->plan);
     }
     if (cache->input_shape) {
-        free(cache->input_shape);
+        cml_free(cache->input_shape);
     }
     if (cache->input_buffer) {
-        free(cache->input_buffer);
+        cml_free(cache->input_buffer);
     }
     if (cache->output_buffer) {
-        free(cache->output_buffer);
+        cml_free(cache->output_buffer);
     }
-    free(cache);
+    cml_free(cache);
 }
 
 static bool shapes_match(CachedModelGraph* cache, Tensor* input) {
@@ -324,14 +325,14 @@ static CachedModelGraph* create_cached_graph(Tensor* input, Tensor* output, CMLG
     if (!input || !output || !ir)
         return NULL;
 
-    CachedModelGraph* cache = calloc(1, sizeof(CachedModelGraph));
+    CachedModelGraph* cache = cml_calloc(1, sizeof(CachedModelGraph));
     if (!cache)
         return NULL;
 
     cache->input_ndim  = input->ndim;
-    cache->input_shape = malloc(sizeof(int) * input->ndim);
+    cache->input_shape = cml_malloc(sizeof(int) * input->ndim);
     if (!cache->input_shape) {
-        free(cache);
+        cml_free(cache);
         return NULL;
     }
     memcpy(cache->input_shape, input->shape, sizeof(int) * input->ndim);
@@ -340,8 +341,8 @@ static CachedModelGraph* create_cached_graph(Tensor* input, Tensor* output, CMLG
     cache->input_buffer =
         aligned_alloc(32, alloc_size_aligned((size_t)input->numel * sizeof(float), 32));
     if (!cache->input_buffer) {
-        free(cache->input_shape);
-        free(cache);
+        cml_free(cache->input_shape);
+        cml_free(cache);
         return NULL;
     }
 
@@ -349,18 +350,18 @@ static CachedModelGraph* create_cached_graph(Tensor* input, Tensor* output, CMLG
     cache->output_buffer =
         aligned_alloc(32, alloc_size_aligned((size_t)output->numel * sizeof(float), 32));
     if (!cache->output_buffer) {
-        free(cache->input_buffer);
-        free(cache->input_shape);
-        free(cache);
+        cml_free(cache->input_buffer);
+        cml_free(cache->input_shape);
+        cml_free(cache);
         return NULL;
     }
 
     cache->plan = cml_create_execution_plan(ir);
     if (!cache->plan) {
-        free(cache->output_buffer);
-        free(cache->input_buffer);
-        free(cache->input_shape);
-        free(cache);
+        cml_free(cache->output_buffer);
+        cml_free(cache->input_buffer);
+        cml_free(cache->input_shape);
+        cml_free(cache);
         return NULL;
     }
 
@@ -540,14 +541,14 @@ static void sequential_free(Module* module) {
                 module_free(seq->modules[i]);
             }
         }
-        free(seq->modules);
+        cml_free(seq->modules);
     }
 
-    free(seq);
+    cml_free(seq);
 }
 
 Sequential* nn_sequential(void) {
-    Sequential* seq = malloc(sizeof(Sequential));
+    Sequential* seq = cml_malloc(sizeof(Sequential));
     if (!seq) {
         error_stack_push(CM_MEMORY_ALLOCATION_ERROR,
                          "Failed to allocate memory for Sequential module", __FILE__, __LINE__,
@@ -558,7 +559,7 @@ Sequential* nn_sequential(void) {
     if (module_init((Module*)seq, "Sequential", sequential_forward, sequential_free) != 0) {
         error_stack_push(CM_OPERATION_FAILED, "Failed to initialize Sequential module", __FILE__,
                          __LINE__, __func__);
-        free(seq);
+        cml_free(seq);
         return NULL;
     }
 
@@ -581,7 +582,7 @@ int sequential_add(Sequential* seq, Module* module) {
         return -1;
     if (seq->num_modules >= seq->capacity) {
         int new_capacity     = seq->capacity == 0 ? 8 : seq->capacity * 2;
-        Module** new_modules = realloc(seq->modules, (size_t)new_capacity * sizeof(Module*));
+        Module** new_modules = cml_realloc(seq->modules, (size_t)new_capacity * sizeof(Module*));
         if (!new_modules) {
             LOG_ERROR("Failed to allocate memory for Sequential modules");
             return -1;
@@ -615,7 +616,7 @@ int sequential_add(Sequential* seq, Module* module) {
             }
         }
         if (params)
-            free(params);
+            cml_free(params);
     }
 
     LOG_DEBUG(

--- a/src/nn/layers/sequential.c
+++ b/src/nn/layers/sequential.c
@@ -81,7 +81,7 @@ static void fast_path_free(SequentialFastPath* fp) {
             cml_free(fp->ops[i].weight_transposed);
         if (fp->ops[i].out_buf &&
             (i == 0 || fp->ops[i].out_buf != fp->ops[i - 1].out_buf)) {
-            cml_free(fp->ops[i].out_buf);
+            cml_aligned_free(fp->ops[i].out_buf);
         }
     }
     cml_free(fp->ops);
@@ -147,7 +147,7 @@ static SequentialFastPath* fast_path_build(Sequential* seq, Tensor* input) {
             }
 
             size_t nbytes = alloc_size_aligned(op->out_numel * sizeof(float), 64);
-            op->out_buf   = aligned_alloc(64, nbytes);
+            op->out_buf   = cml_aligned_alloc(nbytes, 64);
             if (!op->out_buf) { fast_path_free(fp); return NULL; }
             prev_out       = op->out_buf;
             prev_out_numel = op->out_numel;
@@ -300,10 +300,10 @@ static void free_cached_graph(CachedModelGraph* cache) {
         cml_free(cache->input_shape);
     }
     if (cache->input_buffer) {
-        cml_free(cache->input_buffer);
+        cml_aligned_free(cache->input_buffer);
     }
     if (cache->output_buffer) {
-        cml_free(cache->output_buffer);
+        cml_aligned_free(cache->output_buffer);
     }
     cml_free(cache);
 }
@@ -339,7 +339,7 @@ static CachedModelGraph* create_cached_graph(Tensor* input, Tensor* output, CMLG
     cache->input_numel = input->numel;
 
     cache->input_buffer =
-        aligned_alloc(32, alloc_size_aligned((size_t)input->numel * sizeof(float), 32));
+        cml_aligned_alloc(alloc_size_aligned((size_t)input->numel * sizeof(float), 32), 32);
     if (!cache->input_buffer) {
         cml_free(cache->input_shape);
         cml_free(cache);
@@ -348,9 +348,9 @@ static CachedModelGraph* create_cached_graph(Tensor* input, Tensor* output, CMLG
 
     cache->output_numel  = output->numel;
     cache->output_buffer =
-        aligned_alloc(32, alloc_size_aligned((size_t)output->numel * sizeof(float), 32));
+        cml_aligned_alloc(alloc_size_aligned((size_t)output->numel * sizeof(float), 32), 32);
     if (!cache->output_buffer) {
-        cml_free(cache->input_buffer);
+        cml_aligned_free(cache->input_buffer);
         cml_free(cache->input_shape);
         cml_free(cache);
         return NULL;
@@ -358,8 +358,8 @@ static CachedModelGraph* create_cached_graph(Tensor* input, Tensor* output, CMLG
 
     cache->plan = cml_create_execution_plan(ir);
     if (!cache->plan) {
-        cml_free(cache->output_buffer);
-        cml_free(cache->input_buffer);
+        cml_aligned_free(cache->output_buffer);
+        cml_aligned_free(cache->input_buffer);
         cml_free(cache->input_shape);
         cml_free(cache);
         return NULL;

--- a/src/nn/layers/transformer.c
+++ b/src/nn/layers/transformer.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 static void xavier_init(float* data, size_t numel, int fan_in, int fan_out) {
     float scale = sqrtf(2.0f / (float)(fan_in + fan_out));
@@ -59,7 +60,7 @@ static Tensor* mha_module_forward(Module* module, Tensor* input) {
 static void mha_free(Module* module) {
     MultiHeadAttention* mha = (MultiHeadAttention*)module;
     if (!mha) return;
-    free(mha);
+    cml_free(mha);
 }
 
 MultiHeadAttention* nn_multihead_attention(int embed_dim, int num_heads, float dropout,
@@ -69,14 +70,14 @@ MultiHeadAttention* nn_multihead_attention(int embed_dim, int num_heads, float d
         return NULL;
     }
 
-    MultiHeadAttention* mha = malloc(sizeof(MultiHeadAttention));
+    MultiHeadAttention* mha = cml_malloc(sizeof(MultiHeadAttention));
     if (!mha) {
         LOG_ERROR("Failed to allocate MultiHeadAttention");
         return NULL;
     }
 
     if (module_init((Module*)mha, "MultiHeadAttention", mha_module_forward, mha_free) != 0) {
-        free(mha);
+        cml_free(mha);
         return NULL;
     }
 
@@ -224,19 +225,19 @@ static void encoder_layer_free(Module* module) {
     TransformerEncoderLayer* layer = (TransformerEncoderLayer*)module;
     if (!layer) return;
     if (layer->self_attn) module_free((Module*)layer->self_attn);
-    free(layer);
+    cml_free(layer);
 }
 
 TransformerEncoderLayer* nn_transformer_encoder_layer(int d_model, int nhead, int dim_feedforward,
                                                        float dropout, DType dtype, DeviceType device) {
-    TransformerEncoderLayer* layer = malloc(sizeof(TransformerEncoderLayer));
+    TransformerEncoderLayer* layer = cml_malloc(sizeof(TransformerEncoderLayer));
     if (!layer) {
         LOG_ERROR("Failed to allocate TransformerEncoderLayer");
         return NULL;
     }
 
     if (module_init((Module*)layer, "TransformerEncoderLayer", encoder_layer_forward, encoder_layer_free) != 0) {
-        free(layer);
+        cml_free(layer);
         return NULL;
     }
 
@@ -350,26 +351,26 @@ static void transformer_encoder_free(Module* module) {
         for (int i = 0; i < enc->num_layers; i++) {
             if (enc->layers[i]) module_free((Module*)enc->layers[i]);
         }
-        free(enc->layers);
+        cml_free(enc->layers);
     }
-    free(enc);
+    cml_free(enc);
 }
 
 TransformerEncoder* nn_transformer_encoder(int d_model, int nhead, int dim_feedforward,
                                             float dropout, int num_layers,
                                             DType dtype, DeviceType device) {
-    TransformerEncoder* enc = malloc(sizeof(TransformerEncoder));
+    TransformerEncoder* enc = cml_malloc(sizeof(TransformerEncoder));
     if (!enc) return NULL;
 
     if (module_init((Module*)enc, "TransformerEncoder", transformer_encoder_forward, transformer_encoder_free) != 0) {
-        free(enc); return NULL;
+        cml_free(enc); return NULL;
     }
 
     enc->d_model = d_model;
     enc->num_layers = num_layers;
     enc->norm_eps = 1e-5f;
 
-    enc->layers = malloc(num_layers * sizeof(TransformerEncoderLayer*));
+    enc->layers = cml_malloc(num_layers * sizeof(TransformerEncoderLayer*));
     if (!enc->layers) { module_free((Module*)enc); return NULL; }
 
     for (int i = 0; i < num_layers; i++) {
@@ -455,16 +456,16 @@ static void decoder_layer_free(Module* module) {
     if (!layer) return;
     if (layer->self_attn) module_free((Module*)layer->self_attn);
     if (layer->cross_attn) module_free((Module*)layer->cross_attn);
-    free(layer);
+    cml_free(layer);
 }
 
 TransformerDecoderLayer* nn_transformer_decoder_layer(int d_model, int nhead, int dim_feedforward,
                                                        float dropout, DType dtype, DeviceType device) {
-    TransformerDecoderLayer* layer = malloc(sizeof(TransformerDecoderLayer));
+    TransformerDecoderLayer* layer = cml_malloc(sizeof(TransformerDecoderLayer));
     if (!layer) return NULL;
 
     if (module_init((Module*)layer, "TransformerDecoderLayer", decoder_layer_forward_wrapper, decoder_layer_free) != 0) {
-        free(layer); return NULL;
+        cml_free(layer); return NULL;
     }
 
     layer->d_model = d_model;
@@ -573,26 +574,26 @@ static void transformer_decoder_free(Module* module) {
         for (int i = 0; i < dec->num_layers; i++) {
             if (dec->layers[i]) module_free((Module*)dec->layers[i]);
         }
-        free(dec->layers);
+        cml_free(dec->layers);
     }
-    free(dec);
+    cml_free(dec);
 }
 
 TransformerDecoder* nn_transformer_decoder(int d_model, int nhead, int dim_feedforward,
                                             float dropout, int num_layers,
                                             DType dtype, DeviceType device) {
-    TransformerDecoder* dec = malloc(sizeof(TransformerDecoder));
+    TransformerDecoder* dec = cml_malloc(sizeof(TransformerDecoder));
     if (!dec) return NULL;
 
     if (module_init((Module*)dec, "TransformerDecoder", transformer_decoder_forward, transformer_decoder_free) != 0) {
-        free(dec); return NULL;
+        cml_free(dec); return NULL;
     }
 
     dec->d_model = d_model;
     dec->num_layers = num_layers;
     dec->norm_eps = 1e-5f;
 
-    dec->layers = malloc(num_layers * sizeof(TransformerDecoderLayer*));
+    dec->layers = cml_malloc(num_layers * sizeof(TransformerDecoderLayer*));
     if (!dec->layers) { module_free((Module*)dec); return NULL; }
 
     for (int i = 0; i < num_layers; i++) {
@@ -631,7 +632,7 @@ KVCache* kv_cache_create(int batch, int num_heads, int max_seq_len, int head_dim
         return NULL;
     }
 
-    KVCache* cache = calloc(1, sizeof(KVCache));
+    KVCache* cache = cml_calloc(1, sizeof(KVCache));
     if (!cache) return NULL;
 
     cache->max_seq_len = max_seq_len;
@@ -641,12 +642,12 @@ KVCache* kv_cache_create(int batch, int num_heads, int max_seq_len, int head_dim
     int shape[] = {batch, num_heads, max_seq_len, head_dim};
 
     cache->key_cache = tensor_zeros(shape, 4, &config);
-    if (!cache->key_cache) { free(cache); return NULL; }
+    if (!cache->key_cache) { cml_free(cache); return NULL; }
 
     cache->value_cache = tensor_zeros(shape, 4, &config);
     if (!cache->value_cache) {
         tensor_free(cache->key_cache);
-        free(cache);
+        cml_free(cache);
         return NULL;
     }
 
@@ -657,7 +658,7 @@ void kv_cache_free(KVCache* cache) {
     if (!cache) return;
     if (cache->key_cache)   tensor_free(cache->key_cache);
     if (cache->value_cache) tensor_free(cache->value_cache);
-    free(cache);
+    cml_free(cache);
 }
 
 void kv_cache_reset(KVCache* cache) {
@@ -751,7 +752,7 @@ Tensor* multihead_attention_forward_cached(MultiHeadAttention* mha, Tensor* quer
 
     /* Build contiguous Q/K/V tensors for the lazy attention path. */
     int q4_shape[] = {batch, num_heads, seq_q, head_dim};
-    float* Q_mh = malloc((size_t)batch * num_heads * seq_q * head_dim * sizeof(float));
+    float* Q_mh = cml_malloc((size_t)batch * num_heads * seq_q * head_dim * sizeof(float));
     if (!Q_mh) return NULL;
     for (int b = 0; b < batch; b++)
         for (int s = 0; s < seq_q; s++)
@@ -760,9 +761,9 @@ Tensor* multihead_attention_forward_cached(MultiHeadAttention* mha, Tensor* quer
                     Q_mh[b*num_heads*seq_q*head_dim + h*seq_q*head_dim + s*head_dim + d] =
                         Q_data[b*seq_q*embed_dim + s*embed_dim + h*head_dim + d];
 
-    float* K_cached = malloc((size_t)batch * num_heads * cached_len * head_dim * sizeof(float));
-    float* V_cached = malloc((size_t)batch * num_heads * cached_len * head_dim * sizeof(float));
-    if (!K_cached || !V_cached) { free(Q_mh); free(K_cached); free(V_cached); return NULL; }
+    float* K_cached = cml_malloc((size_t)batch * num_heads * cached_len * head_dim * sizeof(float));
+    float* V_cached = cml_malloc((size_t)batch * num_heads * cached_len * head_dim * sizeof(float));
+    if (!K_cached || !V_cached) { cml_free(Q_mh); cml_free(K_cached); cml_free(V_cached); return NULL; }
 
     for (int b = 0; b < batch; b++)
         for (int h = 0; h < num_heads; h++)
@@ -776,10 +777,10 @@ Tensor* multihead_attention_forward_cached(MultiHeadAttention* mha, Tensor* quer
 
     TensorConfig cfg = {.dtype = query->dtype, .device = query->device,
                         .has_dtype = true, .has_device = true};
-    Tensor* Q_lazy = tensor_from_data(Q_mh, q4_shape, 4, &cfg); free(Q_mh);
+    Tensor* Q_lazy = tensor_from_data(Q_mh, q4_shape, 4, &cfg); cml_free(Q_mh);
     int k4_shape[] = {batch, num_heads, cached_len, head_dim};
-    Tensor* K_lazy = tensor_from_data(K_cached, k4_shape, 4, &cfg); free(K_cached);
-    Tensor* V_lazy = tensor_from_data(V_cached, k4_shape, 4, &cfg); free(V_cached);
+    Tensor* K_lazy = tensor_from_data(K_cached, k4_shape, 4, &cfg); cml_free(K_cached);
+    Tensor* V_lazy = tensor_from_data(V_cached, k4_shape, 4, &cfg); cml_free(V_cached);
     if (!Q_lazy || !K_lazy || !V_lazy) return NULL;
 
     Tensor* attn_out = uop_scaled_dot_product_attention(Q_lazy, K_lazy, V_lazy, mask);

--- a/src/nn/layers/upsample.c
+++ b/src/nn/layers/upsample.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 static float bicubic_kernel(float x) {
     float ax = fabsf(x);
@@ -388,19 +389,19 @@ static void upsample_free(Module* module) {
     Upsample* layer = (Upsample*)module;
     if (!layer)
         return;
-    free(layer);
+    cml_free(layer);
 }
 
 Upsample* nn_upsample(float scale_factor, const int* output_size, int num_output_dims,
                        UpsampleMode mode, bool align_corners) {
-    Upsample* layer = calloc(1, sizeof(Upsample));
+    Upsample* layer = cml_calloc(1, sizeof(Upsample));
     if (!layer) {
         LOG_ERROR("Upsample: failed to allocate memory");
         return NULL;
     }
 
     if (module_init((Module*)layer, "Upsample", upsample_forward, upsample_free) != 0) {
-        free(layer);
+        cml_free(layer);
         return NULL;
     }
 

--- a/src/nn/llama.c
+++ b/src/nn/llama.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <math.h>
 #include <time.h>
+#include "alloc/cml_allocator.h"
 
 CMLLLaMAConfig cml_llama_config_7b(void) {
     CMLLLaMAConfig config = {
@@ -155,7 +156,7 @@ static Tensor* swiglu_ffn(Tensor* x, Tensor* gate_proj, Tensor* up_proj, Tensor*
 }
 
 static CMLLLaMALayer* llama_layer_create(const CMLLLaMAConfig* config) {
-    CMLLLaMALayer* layer = (CMLLLaMALayer*)calloc(1, sizeof(CMLLLaMALayer));
+    CMLLLaMALayer* layer = (CMLLLaMALayer*)cml_calloc(1, sizeof(CMLLLaMALayer));
     if (!layer) return NULL;
 
     int head_dim = config->hidden_size / config->num_heads;
@@ -164,7 +165,7 @@ static CMLLLaMALayer* llama_layer_create(const CMLLLaMAConfig* config) {
     layer->kv_cache = cml_kv_cache_create(config->max_seq_len,
                                            config->num_kv_heads, head_dim);
     if (!layer->kv_cache) {
-        free(layer);
+        cml_free(layer);
         return NULL;
     }
 
@@ -188,7 +189,7 @@ static void llama_layer_free(CMLLLaMALayer* layer) {
     if (layer->post_attn_layernorm) tensor_free(layer->post_attn_layernorm);
     if (layer->kv_cache) cml_kv_cache_free(layer->kv_cache);
 
-    free(layer);
+    cml_free(layer);
 }
 
 CMLLLaMAModel* cml_llama_create(const CMLLLaMAConfig* config) {
@@ -197,7 +198,7 @@ CMLLLaMAModel* cml_llama_create(const CMLLLaMAConfig* config) {
         return NULL;
     }
 
-    CMLLLaMAModel* model = (CMLLLaMAModel*)calloc(1, sizeof(CMLLLaMAModel));
+    CMLLLaMAModel* model = (CMLLLaMAModel*)cml_calloc(1, sizeof(CMLLLaMAModel));
     if (!model) {
         LOG_ERROR("cml_llama_create: allocation failed");
         return NULL;
@@ -209,11 +210,11 @@ CMLLLaMAModel* cml_llama_create(const CMLLLaMAConfig* config) {
     model->current_seq_len = 0;
 
     /* Allocate layer array */
-    model->layers = (CMLLLaMALayer**)calloc((size_t)config->num_layers,
+    model->layers = (CMLLLaMALayer**)cml_calloc((size_t)config->num_layers,
                                              sizeof(CMLLLaMALayer*));
     if (!model->layers) {
         LOG_ERROR("cml_llama_create: layer array allocation failed");
-        free(model);
+        cml_free(model);
         return NULL;
     }
 
@@ -226,8 +227,8 @@ CMLLLaMAModel* cml_llama_create(const CMLLLaMAConfig* config) {
             for (int j = 0; j < i; j++) {
                 llama_layer_free(model->layers[j]);
             }
-            free(model->layers);
-            free(model);
+            cml_free(model->layers);
+            cml_free(model);
             return NULL;
         }
     }
@@ -247,7 +248,7 @@ void cml_llama_free(CMLLLaMAModel* model) {
         for (int i = 0; i < model->num_layers; i++) {
             llama_layer_free(model->layers[i]);
         }
-        free(model->layers);
+        cml_free(model->layers);
     }
 
     /* Free embeddings and output weights */
@@ -258,7 +259,7 @@ void cml_llama_free(CMLLLaMAModel* model) {
     /* Free tokenizer */
     if (model->tokenizer) cml_tokenizer_free(model->tokenizer);
 
-    free(model);
+    cml_free(model);
 }
 
 static int load_tensor_by_name(CMLLLaMAModel* model, GGUFContext* ctx, const char* name) {
@@ -660,7 +661,7 @@ int cml_llama_sample_token(Tensor* logits, const CMLGenerationConfig* config) {
     }
 
     /* Apply temperature */
-    float* scaled = (float*)malloc((size_t)vocab_size * sizeof(float));
+    float* scaled = (float*)cml_malloc((size_t)vocab_size * sizeof(float));
     if (!scaled) return -1;
 
     float inv_temp = 1.0f / config->temperature;
@@ -669,8 +670,8 @@ int cml_llama_sample_token(Tensor* logits, const CMLGenerationConfig* config) {
     }
 
     /* Build sorted entries for top-k / top-p filtering */
-    LogitEntry* entries = (LogitEntry*)malloc((size_t)vocab_size * sizeof(LogitEntry));
-    if (!entries) { free(scaled); return -1; }
+    LogitEntry* entries = (LogitEntry*)cml_malloc((size_t)vocab_size * sizeof(LogitEntry));
+    if (!entries) { cml_free(scaled); return -1; }
 
     for (int i = 0; i < vocab_size; i++) {
         entries[i].value = scaled[i];
@@ -731,8 +732,8 @@ int cml_llama_sample_token(Tensor* logits, const CMLGenerationConfig* config) {
         }
     }
 
-    free(entries);
-    free(scaled);
+    cml_free(entries);
+    cml_free(scaled);
     return sampled_id;
 }
 
@@ -757,18 +758,18 @@ CMLGenerationResult* cml_llama_generate(CMLLLaMAModel* model, const char* prompt
 
     if (!prompt_tokens || num_prompt_tokens <= 0) {
         LOG_ERROR("cml_llama_generate: tokenization failed or empty prompt");
-        if (prompt_tokens) free(prompt_tokens);
+        if (prompt_tokens) cml_free(prompt_tokens);
         return NULL;
     }
 
     int max_total = num_prompt_tokens + config->max_new_tokens;
-    CMLGenerationResult* result = (CMLGenerationResult*)calloc(1, sizeof(CMLGenerationResult));
-    if (!result) { free(prompt_tokens); return NULL; }
+    CMLGenerationResult* result = (CMLGenerationResult*)cml_calloc(1, sizeof(CMLGenerationResult));
+    if (!result) { cml_free(prompt_tokens); return NULL; }
 
-    result->token_ids = (int*)malloc((size_t)max_total * sizeof(int));
+    result->token_ids = (int*)cml_malloc((size_t)max_total * sizeof(int));
     if (!result->token_ids) {
-        free(prompt_tokens);
-        free(result);
+        cml_free(prompt_tokens);
+        cml_free(result);
         return NULL;
     }
 
@@ -783,12 +784,12 @@ CMLGenerationResult* cml_llama_generate(CMLLLaMAModel* model, const char* prompt
     clock_gettime(CLOCK_MONOTONIC, &ts_start);
 
     Tensor* logits = cml_llama_forward(model, prompt_tokens, num_prompt_tokens);
-    free(prompt_tokens);
+    cml_free(prompt_tokens);
 
     if (!logits) {
         LOG_ERROR("cml_llama_generate: prefill forward failed");
-        free(result->token_ids);
-        free(result);
+        cml_free(result->token_ids);
+        cml_free(result);
         return NULL;
     }
 
@@ -852,9 +853,9 @@ CMLGenerationResult* cml_llama_generate(CMLLLaMAModel* model, const char* prompt
 
 void cml_generation_result_free(CMLGenerationResult* result) {
     if (!result) return;
-    if (result->token_ids) free(result->token_ids);
-    if (result->text) free(result->text);
-    free(result);
+    if (result->token_ids) cml_free(result->token_ids);
+    if (result->text) cml_free(result->text);
+    cml_free(result);
 }
 
 void cml_llama_reset(CMLLLaMAModel* model) {

--- a/src/nn/llm_ops.c
+++ b/src/nn/llm_ops.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 static void llm_softmax_inplace(float* data, int rows, int cols) {
     for (int r = 0; r < rows; r++) {
@@ -83,7 +84,7 @@ CMLKVCache* cml_kv_cache_create(int max_seq_len, int num_kv_heads, int head_dim)
         return NULL;
     }
 
-    CMLKVCache* cache = (CMLKVCache*)calloc(1, sizeof(CMLKVCache));
+    CMLKVCache* cache = (CMLKVCache*)cml_calloc(1, sizeof(CMLKVCache));
     if (!cache) {
         LOG_ERROR("cml_kv_cache_create: allocation failed");
         return NULL;
@@ -105,7 +106,7 @@ CMLKVCache* cml_kv_cache_create(int max_seq_len, int num_kv_heads, int head_dim)
         LOG_ERROR("cml_kv_cache_create: failed to allocate cache tensors");
         if (cache->key_cache) tensor_free(cache->key_cache);
         if (cache->value_cache) tensor_free(cache->value_cache);
-        free(cache);
+        cml_free(cache);
         return NULL;
     }
     return cache;
@@ -115,7 +116,7 @@ void cml_kv_cache_free(CMLKVCache* cache) {
     if (!cache) return;
     if (cache->key_cache) tensor_free(cache->key_cache);
     if (cache->value_cache) tensor_free(cache->value_cache);
-    free(cache);
+    cml_free(cache);
 }
 
 int cml_kv_cache_append(CMLKVCache* cache, Tensor* new_key, Tensor* new_value) {
@@ -244,17 +245,17 @@ Tensor* cml_gqa_forward(Tensor* Q, Tensor* K, Tensor* V, const CMLGQAConfig* con
 
     /* Allocate output: [batch, seq_q, num_heads * head_dim] */
     size_t out_size = (size_t)batch * seq_q * num_heads * head_dim;
-    float* output = (float*)calloc(out_size, sizeof(float));
+    float* output = (float*)cml_calloc(out_size, sizeof(float));
     if (!output) {
         LOG_ERROR("cml_gqa_forward: allocation failed");
         return NULL;
     }
 
     /* Allocate scratch for attention scores: [seq_q, kv_len] per head */
-    float* scores = (float*)malloc((size_t)seq_q * kv_len * sizeof(float));
+    float* scores = (float*)cml_malloc((size_t)seq_q * kv_len * sizeof(float));
     if (!scores) {
         LOG_ERROR("cml_gqa_forward: scores allocation failed");
-        free(output);
+        cml_free(output);
         return NULL;
     }
 
@@ -345,14 +346,14 @@ Tensor* cml_gqa_forward(Tensor* Q, Tensor* K, Tensor* V, const CMLGQAConfig* con
         }
     }
 
-    free(scores);
+    cml_free(scores);
 
     /* Create output tensor */
     int out_shape[] = {batch, seq_q, num_heads * head_dim};
     TensorConfig out_cfg = {.dtype = Q->dtype, .device = Q->device,
                             .has_dtype = true, .has_device = true};
     Tensor* result = tensor_from_data(output, out_shape, 3, &out_cfg);
-    free(output);
+    cml_free(output);
 
     if (!result) {
         LOG_ERROR("cml_gqa_forward: failed to create output tensor");
@@ -501,18 +502,18 @@ Tensor* cml_gqa_flash_forward(Tensor* Q, Tensor* K, Tensor* V,
     }
 
     size_t out_size = (size_t)batch * seq_q * num_heads * head_dim;
-    float* output = (float*)calloc(out_size, sizeof(float));
+    float* output = (float*)cml_calloc(out_size, sizeof(float));
     if (!output) return NULL;
 
     /* Per-query-position online softmax state */
-    float* row_max = (float*)malloc((size_t)tile_q * sizeof(float));
-    float* row_sum = (float*)malloc((size_t)tile_q * sizeof(float));
-    float* tile_scores = (float*)malloc((size_t)tile_q * tile_kv * sizeof(float));
-    float* acc = (float*)malloc((size_t)tile_q * head_dim * sizeof(float));
+    float* row_max = (float*)cml_malloc((size_t)tile_q * sizeof(float));
+    float* row_sum = (float*)cml_malloc((size_t)tile_q * sizeof(float));
+    float* tile_scores = (float*)cml_malloc((size_t)tile_q * tile_kv * sizeof(float));
+    float* acc = (float*)cml_malloc((size_t)tile_q * head_dim * sizeof(float));
 
     if (!row_max || !row_sum || !tile_scores || !acc) {
-        free(output); free(row_max); free(row_sum);
-        free(tile_scores); free(acc);
+        cml_free(output); cml_free(row_max); cml_free(row_sum);
+        cml_free(tile_scores); cml_free(acc);
         return NULL;
     }
 
@@ -619,16 +620,16 @@ Tensor* cml_gqa_flash_forward(Tensor* Q, Tensor* K, Tensor* V,
         }
     }
 
-    free(row_max);
-    free(row_sum);
-    free(tile_scores);
-    free(acc);
+    cml_free(row_max);
+    cml_free(row_sum);
+    cml_free(tile_scores);
+    cml_free(acc);
 
     int out_shape[] = {batch, seq_q, num_heads * head_dim};
     TensorConfig out_cfg = {.dtype = Q->dtype, .device = Q->device,
                             .has_dtype = true, .has_device = true};
     Tensor* result = tensor_from_data(output, out_shape, 3, &out_cfg);
-    free(output);
+    cml_free(output);
     return result;
 }
 
@@ -823,7 +824,7 @@ CMLMoELayer* cml_moe_create(const CMLMoEConfig* config) {
         return NULL;
     }
 
-    CMLMoELayer* moe = (CMLMoELayer*)calloc(1, sizeof(CMLMoELayer));
+    CMLMoELayer* moe = (CMLMoELayer*)cml_calloc(1, sizeof(CMLMoELayer));
     if (!moe) {
         LOG_ERROR("cml_moe_create: allocation failed");
         return NULL;
@@ -844,15 +845,15 @@ CMLMoELayer* cml_moe_create(const CMLMoEConfig* config) {
     moe->gate_weight = tensor_empty(gate_shape, 2, &tcfg);
     if (!moe->gate_weight) {
         LOG_ERROR("cml_moe_create: failed to create gate weight");
-        free(moe);
+        cml_free(moe);
         return NULL;
     }
     float* gw = (float*)tensor_data_ptr(moe->gate_weight);
     if (gw) llm_xavier_init(gw, (size_t)input_dim * num_experts, input_dim, num_experts);
 
     /* Expert weights */
-    moe->expert_w1 = (Tensor**)calloc((size_t)num_experts, sizeof(Tensor*));
-    moe->expert_w2 = (Tensor**)calloc((size_t)num_experts, sizeof(Tensor*));
+    moe->expert_w1 = (Tensor**)cml_calloc((size_t)num_experts, sizeof(Tensor*));
+    moe->expert_w2 = (Tensor**)cml_calloc((size_t)num_experts, sizeof(Tensor*));
     if (!moe->expert_w1 || !moe->expert_w2) {
         LOG_ERROR("cml_moe_create: failed to allocate expert arrays");
         cml_moe_free(moe);
@@ -890,15 +891,15 @@ void cml_moe_free(CMLMoELayer* moe) {
         for (int e = 0; e < num_experts; e++) {
             if (moe->expert_w1[e]) tensor_free(moe->expert_w1[e]);
         }
-        free(moe->expert_w1);
+        cml_free(moe->expert_w1);
     }
     if (moe->expert_w2) {
         for (int e = 0; e < num_experts; e++) {
             if (moe->expert_w2[e]) tensor_free(moe->expert_w2[e]);
         }
-        free(moe->expert_w2);
+        cml_free(moe->expert_w2);
     }
-    free(moe);
+    cml_free(moe);
 }
 
 Tensor* cml_moe_forward(CMLMoELayer* moe, Tensor* input) {
@@ -932,7 +933,7 @@ Tensor* cml_moe_forward(CMLMoELayer* moe, Tensor* input) {
     }
 
     /* Step 1: Compute gating scores [total_tokens, num_experts] */
-    float* gate_scores = (float*)calloc((size_t)total_tokens * num_experts, sizeof(float));
+    float* gate_scores = (float*)cml_calloc((size_t)total_tokens * num_experts, sizeof(float));
     if (!gate_scores) {
         LOG_ERROR("cml_moe_forward: allocation failed");
         return NULL;
@@ -953,13 +954,13 @@ Tensor* cml_moe_forward(CMLMoELayer* moe, Tensor* input) {
     llm_softmax_inplace(gate_scores, total_tokens, num_experts);
 
     /* Step 3: Find top-k experts per token */
-    int* top_k_indices = (int*)malloc((size_t)total_tokens * top_k * sizeof(int));
-    float* top_k_weights = (float*)malloc((size_t)total_tokens * top_k * sizeof(float));
+    int* top_k_indices = (int*)cml_malloc((size_t)total_tokens * top_k * sizeof(int));
+    float* top_k_weights = (float*)cml_malloc((size_t)total_tokens * top_k * sizeof(float));
     if (!top_k_indices || !top_k_weights) {
         LOG_ERROR("cml_moe_forward: allocation failed");
-        free(gate_scores);
-        free(top_k_indices);
-        free(top_k_weights);
+        cml_free(gate_scores);
+        cml_free(top_k_indices);
+        cml_free(top_k_weights);
         return NULL;
     }
 
@@ -967,11 +968,11 @@ Tensor* cml_moe_forward(CMLMoELayer* moe, Tensor* input) {
         float* row = gate_scores + t * num_experts;
 
         /* Simple selection of top-k by repeated argmax */
-        bool* selected = (bool*)calloc((size_t)num_experts, sizeof(bool));
+        bool* selected = (bool*)cml_calloc((size_t)num_experts, sizeof(bool));
         if (!selected) {
-            free(gate_scores);
-            free(top_k_indices);
-            free(top_k_weights);
+            cml_free(gate_scores);
+            cml_free(top_k_indices);
+            cml_free(top_k_weights);
             return NULL;
         }
 
@@ -988,7 +989,7 @@ Tensor* cml_moe_forward(CMLMoELayer* moe, Tensor* input) {
             top_k_weights[t * top_k + ki] = best_val;
             if (best_idx >= 0) selected[best_idx] = true;
         }
-        free(selected);
+        cml_free(selected);
 
         /* Optionally re-normalize top-k weights to sum to 1 */
         if (moe->config.normalize_weights) {
@@ -1005,20 +1006,20 @@ Tensor* cml_moe_forward(CMLMoELayer* moe, Tensor* input) {
         }
     }
 
-    free(gate_scores);
+    cml_free(gate_scores);
 
     /* Step 4: Compute expert outputs and combine */
-    float* output = (float*)calloc((size_t)total_tokens * input_dim, sizeof(float));
-    float* expert_hidden = (float*)malloc((size_t)hidden_dim * sizeof(float));
-    float* expert_out = (float*)malloc((size_t)input_dim * sizeof(float));
+    float* output = (float*)cml_calloc((size_t)total_tokens * input_dim, sizeof(float));
+    float* expert_hidden = (float*)cml_malloc((size_t)hidden_dim * sizeof(float));
+    float* expert_out = (float*)cml_malloc((size_t)input_dim * sizeof(float));
 
     if (!output || !expert_hidden || !expert_out) {
         LOG_ERROR("cml_moe_forward: allocation failed");
-        free(output);
-        free(expert_hidden);
-        free(expert_out);
-        free(top_k_indices);
-        free(top_k_weights);
+        cml_free(output);
+        cml_free(expert_hidden);
+        cml_free(expert_out);
+        cml_free(top_k_indices);
+        cml_free(top_k_weights);
         return NULL;
     }
 
@@ -1062,17 +1063,17 @@ Tensor* cml_moe_forward(CMLMoELayer* moe, Tensor* input) {
         }
     }
 
-    free(expert_hidden);
-    free(expert_out);
-    free(top_k_indices);
-    free(top_k_weights);
+    cml_free(expert_hidden);
+    cml_free(expert_out);
+    cml_free(top_k_indices);
+    cml_free(top_k_weights);
 
     /* Create output tensor [batch, seq_len, input_dim] */
     int out_shape[] = {batch, seq_len, input_dim};
     TensorConfig out_cfg = {.dtype = input->dtype, .device = input->device,
                             .has_dtype = true, .has_device = true};
     Tensor* result = tensor_from_data(output, out_shape, 3, &out_cfg);
-    free(output);
+    cml_free(output);
 
     if (!result) {
         LOG_ERROR("cml_moe_forward: failed to create output tensor");
@@ -1109,7 +1110,7 @@ Tensor* cml_moe_get_routing(CMLMoELayer* moe, Tensor* input) {
         return NULL;
     }
 
-    float* routing = (float*)calloc((size_t)total_tokens * num_experts, sizeof(float));
+    float* routing = (float*)cml_calloc((size_t)total_tokens * num_experts, sizeof(float));
     if (!routing) {
         LOG_ERROR("cml_moe_get_routing: allocation failed");
         return NULL;
@@ -1133,7 +1134,7 @@ Tensor* cml_moe_get_routing(CMLMoELayer* moe, Tensor* input) {
     TensorConfig out_cfg = {.dtype = DTYPE_FLOAT32, .device = DEVICE_CPU,
                             .has_dtype = true, .has_device = true};
     Tensor* result = tensor_from_data(routing, out_shape, 2, &out_cfg);
-    free(routing);
+    cml_free(routing);
     return result;
 }
 
@@ -1145,7 +1146,7 @@ CMLTokenizer* cml_tokenizer_create(char** vocab, int vocab_size,
         return NULL;
     }
 
-    CMLTokenizer* tok = (CMLTokenizer*)calloc(1, sizeof(CMLTokenizer));
+    CMLTokenizer* tok = (CMLTokenizer*)cml_calloc(1, sizeof(CMLTokenizer));
     if (!tok) {
         LOG_ERROR("cml_tokenizer_create: allocation failed");
         return NULL;
@@ -1158,16 +1159,16 @@ CMLTokenizer* cml_tokenizer_create(char** vocab, int vocab_size,
     tok->unk_token_id = -1;
 
     /* Copy vocab strings */
-    tok->vocab = (char**)calloc((size_t)vocab_size, sizeof(char*));
+    tok->vocab = (char**)cml_calloc((size_t)vocab_size, sizeof(char*));
     if (!tok->vocab) {
         LOG_ERROR("cml_tokenizer_create: failed to allocate vocab array");
-        free(tok);
+        cml_free(tok);
         return NULL;
     }
 
     for (int i = 0; i < vocab_size; i++) {
         if (vocab[i]) {
-            tok->vocab[i] = strdup(vocab[i]);
+            tok->vocab[i] = cml_strdup(vocab[i]);
             if (!tok->vocab[i]) {
                 LOG_ERROR("cml_tokenizer_create: strdup failed for token %d", i);
                 cml_tokenizer_free(tok);
@@ -1179,7 +1180,7 @@ CMLTokenizer* cml_tokenizer_create(char** vocab, int vocab_size,
     /* Build hash table: size = 2 * vocab_size for low load factor */
     tok->hash_size = vocab_size * 2;
     if (tok->hash_size < 64) tok->hash_size = 64;
-    tok->token_to_id = (int*)malloc((size_t)tok->hash_size * sizeof(int));
+    tok->token_to_id = (int*)cml_malloc((size_t)tok->hash_size * sizeof(int));
     if (!tok->token_to_id) {
         LOG_ERROR("cml_tokenizer_create: failed to allocate hash table");
         cml_tokenizer_free(tok);
@@ -1200,7 +1201,7 @@ CMLTokenizer* cml_tokenizer_create(char** vocab, int vocab_size,
     /* Copy merge rules */
     tok->num_merges = num_merges;
     if (num_merges > 0 && merge_pairs) {
-        tok->merges = (CMLBPEMerge*)calloc((size_t)num_merges, sizeof(CMLBPEMerge));
+        tok->merges = (CMLBPEMerge*)cml_calloc((size_t)num_merges, sizeof(CMLBPEMerge));
         if (!tok->merges) {
             LOG_ERROR("cml_tokenizer_create: failed to allocate merges");
             cml_tokenizer_free(tok);
@@ -1209,7 +1210,7 @@ CMLTokenizer* cml_tokenizer_create(char** vocab, int vocab_size,
 
         for (int i = 0; i < num_merges; i++) {
             if (merge_pairs[i]) {
-                tok->merges[i].pair = strdup(merge_pairs[i]);
+                tok->merges[i].pair = cml_strdup(merge_pairs[i]);
                 if (!tok->merges[i].pair) {
                     LOG_ERROR("cml_tokenizer_create: strdup failed for merge %d", i);
                     cml_tokenizer_free(tok);
@@ -1232,20 +1233,20 @@ void cml_tokenizer_free(CMLTokenizer* tok) {
 
     if (tok->vocab) {
         for (int i = 0; i < tok->vocab_size; i++) {
-            free(tok->vocab[i]);
+            cml_free(tok->vocab[i]);
         }
-        free(tok->vocab);
+        cml_free(tok->vocab);
     }
 
     if (tok->merges) {
         for (int i = 0; i < tok->num_merges; i++) {
-            free(tok->merges[i].pair);
+            cml_free(tok->merges[i].pair);
         }
-        free(tok->merges);
+        cml_free(tok->merges);
     }
 
-    free(tok->token_to_id);
-    free(tok);
+    cml_free(tok->token_to_id);
+    cml_free(tok);
 }
 
 int* cml_tokenizer_encode(CMLTokenizer* tok, const char* text, int* num_tokens) {
@@ -1265,7 +1266,7 @@ int* cml_tokenizer_encode(CMLTokenizer* tok, const char* text, int* num_tokens) 
      * Each character becomes a separate token string. */
     int capacity = text_len + 16;
     int count = 0;
-    char** tokens = (char**)malloc((size_t)capacity * sizeof(char*));
+    char** tokens = (char**)cml_malloc((size_t)capacity * sizeof(char*));
     if (!tokens) {
         *num_tokens = 0;
         return NULL;
@@ -1273,10 +1274,10 @@ int* cml_tokenizer_encode(CMLTokenizer* tok, const char* text, int* num_tokens) 
 
     for (int i = 0; i < text_len; i++) {
         char buf[2] = {text[i], '\0'};
-        tokens[count] = strdup(buf);
+        tokens[count] = cml_strdup(buf);
         if (!tokens[count]) {
-            for (int j = 0; j < count; j++) free(tokens[j]);
-            free(tokens);
+            for (int j = 0; j < count; j++) cml_free(tokens[j]);
+            cml_free(tokens);
             *num_tokens = 0;
             return NULL;
         }
@@ -1302,7 +1303,7 @@ int* cml_tokenizer_encode(CMLTokenizer* tok, const char* text, int* num_tokens) 
                 if (len_a + len_b != merge_len) continue;
 
                 /* Build concatenated string to compare */
-                char* concat = (char*)malloc(merge_len + 1);
+                char* concat = (char*)cml_malloc(merge_len + 1);
                 if (!concat) continue;
                 memcpy(concat, tokens[i], len_a);
                 memcpy(concat + len_a, tokens[i + 1], len_b);
@@ -1310,9 +1311,9 @@ int* cml_tokenizer_encode(CMLTokenizer* tok, const char* text, int* num_tokens) 
 
                 if (strcmp(concat, merge_str) == 0) {
                     /* Merge: replace tokens[i] with the merged string, remove tokens[i+1] */
-                    free(tokens[i]);
+                    cml_free(tokens[i]);
                     tokens[i] = concat;
-                    free(tokens[i + 1]);
+                    cml_free(tokens[i + 1]);
                     /* Shift remaining tokens left */
                     for (int j = i + 1; j < count - 1; j++) {
                         tokens[j] = tokens[j + 1];
@@ -1321,17 +1322,17 @@ int* cml_tokenizer_encode(CMLTokenizer* tok, const char* text, int* num_tokens) 
                     found = true;
                     break; /* restart scan for this merge rule */
                 } else {
-                    free(concat);
+                    cml_free(concat);
                 }
             }
         }
     }
 
     /* Step 3: Convert token strings to IDs */
-    int* ids = (int*)malloc((size_t)count * sizeof(int));
+    int* ids = (int*)cml_malloc((size_t)count * sizeof(int));
     if (!ids) {
-        for (int i = 0; i < count; i++) free(tokens[i]);
-        free(tokens);
+        for (int i = 0; i < count; i++) cml_free(tokens[i]);
+        cml_free(tokens);
         *num_tokens = 0;
         return NULL;
     }
@@ -1344,9 +1345,9 @@ int* cml_tokenizer_encode(CMLTokenizer* tok, const char* text, int* num_tokens) 
             /* Unknown token */
             ids[i] = tok->unk_token_id >= 0 ? tok->unk_token_id : 0;
         }
-        free(tokens[i]);
+        cml_free(tokens[i]);
     }
-    free(tokens);
+    cml_free(tokens);
 
     *num_tokens = count;
     return ids;
@@ -1367,7 +1368,7 @@ char* cml_tokenizer_decode(CMLTokenizer* tok, const int* tokens, int num_tokens)
         }
     }
 
-    char* result = (char*)malloc(total_len + 1);
+    char* result = (char*)cml_malloc(total_len + 1);
     if (!result) {
         LOG_ERROR("cml_tokenizer_decode: allocation failed");
         return NULL;

--- a/src/nn/lora.c
+++ b/src/nn/lora.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 CMLLoRALinear* cml_lora_linear_create(Tensor* base_weight, int rank, float alpha) {
     if (!base_weight) {
@@ -25,7 +26,7 @@ CMLLoRALinear* cml_lora_linear_create(Tensor* base_weight, int rank, float alpha
     int out_features = base_weight->shape[0];
     int in_features = base_weight->shape[1];
 
-    CMLLoRALinear* lora = (CMLLoRALinear*)calloc(1, sizeof(CMLLoRALinear));
+    CMLLoRALinear* lora = (CMLLoRALinear*)cml_calloc(1, sizeof(CMLLoRALinear));
     if (!lora) {
         LOG_ERROR("Failed to allocate CMLLoRALinear");
         return NULL;
@@ -54,7 +55,7 @@ CMLLoRALinear* cml_lora_linear_create(Tensor* base_weight, int rank, float alpha
     lora->lora_A = tensor_empty(shape_A, 2, &cfg);
     if (!lora->lora_A) {
         LOG_ERROR("Failed to allocate lora_A");
-        free(lora);
+        cml_free(lora);
         return NULL;
     }
     tensor_ensure_executed(lora->lora_A);
@@ -76,7 +77,7 @@ CMLLoRALinear* cml_lora_linear_create(Tensor* base_weight, int rank, float alpha
     if (!lora->lora_B) {
         LOG_ERROR("Failed to allocate lora_B");
         tensor_free(lora->lora_A);
-        free(lora);
+        cml_free(lora);
         return NULL;
     }
 
@@ -99,7 +100,7 @@ void cml_lora_linear_free(CMLLoRALinear* lora) {
         lora->frozen_base = NULL;
     }
     /* Do NOT free base_weight - we don't own it */
-    free(lora);
+    cml_free(lora);
 }
 
 Tensor* cml_lora_linear_forward(CMLLoRALinear* lora, Tensor* input) {
@@ -183,7 +184,7 @@ Tensor* cml_lora_linear_forward(CMLLoRALinear* lora, Tensor* input) {
      * input: [batch, in_f], A: [rank, in_f] => tmp: [batch, rank]
      * tmp[b][r] = sum_i( input[b][i] * A[r][i] )
      */
-    float* tmp = (float*)calloc((size_t)batch * (size_t)r, sizeof(float));
+    float* tmp = (float*)cml_calloc((size_t)batch * (size_t)r, sizeof(float));
     if (!tmp) {
         LOG_ERROR("Failed to allocate temporary buffer for LoRA forward");
         tensor_free(output);
@@ -217,7 +218,7 @@ Tensor* cml_lora_linear_forward(CMLLoRALinear* lora, Tensor* input) {
         }
     }
 
-    free(tmp);
+    cml_free(tmp);
     return output;
 }
 
@@ -329,7 +330,7 @@ CMLLoRAAdapter* cml_lora_adapter_create(const char* name, int rank, float alpha)
         return NULL;
     }
 
-    CMLLoRAAdapter* adapter = (CMLLoRAAdapter*)calloc(1, sizeof(CMLLoRAAdapter));
+    CMLLoRAAdapter* adapter = (CMLLoRAAdapter*)cml_calloc(1, sizeof(CMLLoRAAdapter));
     if (!adapter) {
         LOG_ERROR("Failed to allocate CMLLoRAAdapter");
         return NULL;
@@ -354,8 +355,8 @@ void cml_lora_adapter_free(CMLLoRAAdapter* adapter) {
             cml_lora_linear_free(adapter->layers[i]);
         }
     }
-    free(adapter->layers);
-    free(adapter);
+    cml_free(adapter->layers);
+    cml_free(adapter);
 }
 
 int cml_lora_adapter_add_layer(CMLLoRAAdapter* adapter, CMLLoRALinear* layer) {
@@ -365,7 +366,7 @@ int cml_lora_adapter_add_layer(CMLLoRAAdapter* adapter, CMLLoRALinear* layer) {
     }
 
     int new_count = adapter->num_layers + 1;
-    CMLLoRALinear** new_layers = (CMLLoRALinear**)realloc(
+    CMLLoRALinear** new_layers = (CMLLoRALinear**)cml_realloc(
         adapter->layers, (size_t)new_count * sizeof(CMLLoRALinear*));
     if (!new_layers) {
         LOG_ERROR("Failed to reallocate adapter layers array");

--- a/src/nn/model_io.c
+++ b/src/nn/model_io.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 #define CML_MODEL_MAGIC "CML\0"
 #define CML_CKPT_MAGIC  "CKP\0"
@@ -85,7 +86,7 @@ int model_load(Module* model, const char* filepath) {
     for (int i = 0; i < num_params; i++) {
         int32_t name_len;
         fread(&name_len, sizeof(int32_t), 1, f);
-        char* name = malloc((size_t)(name_len + 1));
+        char* name = cml_malloc((size_t)(name_len + 1));
         if (!name) { fclose(f); return -1; }
         fread(name, 1, (size_t)name_len, f);
         name[name_len] = '\0';
@@ -95,7 +96,7 @@ int model_load(Module* model, const char* filepath) {
         int32_t ndim;
         fread(&ndim, sizeof(int32_t), 1, f);
 
-        int* shape = malloc((size_t)ndim * sizeof(int));
+        int* shape = cml_malloc((size_t)ndim * sizeof(int));
         for (int d = 0; d < ndim; d++) {
             int32_t dim;
             fread(&dim, sizeof(int32_t), 1, f);
@@ -120,8 +121,8 @@ int model_load(Module* model, const char* filepath) {
             LOG_WARNING("Parameter '%s' not found in model, skipping", name);
         }
 
-        free(name);
-        free(shape);
+        cml_free(name);
+        cml_free(shape);
     }
 
     fclose(f);
@@ -225,7 +226,7 @@ int model_load_checkpoint(Module* model, Optimizer* optimizer, int* epoch, float
     for (int i = 0; i < num_params; i++) {
         int32_t name_len;
         fread(&name_len, sizeof(int32_t), 1, f);
-        char* name = malloc((size_t)(name_len + 1));
+        char* name = cml_malloc((size_t)(name_len + 1));
         if (!name) { fclose(f); return -1; }
         fread(name, 1, (size_t)name_len, f);
         name[name_len] = '\0';
@@ -252,7 +253,7 @@ int model_load_checkpoint(Module* model, Optimizer* optimizer, int* epoch, float
         } else {
             fseek(f, (long)data_size, SEEK_CUR);
         }
-        free(name);
+        cml_free(name);
     }
     int32_t has_optim;
     fread(&has_optim, sizeof(int32_t), 1, f);

--- a/src/nn/openai_api.c
+++ b/src/nn/openai_api.c
@@ -12,6 +12,7 @@
 #include <sys/socket.h>
 #include <time.h>
 #include <unistd.h>
+#include "alloc/cml_allocator.h"
 
 #define HTTP_BUF_SIZE  (256 * 1024)
 #define MAX_MESSAGES   64
@@ -238,7 +239,7 @@ static void handle_chat_completions(int fd, CMLOpenAIServer* srv, const char* bo
         int* prompt_tokens = cml_tokenizer_encode(tokenizer, prompt, &num_prompt_tokens);
         if (!prompt_tokens || num_prompt_tokens == 0) {
             send_sse_chunk(fd, "[DONE]");
-            free(prompt_tokens);
+            cml_free(prompt_tokens);
             return;
         }
 
@@ -284,7 +285,7 @@ static void handle_chat_completions(int fd, CMLOpenAIServer* srv, const char* bo
                      escaped);
 
             send_sse_chunk(fd, chunk_json);
-            free(token_text);
+            cml_free(token_text);
             total_generated++;
         }
 
@@ -299,7 +300,7 @@ static void handle_chat_completions(int fd, CMLOpenAIServer* srv, const char* bo
         send_sse_chunk(fd, done_json);
         send_sse_chunk(fd, "[DONE]");
 
-        free(prompt_tokens);
+        cml_free(prompt_tokens);
     } else {
         CMLGenerationResult* result = cml_llama_generate(model, prompt, &gen_config);
         if (!result || !result->text) {
@@ -325,7 +326,7 @@ static void handle_chat_completions(int fd, CMLOpenAIServer* srv, const char* bo
 
         int prompt_tokens_count = 0;
         int* pt = cml_tokenizer_encode(tokenizer, prompt, &prompt_tokens_count);
-        free(pt);
+        cml_free(pt);
 
         char resp[65536];
         snprintf(resp, sizeof(resp),
@@ -385,7 +386,7 @@ static void handle_request(int fd, CMLOpenAIServer* srv, const char* request) {
 CMLOpenAIServer* cml_openai_server_create(int port) {
     if (port <= 0) return NULL;
 
-    CMLOpenAIServer* srv = (CMLOpenAIServer*)calloc(1, sizeof(CMLOpenAIServer));
+    CMLOpenAIServer* srv = (CMLOpenAIServer*)cml_calloc(1, sizeof(CMLOpenAIServer));
     if (!srv) return NULL;
 
     srv->port = port;
@@ -462,7 +463,7 @@ int cml_openai_server_run(CMLOpenAIServer* srv) {
     LOG_INFO("  GET  /v1/models");
     LOG_INFO("  GET  /health");
 
-    char* buf = (char*)malloc(HTTP_BUF_SIZE);
+    char* buf = (char*)cml_malloc(HTTP_BUF_SIZE);
     if (!buf) {
         LOG_ERROR("openai_api: buffer allocation failed");
         return -1;
@@ -490,7 +491,7 @@ int cml_openai_server_run(CMLOpenAIServer* srv) {
         close(client_fd);
     }
 
-    free(buf);
+    cml_free(buf);
     return 0;
 }
 
@@ -511,5 +512,5 @@ void cml_openai_server_free(CMLOpenAIServer* srv) {
     if (srv->model) {
         cml_llama_free((CMLLLaMAModel*)srv->model);
     }
-    free(srv);
+    cml_free(srv);
 }

--- a/src/nn/paged_attention.c
+++ b/src/nn/paged_attention.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 static void paged_softmax_inplace(float* data, int rows, int cols) {
     for (int r = 0; r < rows; r++) {
@@ -43,7 +44,7 @@ CMLPagedKVCache* cml_paged_kv_cache_create(int max_blocks, int max_sequences,
         return NULL;
     }
 
-    CMLPagedKVCache* cache = (CMLPagedKVCache*)calloc(1, sizeof(CMLPagedKVCache));
+    CMLPagedKVCache* cache = (CMLPagedKVCache*)cml_calloc(1, sizeof(CMLPagedKVCache));
     if (!cache) {
         LOG_ERROR("cml_paged_kv_cache_create: allocation failed");
         return NULL;
@@ -54,26 +55,26 @@ CMLPagedKVCache* cml_paged_kv_cache_create(int max_blocks, int max_sequences,
     cache->num_kv_heads = num_kv_heads;
     cache->head_dim = head_dim;
     cache->block_size = CML_PAGE_BLOCK_SIZE;
-    cache->blocks = (CMLPageBlock*)calloc((size_t)max_blocks, sizeof(CMLPageBlock));
+    cache->blocks = (CMLPageBlock*)cml_calloc((size_t)max_blocks, sizeof(CMLPageBlock));
     if (!cache->blocks) {
         LOG_ERROR("cml_paged_kv_cache_create: block array allocation failed");
-        free(cache);
+        cml_free(cache);
         return NULL;
     }
 
     size_t buf_floats = block_buf_size(cache);
     for (int i = 0; i < max_blocks; i++) {
-        cache->blocks[i].key_data = (float*)calloc(buf_floats, sizeof(float));
-        cache->blocks[i].value_data = (float*)calloc(buf_floats, sizeof(float));
+        cache->blocks[i].key_data = (float*)cml_calloc(buf_floats, sizeof(float));
+        cache->blocks[i].value_data = (float*)cml_calloc(buf_floats, sizeof(float));
         if (!cache->blocks[i].key_data || !cache->blocks[i].value_data) {
             LOG_ERROR("cml_paged_kv_cache_create: block %d data allocation failed", i);
             /* Clean up already-allocated blocks */
             for (int j = 0; j <= i; j++) {
-                free(cache->blocks[j].key_data);
-                free(cache->blocks[j].value_data);
+                cml_free(cache->blocks[j].key_data);
+                cml_free(cache->blocks[j].value_data);
             }
-            free(cache->blocks);
-            free(cache);
+            cml_free(cache->blocks);
+            cml_free(cache);
             return NULL;
         }
         cache->blocks[i].block_id = i;
@@ -81,15 +82,15 @@ CMLPagedKVCache* cml_paged_kv_cache_create(int max_blocks, int max_sequences,
         cache->blocks[i].in_use = false;
     }
     cache->num_blocks = max_blocks;
-    cache->free_list = (int*)malloc((size_t)max_blocks * sizeof(int));
+    cache->free_list = (int*)cml_malloc((size_t)max_blocks * sizeof(int));
     if (!cache->free_list) {
         LOG_ERROR("cml_paged_kv_cache_create: free list allocation failed");
         for (int i = 0; i < max_blocks; i++) {
-            free(cache->blocks[i].key_data);
-            free(cache->blocks[i].value_data);
+            cml_free(cache->blocks[i].key_data);
+            cml_free(cache->blocks[i].value_data);
         }
-        free(cache->blocks);
-        free(cache);
+        cml_free(cache->blocks);
+        cml_free(cache);
         return NULL;
     }
     /* Push all block IDs onto the free list (top of stack = last element) */
@@ -97,16 +98,16 @@ CMLPagedKVCache* cml_paged_kv_cache_create(int max_blocks, int max_sequences,
         cache->free_list[i] = i;
     }
     cache->free_count = max_blocks;
-    cache->sequences = (CMLBlockTable*)calloc((size_t)max_sequences, sizeof(CMLBlockTable));
+    cache->sequences = (CMLBlockTable*)cml_calloc((size_t)max_sequences, sizeof(CMLBlockTable));
     if (!cache->sequences) {
         LOG_ERROR("cml_paged_kv_cache_create: sequence table allocation failed");
-        free(cache->free_list);
+        cml_free(cache->free_list);
         for (int i = 0; i < max_blocks; i++) {
-            free(cache->blocks[i].key_data);
-            free(cache->blocks[i].value_data);
+            cml_free(cache->blocks[i].key_data);
+            cml_free(cache->blocks[i].value_data);
         }
-        free(cache->blocks);
-        free(cache);
+        cml_free(cache->blocks);
+        cml_free(cache);
         return NULL;
     }
     /* Mark all sequence slots as unused (block_ids == NULL) */
@@ -128,22 +129,22 @@ void cml_paged_kv_cache_free(CMLPagedKVCache* cache) {
     /* Free all sequence block tables */
     if (cache->sequences) {
         for (int i = 0; i < cache->max_sequences; i++) {
-            free(cache->sequences[i].block_ids);
+            cml_free(cache->sequences[i].block_ids);
         }
-        free(cache->sequences);
+        cml_free(cache->sequences);
     }
 
     /* Free block data */
     if (cache->blocks) {
         for (int i = 0; i < cache->num_blocks; i++) {
-            free(cache->blocks[i].key_data);
-            free(cache->blocks[i].value_data);
+            cml_free(cache->blocks[i].key_data);
+            cml_free(cache->blocks[i].value_data);
         }
-        free(cache->blocks);
+        cml_free(cache->blocks);
     }
 
-    free(cache->free_list);
-    free(cache);
+    cml_free(cache->free_list);
+    cml_free(cache);
 }
 
 int cml_paged_cache_alloc_block(CMLPagedKVCache* cache) {
@@ -215,7 +216,7 @@ int cml_paged_cache_init_sequence(CMLPagedKVCache* cache) {
     /* Allocate an initial block table with room for a few block IDs */
     int initial_capacity = 8;
     CMLBlockTable* bt = &cache->sequences[seq_id];
-    bt->block_ids = (int*)malloc((size_t)initial_capacity * sizeof(int));
+    bt->block_ids = (int*)cml_malloc((size_t)initial_capacity * sizeof(int));
     if (!bt->block_ids) {
         LOG_ERROR("cml_paged_cache_init_sequence: allocation failed");
         return -1;
@@ -250,7 +251,7 @@ void cml_paged_cache_free_sequence(CMLPagedKVCache* cache, int seq_id) {
         cml_paged_cache_free_block(cache, bt->block_ids[i]);
     }
 
-    free(bt->block_ids);
+    cml_free(bt->block_ids);
     bt->block_ids = NULL;
     bt->num_blocks = 0;
     bt->capacity = 0;
@@ -295,7 +296,7 @@ int cml_paged_cache_append(CMLPagedKVCache* cache, int seq_id,
         /* Grow block table if needed */
         if (bt->num_blocks >= bt->capacity) {
             int new_cap = bt->capacity * 2;
-            int* new_ids = (int*)realloc(bt->block_ids, (size_t)new_cap * sizeof(int));
+            int* new_ids = (int*)cml_realloc(bt->block_ids, (size_t)new_cap * sizeof(int));
             if (!new_ids) {
                 LOG_ERROR("cml_paged_cache_append: block table realloc failed");
                 cml_paged_cache_free_block(cache, new_bid);
@@ -397,17 +398,17 @@ Tensor* cml_paged_gqa_forward(CMLPagedKVCache* cache, int seq_id,
 
     /* Allocate output: [1, seq_q, num_heads * head_dim] */
     size_t out_size = (size_t)seq_q * num_heads * head_dim;
-    float* output = (float*)calloc(out_size, sizeof(float));
+    float* output = (float*)cml_calloc(out_size, sizeof(float));
     if (!output) {
         LOG_ERROR("cml_paged_gqa_forward: output allocation failed");
         return NULL;
     }
 
     /* Allocate scratch for attention scores: [seq_q, kv_len] */
-    float* scores = (float*)malloc((size_t)seq_q * kv_len * sizeof(float));
+    float* scores = (float*)cml_malloc((size_t)seq_q * kv_len * sizeof(float));
     if (!scores) {
         LOG_ERROR("cml_paged_gqa_forward: scores allocation failed");
-        free(output);
+        cml_free(output);
         return NULL;
     }
 
@@ -478,14 +479,14 @@ Tensor* cml_paged_gqa_forward(CMLPagedKVCache* cache, int seq_id,
         }
     }
 
-    free(scores);
+    cml_free(scores);
 
     /* Wrap output into a tensor [1, seq_q, num_heads * head_dim] */
     int out_shape[] = {1, seq_q, num_heads * head_dim};
     TensorConfig out_cfg = {.dtype = DTYPE_FLOAT32, .device = DEVICE_CPU,
                             .has_dtype = true, .has_device = true};
     Tensor* result = tensor_from_data(output, out_shape, 3, &out_cfg);
-    free(output);
+    cml_free(output);
 
     if (!result) {
         LOG_ERROR("cml_paged_gqa_forward: failed to create output tensor");

--- a/src/nn/qlora.c
+++ b/src/nn/qlora.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 CMLNF4Tensor* cml_nf4_tensor_create(Tensor* float_tensor, int block_size) {
     if (!float_tensor) {
@@ -23,7 +24,7 @@ CMLNF4Tensor* cml_nf4_tensor_create(Tensor* float_tensor, int block_size) {
         return NULL;
     }
 
-    CMLNF4Tensor* nf4 = (CMLNF4Tensor*)calloc(1, sizeof(CMLNF4Tensor));
+    CMLNF4Tensor* nf4 = (CMLNF4Tensor*)cml_calloc(1, sizeof(CMLNF4Tensor));
     if (!nf4) {
         LOG_ERROR("cml_nf4_tensor_create: failed to allocate CMLNF4Tensor");
         return NULL;
@@ -34,10 +35,10 @@ CMLNF4Tensor* cml_nf4_tensor_create(Tensor* float_tensor, int block_size) {
     nf4->original_ndim = float_tensor->ndim;
 
     /* Copy original shape */
-    nf4->original_shape = (int*)malloc((size_t)float_tensor->ndim * sizeof(int));
+    nf4->original_shape = (int*)cml_malloc((size_t)float_tensor->ndim * sizeof(int));
     if (!nf4->original_shape) {
         LOG_ERROR("cml_nf4_tensor_create: failed to allocate shape copy");
-        free(nf4);
+        cml_free(nf4);
         return NULL;
     }
     memcpy(nf4->original_shape, float_tensor->shape,
@@ -49,8 +50,8 @@ CMLNF4Tensor* cml_nf4_tensor_create(Tensor* float_tensor, int block_size) {
     Tensor* packed = cml_quantize_nf4(float_tensor, block_size, &scales, &num_scales);
     if (!packed) {
         LOG_ERROR("cml_nf4_tensor_create: NF4 quantization failed");
-        free(nf4->original_shape);
-        free(nf4);
+        cml_free(nf4->original_shape);
+        cml_free(nf4);
         return NULL;
     }
 
@@ -69,14 +70,14 @@ void cml_nf4_tensor_free(CMLNF4Tensor* nf4) {
         nf4->packed_data = NULL;
     }
     if (nf4->scales) {
-        free(nf4->scales);
+        cml_free(nf4->scales);
         nf4->scales = NULL;
     }
     if (nf4->original_shape) {
-        free(nf4->original_shape);
+        cml_free(nf4->original_shape);
         nf4->original_shape = NULL;
     }
-    free(nf4);
+    cml_free(nf4);
 }
 
 Tensor* cml_nf4_tensor_dequantize(const CMLNF4Tensor* nf4) {
@@ -107,7 +108,7 @@ Tensor* cml_nf4_tensor_dequantize(const CMLNF4Tensor* nf4) {
             return NULL;
         }
 
-        int* shape_copy = (int*)malloc((size_t)nf4->original_ndim * sizeof(int));
+        int* shape_copy = (int*)cml_malloc((size_t)nf4->original_ndim * sizeof(int));
         if (!shape_copy) {
             tensor_free(flat);
             return NULL;
@@ -118,7 +119,7 @@ Tensor* cml_nf4_tensor_dequantize(const CMLNF4Tensor* nf4) {
         TensorConfig config = {.dtype = DTYPE_FLOAT32, .device = DEVICE_CPU,
                                .has_dtype = true, .has_device = true};
         Tensor* reshaped = tensor_from_data(fdata, shape_copy, nf4->original_ndim, &config);
-        free(shape_copy);
+        cml_free(shape_copy);
         tensor_free(flat);
 
         if (!reshaped) {
@@ -154,7 +155,7 @@ CMLQLoRALinear* cml_qlora_linear_create(Tensor* base_weight, int rank,
     int out_features = base_weight->shape[0];
     int in_features = base_weight->shape[1];
 
-    CMLQLoRALinear* qlora = (CMLQLoRALinear*)calloc(1, sizeof(CMLQLoRALinear));
+    CMLQLoRALinear* qlora = (CMLQLoRALinear*)cml_calloc(1, sizeof(CMLQLoRALinear));
     if (!qlora) {
         LOG_ERROR("cml_qlora_linear_create: failed to allocate CMLQLoRALinear");
         return NULL;
@@ -171,7 +172,7 @@ CMLQLoRALinear* cml_qlora_linear_create(Tensor* base_weight, int rank,
     qlora->base_weight_nf4 = cml_nf4_tensor_create(base_weight, block_size);
     if (!qlora->base_weight_nf4) {
         LOG_ERROR("cml_qlora_linear_create: failed to quantize base weight to NF4");
-        free(qlora);
+        cml_free(qlora);
         return NULL;
     }
 
@@ -190,7 +191,7 @@ CMLQLoRALinear* cml_qlora_linear_create(Tensor* base_weight, int rank,
     if (!qlora->lora_A) {
         LOG_ERROR("cml_qlora_linear_create: failed to allocate lora_A");
         cml_nf4_tensor_free(qlora->base_weight_nf4);
-        free(qlora);
+        cml_free(qlora);
         return NULL;
     }
     tensor_ensure_executed(qlora->lora_A);
@@ -212,7 +213,7 @@ CMLQLoRALinear* cml_qlora_linear_create(Tensor* base_weight, int rank,
         LOG_ERROR("cml_qlora_linear_create: failed to allocate lora_B");
         tensor_free(qlora->lora_A);
         cml_nf4_tensor_free(qlora->base_weight_nf4);
-        free(qlora);
+        cml_free(qlora);
         return NULL;
     }
 
@@ -234,7 +235,7 @@ void cml_qlora_linear_free(CMLQLoRALinear* qlora) {
         tensor_free(qlora->lora_B);
         qlora->lora_B = NULL;
     }
-    free(qlora);
+    cml_free(qlora);
 }
 
 Tensor* cml_qlora_linear_forward(CMLQLoRALinear* qlora, Tensor* input) {
@@ -326,7 +327,7 @@ Tensor* cml_qlora_linear_forward(CMLQLoRALinear* qlora, Tensor* input) {
      * input: [batch, in_f], A: [rank, in_f] => tmp: [batch, rank]
      * tmp[b][r] = sum_i( input[b][i] * A[r][i] )
      */
-    float* tmp = (float*)calloc((size_t)batch * (size_t)r, sizeof(float));
+    float* tmp = (float*)cml_calloc((size_t)batch * (size_t)r, sizeof(float));
     if (!tmp) {
         LOG_ERROR("cml_qlora_linear_forward: failed to allocate temporary buffer");
         tensor_free(output);
@@ -360,7 +361,7 @@ Tensor* cml_qlora_linear_forward(CMLQLoRALinear* qlora, Tensor* input) {
         }
     }
 
-    free(tmp);
+    cml_free(tmp);
     return output;
 }
 

--- a/src/nn/serving.c
+++ b/src/nn/serving.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include "alloc/cml_allocator.h"
 
 static double serving_time_ms(void) {
     struct timespec ts;
@@ -34,9 +35,9 @@ static CMLSequenceRequest* find_request(CMLServingContext* ctx, int request_id) 
 
 static void free_request(CMLSequenceRequest* req) {
     if (!req) return;
-    free(req->prompt_tokens);
-    free(req->generated_tokens);
-    free(req);
+    cml_free(req->prompt_tokens);
+    cml_free(req->generated_tokens);
+    cml_free(req);
 }
 
 CMLServingConfig cml_serving_default_config(void) {
@@ -57,7 +58,7 @@ CMLServingContext* cml_serving_create(const CMLServingConfig* config) {
         return NULL;
     }
 
-    CMLServingContext* ctx = (CMLServingContext*)calloc(1, sizeof(CMLServingContext));
+    CMLServingContext* ctx = (CMLServingContext*)cml_calloc(1, sizeof(CMLServingContext));
     if (!ctx) {
         LOG_ERROR("cml_serving_create: allocation failed");
         return NULL;
@@ -78,11 +79,11 @@ CMLServingContext* cml_serving_create(const CMLServingConfig* config) {
 
     /* Allocate circular queue */
     ctx->queue_capacity = ctx->config.max_queue_size;
-    ctx->queue = (CMLSequenceRequest**)calloc((size_t)ctx->queue_capacity,
+    ctx->queue = (CMLSequenceRequest**)cml_calloc((size_t)ctx->queue_capacity,
                                               sizeof(CMLSequenceRequest*));
     if (!ctx->queue) {
         LOG_ERROR("cml_serving_create: queue allocation failed");
-        free(ctx);
+        cml_free(ctx);
         return NULL;
     }
     ctx->queue_head = 0;
@@ -90,12 +91,12 @@ CMLServingContext* cml_serving_create(const CMLServingConfig* config) {
     ctx->queue_count = 0;
 
     /* Allocate active batch array */
-    ctx->active_batch = (CMLSequenceRequest**)calloc((size_t)ctx->config.max_batch_size,
+    ctx->active_batch = (CMLSequenceRequest**)cml_calloc((size_t)ctx->config.max_batch_size,
                                                      sizeof(CMLSequenceRequest*));
     if (!ctx->active_batch) {
         LOG_ERROR("cml_serving_create: active batch allocation failed");
-        free(ctx->queue);
-        free(ctx);
+        cml_free(ctx->queue);
+        cml_free(ctx);
         return NULL;
     }
     ctx->batch_size = 0;
@@ -118,18 +119,18 @@ void cml_serving_free(CMLServingContext* ctx) {
         free_request(ctx->queue[idx]);
         ctx->queue[idx] = NULL;
     }
-    free(ctx->queue);
+    cml_free(ctx->queue);
 
     /* Free all active requests */
     for (int i = 0; i < ctx->batch_size; i++) {
         free_request(ctx->active_batch[i]);
         ctx->active_batch[i] = NULL;
     }
-    free(ctx->active_batch);
+    cml_free(ctx->active_batch);
 
     LOG_INFO("Serving context freed (total_requests=%zu, completed=%zu)",
              ctx->stats.total_requests, ctx->stats.completed_requests);
-    free(ctx);
+    cml_free(ctx);
 }
 
 void cml_serving_set_kv_cache(CMLServingContext* ctx, CMLPagedKVCache* cache) {
@@ -158,7 +159,7 @@ int cml_serving_submit(CMLServingContext* ctx, const int* prompt_tokens,
     }
 
     /* Allocate request */
-    CMLSequenceRequest* req = (CMLSequenceRequest*)calloc(1, sizeof(CMLSequenceRequest));
+    CMLSequenceRequest* req = (CMLSequenceRequest*)cml_calloc(1, sizeof(CMLSequenceRequest));
     if (!req) {
         LOG_ERROR("cml_serving_submit: request allocation failed");
         return -1;
@@ -166,10 +167,10 @@ int cml_serving_submit(CMLServingContext* ctx, const int* prompt_tokens,
 
     req->request_id = ctx->next_request_id++;
     req->num_prompt_tokens = num_tokens;
-    req->prompt_tokens = (int*)malloc((size_t)num_tokens * sizeof(int));
+    req->prompt_tokens = (int*)cml_malloc((size_t)num_tokens * sizeof(int));
     if (!req->prompt_tokens) {
         LOG_ERROR("cml_serving_submit: token copy allocation failed");
-        free(req);
+        cml_free(req);
         return -1;
     }
     memcpy(req->prompt_tokens, prompt_tokens, (size_t)num_tokens * sizeof(int));
@@ -185,11 +186,11 @@ int cml_serving_submit(CMLServingContext* ctx, const int* prompt_tokens,
 
     /* Pre-allocate generated token buffer */
     req->gen_capacity = req->max_new_tokens;
-    req->generated_tokens = (int*)calloc((size_t)req->gen_capacity, sizeof(int));
+    req->generated_tokens = (int*)cml_calloc((size_t)req->gen_capacity, sizeof(int));
     if (!req->generated_tokens) {
         LOG_ERROR("cml_serving_submit: generated token buffer allocation failed");
-        free(req->prompt_tokens);
-        free(req);
+        cml_free(req->prompt_tokens);
+        cml_free(req);
         return -1;
     }
     req->num_generated = 0;

--- a/src/nn/speculative.c
+++ b/src/nn/speculative.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <math.h>
 #include <time.h>
+#include "alloc/cml_allocator.h"
 
 static double now_ms(void) {
     struct timespec ts;
@@ -59,7 +60,7 @@ CMLSpeculativeDecoder* cml_speculative_create(const CMLSpeculativeConfig* config
         return NULL;
     }
 
-    CMLSpeculativeDecoder* dec = (CMLSpeculativeDecoder*)calloc(1, sizeof(CMLSpeculativeDecoder));
+    CMLSpeculativeDecoder* dec = (CMLSpeculativeDecoder*)cml_calloc(1, sizeof(CMLSpeculativeDecoder));
     if (!dec) {
         LOG_ERROR("cml_speculative_create: allocation failed");
         return NULL;
@@ -72,7 +73,7 @@ CMLSpeculativeDecoder* cml_speculative_create(const CMLSpeculativeConfig* config
 
 void cml_speculative_free(CMLSpeculativeDecoder* decoder) {
     if (!decoder) return;
-    free(decoder);
+    cml_free(decoder);
 }
 
 void cml_speculative_set_draft_model(CMLSpeculativeDecoder* dec, void* ctx,
@@ -115,16 +116,16 @@ CMLSpeculativeResult* cml_speculative_decode_step(CMLSpeculativeDecoder* dec,
 
     /* Allocate working buffer for prefix + K draft tokens. */
     int max_seq = prefix_len + K;
-    int* full_seq = (int*)malloc((size_t)max_seq * sizeof(int));
+    int* full_seq = (int*)cml_malloc((size_t)max_seq * sizeof(int));
     if (!full_seq) {
         LOG_ERROR("cml_speculative_decode_step: allocation failed");
         return NULL;
     }
     memcpy(full_seq, prefix_tokens, (size_t)prefix_len * sizeof(int));
 
-    int* draft_tokens = (int*)malloc((size_t)K * sizeof(int));
+    int* draft_tokens = (int*)cml_malloc((size_t)K * sizeof(int));
     if (!draft_tokens) {
-        free(full_seq);
+        cml_free(full_seq);
         LOG_ERROR("cml_speculative_decode_step: allocation failed");
         return NULL;
     }
@@ -165,8 +166,8 @@ CMLSpeculativeResult* cml_speculative_decode_step(CMLSpeculativeDecoder* dec,
 
     if (!target_logits) {
         LOG_ERROR("target forward returned NULL");
-        free(full_seq);
-        free(draft_tokens);
+        cml_free(full_seq);
+        cml_free(draft_tokens);
         return NULL;
     }
 
@@ -209,18 +210,18 @@ CMLSpeculativeResult* cml_speculative_decode_step(CMLSpeculativeDecoder* dec,
     int total_output = num_accepted + ((num_accepted == K) ? 1 : 1);
     /* accepted draft tokens + either correction or bonus */
 
-    CMLSpeculativeResult* result = (CMLSpeculativeResult*)calloc(1, sizeof(CMLSpeculativeResult));
+    CMLSpeculativeResult* result = (CMLSpeculativeResult*)cml_calloc(1, sizeof(CMLSpeculativeResult));
     if (!result) {
-        free(full_seq);
-        free(draft_tokens);
+        cml_free(full_seq);
+        cml_free(draft_tokens);
         return NULL;
     }
 
-    result->accepted_tokens = (int*)malloc((size_t)total_output * sizeof(int));
+    result->accepted_tokens = (int*)cml_malloc((size_t)total_output * sizeof(int));
     if (!result->accepted_tokens) {
-        free(result);
-        free(full_seq);
-        free(draft_tokens);
+        cml_free(result);
+        cml_free(full_seq);
+        cml_free(draft_tokens);
         return NULL;
     }
 
@@ -250,8 +251,8 @@ CMLSpeculativeResult* cml_speculative_decode_step(CMLSpeculativeDecoder* dec,
     dec->total_accepted += (size_t)num_accepted;
     dec->total_steps++;
 
-    free(full_seq);
-    free(draft_tokens);
+    cml_free(full_seq);
+    cml_free(draft_tokens);
 
     LOG_DEBUG("speculative step: drafted=%d accepted=%d rate=%.2f",
               K, num_accepted, result->acceptance_rate);
@@ -261,8 +262,8 @@ CMLSpeculativeResult* cml_speculative_decode_step(CMLSpeculativeDecoder* dec,
 
 void cml_speculative_result_free(CMLSpeculativeResult* result) {
     if (!result) return;
-    free(result->accepted_tokens);
-    free(result);
+    cml_free(result->accepted_tokens);
+    cml_free(result);
 }
 
 float cml_speculative_acceptance_rate(const CMLSpeculativeDecoder* dec) {

--- a/src/nn/state.c
+++ b/src/nn/state.c
@@ -4,14 +4,15 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include "alloc/cml_allocator.h"
 
 #define SD_INIT_CAP 32
 
 StateDict* nn_state_dict_create(void) {
-    StateDict* sd = calloc(1, sizeof(StateDict));
+    StateDict* sd = cml_calloc(1, sizeof(StateDict));
     if (!sd) return NULL;
-    sd->entries  = malloc(SD_INIT_CAP * sizeof(StateDictEntry));
-    if (!sd->entries) { free(sd); return NULL; }
+    sd->entries  = cml_malloc(SD_INIT_CAP * sizeof(StateDictEntry));
+    if (!sd->entries) { cml_free(sd); return NULL; }
     sd->capacity = SD_INIT_CAP;
     sd->count    = 0;
     return sd;
@@ -20,10 +21,10 @@ StateDict* nn_state_dict_create(void) {
 void nn_state_dict_free(StateDict* sd) {
     if (!sd) return;
     for (int i = 0; i < sd->count; ++i)
-        free(sd->entries[i].key);
+        cml_free(sd->entries[i].key);
     
-    free(sd->entries);
-    free(sd);
+    cml_free(sd->entries);
+    cml_free(sd);
 }
 
 int nn_state_dict_set(StateDict* sd, const char* key, Tensor* value) {
@@ -36,13 +37,13 @@ int nn_state_dict_set(StateDict* sd, const char* key, Tensor* value) {
     }
     if (sd->count >= sd->capacity) {
         int new_cap = sd->capacity * 2;
-        StateDictEntry* tmp = realloc(sd->entries,
+        StateDictEntry* tmp = cml_realloc(sd->entries,
                                        (size_t)new_cap * sizeof(StateDictEntry));
         if (!tmp) return -1;
         sd->entries  = tmp;
         sd->capacity = new_cap;
     }
-    sd->entries[sd->count].key   = strdup(key);
+    sd->entries[sd->count].key   = cml_strdup(key);
     sd->entries[sd->count].value = value;
     if (!sd->entries[sd->count].key) return -1;
     ++sd->count;
@@ -61,7 +62,7 @@ int nn_state_dict_remove(StateDict* sd, const char* key) {
     if (!sd || !key) return 0;
     for (int i = 0; i < sd->count; ++i) {
         if (strcmp(sd->entries[i].key, key) == 0) {
-            free(sd->entries[i].key);
+            cml_free(sd->entries[i].key);
             sd->entries[i] = sd->entries[sd->count - 1];
             --sd->count;
             return 1;

--- a/src/ops/ir/aot.c
+++ b/src/ops/ir/aot.c
@@ -13,6 +13,7 @@
 
 #ifdef CML_HAS_LLVM_BACKEND
 #include "ops/ir/llvm/llvm_backend.h"
+#include "alloc/cml_allocator.h"
 #endif
 
 /* Rejects strings containing shell metacharacters that could allow
@@ -441,7 +442,7 @@ CMLAOTModel* cml_aot_load(const char* path) {
         return NULL;
     }
 
-    CMLAOTModel* model = calloc(1, sizeof(CMLAOTModel));
+    CMLAOTModel* model = cml_calloc(1, sizeof(CMLAOTModel));
     if (!model) {
         dlclose(handle);
         return NULL;
@@ -449,7 +450,7 @@ CMLAOTModel* cml_aot_load(const char* path) {
 
     model->handle = handle;
     model->forward_fn = forward_fn;
-    model->path = strdup(path);
+    model->path = cml_strdup(path);
 
     LOG_INFO("AOT model loaded from: %s", path);
     return model;
@@ -472,7 +473,7 @@ int cml_aot_execute(CMLAOTModel* model, Tensor** inputs, int num_inputs,
     } MemRefDesc1D;
 
     int total = num_inputs + num_outputs;
-    MemRefDesc1D* descs = malloc(total * sizeof(MemRefDesc1D));
+    MemRefDesc1D* descs = cml_malloc(total * sizeof(MemRefDesc1D));
     if (!descs)
         return -1;
 
@@ -481,11 +482,11 @@ int cml_aot_execute(CMLAOTModel* model, Tensor** inputs, int num_inputs,
         if (!t || !t->data) {
             /* Allocate output data if needed */
             if (i >= num_inputs && t && !t->data && t->numel > 0) {
-                t->data = calloc(t->numel, sizeof(float));
+                t->data = cml_calloc(t->numel, sizeof(float));
                 t->owns_data = true;
             }
             if (!t || !t->data) {
-                free(descs);
+                cml_free(descs);
                 return -1;
             }
         }
@@ -509,17 +510,17 @@ int cml_aot_execute(CMLAOTModel* model, Tensor** inputs, int num_inputs,
     } else {
         LOG_WARNING("AOT execute: unsupported arg count %d, using generic call", total);
         /* Generic call via function pointer array */
-        void** args = malloc(total * sizeof(void*));
+        void** args = cml_malloc(total * sizeof(void*));
         for (int i = 0; i < total; i++)
             args[i] = &descs[i];
         /* Execute as packed function */
         typedef void (*FnPacked)(void**);
         FnPacked fn = (FnPacked)model->forward_fn;
         fn(args);
-        free(args);
+        cml_free(args);
     }
 
-    free(descs);
+    cml_free(descs);
     return 0;
 }
 
@@ -532,18 +533,18 @@ void cml_aot_free(CMLAOTModel* model) {
 
     if (model->input_shapes) {
         for (int i = 0; i < model->num_inputs; i++)
-            free(model->input_shapes[i]);
-        free(model->input_shapes);
+            cml_free(model->input_shapes[i]);
+        cml_free(model->input_shapes);
     }
     if (model->output_shapes) {
         for (int i = 0; i < model->num_outputs; i++)
-            free(model->output_shapes[i]);
-        free(model->output_shapes);
+            cml_free(model->output_shapes[i]);
+        cml_free(model->output_shapes);
     }
-    free(model->input_ndims);
-    free(model->output_ndims);
-    free((char*)model->path);
-    free(model);
+    cml_free(model->input_ndims);
+    cml_free(model->output_ndims);
+    cml_free((char*)model->path);
+    cml_free(model);
 }
 
 int cml_aot_generate_header(CMLGraph_t ir, const char* header_path, const char* function_name) {

--- a/src/ops/ir/backward.c
+++ b/src/ops/ir/backward.c
@@ -17,6 +17,7 @@
 #endif
 #ifdef __AVX__
 #include <immintrin.h>
+#include "alloc/cml_allocator.h"
 #endif
 
 /* Access the shared BLAS context from execution.c */
@@ -785,7 +786,7 @@ static int cpu_backward_node(struct IRNode* node) {
         CMLBlasContext* blas = get_blas_context();
 
         if (blas && blas->initialized) {
-            float* col_buf = (float*)malloc((size_t)col_h * col_w * sizeof(float));
+            float* col_buf = (float*)cml_malloc((size_t)col_h * col_w * sizeof(float));
             if (!col_buf) break;
 
             for (int g = 0; g < groups; g++) {
@@ -869,7 +870,7 @@ static int cpu_backward_node(struct IRNode* node) {
                 }
             }
 
-            free(col_buf);
+            cml_free(col_buf);
         } else {
             /* Naive fallback with groups, stride, dilation, padding */
             if (in1->requires_grad && in2->data) {
@@ -2042,8 +2043,8 @@ static int cpu_backward_node(struct IRNode* node) {
                 float* g1d = (float*)g1->data, *x = (float*)in1->data;
                 size_t n = in1->numel;
                 // Compute prefix and suffix products to avoid division by zero
-                float* prefix = (float*)calloc(n + 1, sizeof(float));
-                float* suffix = (float*)calloc(n + 1, sizeof(float));
+                float* prefix = (float*)cml_calloc(n + 1, sizeof(float));
+                float* suffix = (float*)cml_calloc(n + 1, sizeof(float));
                 if (prefix && suffix) {
                     prefix[0] = 1.f;
                     for (size_t i = 0; i < n; i++) prefix[i+1] = prefix[i] * x[i];
@@ -2052,7 +2053,7 @@ static int cpu_backward_node(struct IRNode* node) {
                     for (size_t i = 0; i < n; i++)
                         g1d[i] += out_grad[0] * prefix[i] * suffix[i+1];
                 }
-                free(prefix); free(suffix);
+                cml_free(prefix); cml_free(suffix);
             }
         }
         break;
@@ -2930,7 +2931,7 @@ static int cpu_execute_backward(CMLGraph_t ir) {
     /* Use stack buffer for small graphs to avoid malloc/free overhead */
     struct IRNode* stack_buf[64];
     struct IRNode** nodes = (node_count <= 64) ? stack_buf
-                                               : malloc(node_count * sizeof(struct IRNode*));
+                                               : cml_malloc(node_count * sizeof(struct IRNode*));
     if (!nodes) {
         LOG_ERROR("Failed to allocate node array for backward pass");
         return -1;
@@ -2953,7 +2954,7 @@ static int cpu_execute_backward(CMLGraph_t ir) {
     }
 
     if (nodes != stack_buf)
-        free(nodes);
+        cml_free(nodes);
     return 0;
 }
 

--- a/src/ops/ir/beam_search.c
+++ b/src/ops/ir/beam_search.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 static const int BLOCK_SIZES[]   = {32, 64, 128, 256, 512, 1024};
 static const int UNROLL_FACTORS[] = {1, 2, 4};
@@ -32,7 +33,7 @@ bool cml_beam_search_enabled(void) {
 
 CMLBeamSearchCtx* cml_beam_search_create(void) {
     CMLBeamSearchCtx* ctx =
-        (CMLBeamSearchCtx*)calloc(1, sizeof(CMLBeamSearchCtx));
+        (CMLBeamSearchCtx*)cml_calloc(1, sizeof(CMLBeamSearchCtx));
     if (!ctx) {
         LOG_ERROR("Failed to allocate CMLBeamSearchCtx");
         return NULL;
@@ -64,7 +65,7 @@ CMLBeamSearchCtx* cml_beam_search_create(void) {
 
 void cml_beam_search_free(CMLBeamSearchCtx* ctx) {
     if (!ctx) return;
-    free(ctx);
+    cml_free(ctx);
 }
 
 int cml_beam_search_lookup(CMLBeamSearchCtx* ctx, uint64_t kernel_hash,
@@ -565,7 +566,7 @@ int cml_beam_search_tune_opt(CMLBeamSearchCtx* ctx, uint64_t kernel_hash,
 
     for (int i = 0; i < num_configs; i++)
         cml_opt_list_free(opt_lists[i]);
-    free(opt_lists);
+    cml_free(opt_lists);
 
     if (best_idx < 0) {
         LOG_WARNING("BEAM opt tune: no valid configuration found");

--- a/src/ops/ir/compiler_viz.c
+++ b/src/ops/ir/compiler_viz.c
@@ -5,6 +5,7 @@
 
 #ifdef _POSIX_C_SOURCE
 #include <time.h>
+#include "alloc/cml_allocator.h"
 static double viz_get_time_ms(void) {
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
@@ -15,7 +16,7 @@ static double viz_get_time_ms(void) { return 0.0; }
 #endif
 
 CMLCompilerViz* cml_compiler_viz_create(const char* output_path) {
-    CMLCompilerViz* viz = (CMLCompilerViz*)calloc(1, sizeof(CMLCompilerViz));
+    CMLCompilerViz* viz = (CMLCompilerViz*)cml_calloc(1, sizeof(CMLCompilerViz));
     if (!viz) return NULL;
 
     viz->enabled = true;
@@ -30,11 +31,11 @@ void cml_compiler_viz_free(CMLCompilerViz* viz) {
     CMLVizEvent* e = viz->events;
     while (e) {
         CMLVizEvent* next = e->next;
-        free(e->ir_snapshot);
-        free(e);
+        cml_free(e->ir_snapshot);
+        cml_free(e);
         e = next;
     }
-    free(viz);
+    cml_free(viz);
 }
 
 void cml_compiler_viz_enable(CMLCompilerViz* viz, bool enable) {
@@ -45,7 +46,7 @@ int cml_compiler_viz_record(CMLCompilerViz* viz, CMLVizEventType type,
                              const char* description, CMLGraph_t ir) {
     if (!viz || !viz->enabled) return 0;
 
-    CMLVizEvent* event = (CMLVizEvent*)calloc(1, sizeof(CMLVizEvent));
+    CMLVizEvent* event = (CMLVizEvent*)cml_calloc(1, sizeof(CMLVizEvent));
     if (!event) return -1;
 
     event->type = type;
@@ -115,8 +116,8 @@ void cml_compiler_viz_clear(CMLCompilerViz* viz) {
     CMLVizEvent* e = viz->events;
     while (e) {
         CMLVizEvent* next = e->next;
-        free(e->ir_snapshot);
-        free(e);
+        cml_free(e->ir_snapshot);
+        cml_free(e);
         e = next;
     }
     viz->events = NULL;

--- a/src/ops/ir/cross_boundary_fusion.c
+++ b/src/ops/ir/cross_boundary_fusion.c
@@ -5,6 +5,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 /*
  * Softmax + CrossEntropy pattern:
@@ -166,7 +167,7 @@ int cml_cross_boundary_analyze(CMLFusionSchedule* sched,
     *count = 0;
 
     int capacity = 16;
-    CMLCrossBoundaryFusion* fusions = calloc((size_t)capacity,
+    CMLCrossBoundaryFusion* fusions = cml_calloc((size_t)capacity,
                                              sizeof(CMLCrossBoundaryFusion));
     if (!fusions) return -1;
 
@@ -207,9 +208,9 @@ int cml_cross_boundary_analyze(CMLFusionSchedule* sched,
 
             if (found >= capacity) {
                 capacity *= 2;
-                CMLCrossBoundaryFusion* tmp = realloc(fusions,
+                CMLCrossBoundaryFusion* tmp = cml_realloc(fusions,
                     (size_t)capacity * sizeof(CMLCrossBoundaryFusion));
-                if (!tmp) { free(fusions); return -1; }
+                if (!tmp) { cml_free(fusions); return -1; }
                 fusions = tmp;
             }
 
@@ -221,7 +222,7 @@ int cml_cross_boundary_analyze(CMLFusionSchedule* sched,
     }
 
     if (found == 0) {
-        free(fusions);
+        cml_free(fusions);
         *out = NULL;
         *count = 0;
         return 0;
@@ -307,7 +308,7 @@ int cml_cross_boundary_fuse(CMLFusionSchedule* sched,
 }
 
 void cml_cross_boundary_fusions_free(CMLCrossBoundaryFusion* fusions) {
-    free(fusions);
+    cml_free(fusions);
 }
 
 CMLCrossBoundaryStats cml_cross_boundary_stats(const CMLCrossBoundaryFusion* fusions,

--- a/src/ops/ir/decompose.c
+++ b/src/ops/ir/decompose.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <math.h>
 #include <stdatomic.h>
+#include "alloc/cml_allocator.h"
 
 static atomic_int g_decompose_counter = 0;
 
@@ -24,7 +25,7 @@ static void replace_node_with_chain(CMLGraph_t ir, struct IRNode* original,
 
 static char* decompose_unique_name(void) {
     int id = atomic_fetch_add(&g_decompose_counter, 1);
-    char* name = malloc(32);
+    char* name = cml_malloc(32);
     if (name) {
         snprintf(name, 32, "_d%d", id);
     }
@@ -39,7 +40,7 @@ static struct IRNode* create_primitive_node(CMLGraph_t ir, UOpType type,
                                             Tensor** inputs, int num_inputs,
                                             void* params, int* out_shape,
                                             int out_ndim) {
-    struct IRNode* node = calloc(1, sizeof(struct IRNode));
+    struct IRNode* node = cml_calloc(1, sizeof(struct IRNode));
     if (!node) return NULL;
 
     node->type = type;
@@ -47,19 +48,19 @@ static struct IRNode* create_primitive_node(CMLGraph_t ir, UOpType type,
     node->params = params;
 
     if (num_inputs > 0 && inputs) {
-        node->input_names = malloc((size_t)num_inputs * sizeof(char*));
-        node->inputs = malloc((size_t)num_inputs * sizeof(Tensor*));
+        node->input_names = cml_malloc((size_t)num_inputs * sizeof(char*));
+        node->inputs = cml_malloc((size_t)num_inputs * sizeof(Tensor*));
         if (!node->input_names || !node->inputs) {
-            free(node->input_names);
-            free(node->inputs);
-            free(node);
+            cml_free(node->input_names);
+            cml_free(node->inputs);
+            cml_free(node);
             return NULL;
         }
         for (int i = 0; i < num_inputs; i++) {
             node->inputs[i] = inputs[i];
             if (inputs[i] && inputs[i]->ir_node &&
                 ((struct IRNode*)inputs[i]->ir_node)->output_name) {
-                node->input_names[i] = strdup(((struct IRNode*)inputs[i]->ir_node)->output_name);
+                node->input_names[i] = cml_strdup(((struct IRNode*)inputs[i]->ir_node)->output_name);
             } else {
                 node->input_names[i] = decompose_unique_name();
             }
@@ -73,7 +74,7 @@ static struct IRNode* create_primitive_node(CMLGraph_t ir, UOpType type,
     node->next = NULL;
 
     if (out_shape && out_ndim > 0) {
-        node->output_shape = malloc((size_t)out_ndim * sizeof(int));
+        node->output_shape = cml_malloc((size_t)out_ndim * sizeof(int));
         if (node->output_shape) {
             memcpy(node->output_shape, out_shape, (size_t)out_ndim * sizeof(int));
         }
@@ -90,14 +91,14 @@ static struct IRNode* create_primitive_node(CMLGraph_t ir, UOpType type,
         }
     }
 
-    Tensor* out_tensor = calloc(1, sizeof(Tensor));
+    Tensor* out_tensor = cml_calloc(1, sizeof(Tensor));
     if (!out_tensor) {
-        for (int i = 0; i < num_inputs; i++) free(node->input_names[i]);
-        free(node->input_names);
-        free(node->inputs);
-        free(node->output_name);
-        free(node->output_shape);
-        free(node);
+        for (int i = 0; i < num_inputs; i++) cml_free(node->input_names[i]);
+        cml_free(node->input_names);
+        cml_free(node->inputs);
+        cml_free(node->output_name);
+        cml_free(node->output_shape);
+        cml_free(node);
         return NULL;
     }
 
@@ -106,7 +107,7 @@ static struct IRNode* create_primitive_node(CMLGraph_t ir, UOpType type,
     node->output = out_tensor;
 
     if (out_shape && out_ndim > 0) {
-        out_tensor->shape = malloc((size_t)out_ndim * sizeof(int));
+        out_tensor->shape = cml_malloc((size_t)out_ndim * sizeof(int));
         if (out_tensor->shape) {
             memcpy(out_tensor->shape, out_shape, (size_t)out_ndim * sizeof(int));
         }
@@ -134,7 +135,7 @@ static struct IRNode* create_primitive_node(CMLGraph_t ir, UOpType type,
     out_tensor->base = NULL;
 
     if (out_ndim > 0 && out_tensor->shape) {
-        out_tensor->strides = malloc((size_t)out_ndim * sizeof(size_t));
+        out_tensor->strides = cml_malloc((size_t)out_ndim * sizeof(size_t));
         if (out_tensor->strides) {
             size_t stride = 1;
             for (int i = out_ndim - 1; i >= 0; i--) {
@@ -155,12 +156,12 @@ static struct IRNode* create_primitive_node(CMLGraph_t ir, UOpType type,
  * Create a FILL node for a constant scalar broadcast to given shape.
  */
 static struct IRNode* insert_fill_node(CMLGraph_t ir, int* shape, int ndim, float value) {
-    FillParams* params = malloc(sizeof(FillParams));
+    FillParams* params = cml_malloc(sizeof(FillParams));
     if (!params) return NULL;
     params->value = value;
     params->ndim = ndim;
-    params->shape = malloc((size_t)ndim * sizeof(int));
-    if (!params->shape) { free(params); return NULL; }
+    params->shape = cml_malloc((size_t)ndim * sizeof(int));
+    if (!params->shape) { cml_free(params); return NULL; }
     memcpy(params->shape, shape, (size_t)ndim * sizeof(int));
 
     struct IRNode* node = create_primitive_node(ir, UOP_FILL, NULL, 0, params, shape, ndim);
@@ -190,15 +191,15 @@ static void replace_node_with_chain(CMLGraph_t ir, struct IRNode* original,
         orig_output->ir_node = chain_tail;
 
         // Free the chain_tail's intermediate output tensor (no longer needed)
-        if (chain_output->shape) free(chain_output->shape);
-        if (chain_output->strides) free(chain_output->strides);
-        free(chain_output);
+        if (chain_output->shape) cml_free(chain_output->shape);
+        if (chain_output->strides) cml_free(chain_output->strides);
+        cml_free(chain_output);
 
         // Point chain_tail at the original output tensor
         chain_tail->output = orig_output;
 
-        if (chain_tail->output_name) free(chain_tail->output_name);
-        chain_tail->output_name = strdup(original->output_name ? original->output_name : "_decomp");
+        if (chain_tail->output_name) cml_free(chain_tail->output_name);
+        chain_tail->output_name = cml_strdup(original->output_name ? original->output_name : "_decomp");
     }
 
     // Find the node before `original` in the linked list
@@ -235,15 +236,15 @@ static void replace_node_with_chain(CMLGraph_t ir, struct IRNode* original,
     original->output = NULL; // Prevent double-free
     if (original->input_names) {
         for (int i = 0; i < original->num_inputs; i++) {
-            free(original->input_names[i]);
+            cml_free(original->input_names[i]);
         }
-        free(original->input_names);
+        cml_free(original->input_names);
     }
-    free(original->inputs);
-    free(original->output_name);
-    free(original->output_shape);
+    cml_free(original->inputs);
+    cml_free(original->output_name);
+    cml_free(original->output_shape);
     cml_ir_free_node_params(original);
-    free(original);
+    cml_free(original);
 }
 
 /**
@@ -1042,14 +1043,14 @@ static int decompose_mean(CMLGraph_t ir, struct IRNode* node) {
 
     // Deep copy reduce params for the new SUM node
     ReduceParams* orig_params = (ReduceParams*)node->params;
-    ReduceParams* sum_params = malloc(sizeof(ReduceParams));
+    ReduceParams* sum_params = cml_malloc(sizeof(ReduceParams));
     if (!sum_params) return -1;
     if (orig_params) {
         sum_params->keepdim = orig_params->keepdim;
         sum_params->num_dims = orig_params->num_dims;
         if (orig_params->dims && orig_params->num_dims > 0) {
-            sum_params->dims = malloc((size_t)orig_params->num_dims * sizeof(int));
-            if (!sum_params->dims) { free(sum_params); return -1; }
+            sum_params->dims = cml_malloc((size_t)orig_params->num_dims * sizeof(int));
+            if (!sum_params->dims) { cml_free(sum_params); return -1; }
             memcpy(sum_params->dims, orig_params->dims, (size_t)orig_params->num_dims * sizeof(int));
         } else {
             sum_params->dims = NULL;
@@ -1062,7 +1063,7 @@ static int decompose_mean(CMLGraph_t ir, struct IRNode* node) {
 
     // sum(x)
     struct IRNode* sum_node = create_primitive_node(ir, UOP_SUM, &x, 1, sum_params, out_shape, out_ndim);
-    if (!sum_node) { free(sum_params->dims); free(sum_params); return -1; }
+    if (!sum_node) { cml_free(sum_params->dims); cml_free(sum_params); return -1; }
     chain_append(&head, &tail, sum_node);
 
     // Compute n = number of elements being reduced
@@ -1111,14 +1112,14 @@ static int decompose_min_reduce(CMLGraph_t ir, struct IRNode* node) {
 
     // Deep copy reduce params
     ReduceParams* orig_params = (ReduceParams*)node->params;
-    ReduceParams* max_params = malloc(sizeof(ReduceParams));
+    ReduceParams* max_params = cml_malloc(sizeof(ReduceParams));
     if (!max_params) return -1;
     if (orig_params) {
         max_params->keepdim = orig_params->keepdim;
         max_params->num_dims = orig_params->num_dims;
         if (orig_params->dims && orig_params->num_dims > 0) {
-            max_params->dims = malloc((size_t)orig_params->num_dims * sizeof(int));
-            if (!max_params->dims) { free(max_params); return -1; }
+            max_params->dims = cml_malloc((size_t)orig_params->num_dims * sizeof(int));
+            if (!max_params->dims) { cml_free(max_params); return -1; }
             memcpy(max_params->dims, orig_params->dims, (size_t)orig_params->num_dims * sizeof(int));
         } else {
             max_params->dims = NULL;
@@ -1132,7 +1133,7 @@ static int decompose_min_reduce(CMLGraph_t ir, struct IRNode* node) {
     // max_reduce(neg(x))
     struct IRNode* max_node = create_primitive_node(ir, UOP_MAX_REDUCE, &neg_node->output, 1,
                                                      max_params, out_shape, out_ndim);
-    if (!max_node) { free(max_params->dims); free(max_params); return -1; }
+    if (!max_node) { cml_free(max_params->dims); cml_free(max_params); return -1; }
     chain_append(&head, &tail, max_node);
 
     // neg(max_reduce(neg(x)))

--- a/src/ops/ir/disk_cache.c
+++ b/src/ops/ir/disk_cache.c
@@ -9,6 +9,7 @@
 #include <dlfcn.h>
 #include <time.h>
 #include <errno.h>
+#include "alloc/cml_allocator.h"
 
 typedef struct sqlite3 sqlite3;
 typedef struct sqlite3_stmt sqlite3_stmt;
@@ -123,7 +124,7 @@ static char* default_path(void) {
     const char* cache_dir = getenv("CML_CACHE_DIR");
     if (cache_dir) {
         size_t len = strlen(cache_dir) + 32;
-        char* buf = malloc(len);
+        char* buf = cml_malloc(len);
         if (!buf) return NULL;
         snprintf(buf, len, "%s/kernels.db", cache_dir);
         return buf;
@@ -133,7 +134,7 @@ static char* default_path(void) {
     if (!home) home = "/tmp";
 
     size_t len = strlen(home) + 32;
-    char* buf = malloc(len);
+    char* buf = cml_malloc(len);
     if (!buf) return NULL;
     snprintf(buf, len, "%s/.cache/cml/kernels.db", home);
     return buf;
@@ -157,20 +158,20 @@ CMLDiskCache* cml_disk_cache_open(const char* path) {
 
     mkdirs(path);
 
-    CMLDiskCache* cache = calloc(1, sizeof(CMLDiskCache));
+    CMLDiskCache* cache = cml_calloc(1, sizeof(CMLDiskCache));
     if (!cache) {
-        free(alloc_path);
+        cml_free(alloc_path);
         return NULL;
     }
 
     if (sql.open(path, &cache->db) != SQLITE_OK) {
         LOG_ERROR("Failed to open disk cache: %s", path);
-        free(cache);
-        free(alloc_path);
+        cml_free(cache);
+        cml_free(alloc_path);
         return NULL;
     }
 
-    free(alloc_path);
+    cml_free(alloc_path);
 
     char* err = NULL;
     sql.exec(cache->db, "PRAGMA journal_mode=WAL", NULL, NULL, &err);
@@ -189,7 +190,7 @@ CMLDiskCache* cml_disk_cache_open(const char* path) {
         LOG_ERROR("Failed to create table: %s", err);
         if (sql.free_fn) sql.free_fn(err);
         sql.close(cache->db);
-        free(cache);
+        cml_free(cache);
         return NULL;
     }
 
@@ -219,7 +220,7 @@ void cml_disk_cache_close(CMLDiskCache* cache) {
     if (cache->stmt_count) sql.finalize(cache->stmt_count);
     if (cache->db) sql.close(cache->db);
 
-    free(cache);
+    cml_free(cache);
 }
 
 typedef int (*fn_sqlite3_reset)(sqlite3_stmt*);
@@ -285,7 +286,7 @@ int cml_disk_cache_get(CMLDiskCache* cache, uint64_t hash, void** out_data, size
         return -1;
     }
 
-    void* buf = malloc((size_t)blob_size);
+    void* buf = cml_malloc((size_t)blob_size);
     if (!buf) {
         reset_stmt(cache->stmt_get);
         return -1;

--- a/src/ops/ir/dispatch.c
+++ b/src/ops/ir/dispatch.c
@@ -50,6 +50,7 @@
 #include <string.h>
 #include <strings.h>
 #include <stdio.h>
+#include "alloc/cml_allocator.h"
 
 static CMLCUDABackend* g_cuda_backend = NULL;
 static bool g_cuda_init_attempted = false;
@@ -107,7 +108,7 @@ static const char* backend_descriptions[] = {
 };
 
 CMLDispatchContext* cml_dispatch_create(void) {
-    CMLDispatchContext* ctx = (CMLDispatchContext*)calloc(1, sizeof(CMLDispatchContext));
+    CMLDispatchContext* ctx = (CMLDispatchContext*)cml_calloc(1, sizeof(CMLDispatchContext));
     if (!ctx) {
         LOG_ERROR("Failed to allocate dispatch context");
         return NULL;
@@ -208,7 +209,7 @@ void cml_dispatch_free(CMLDispatchContext* ctx) {
     }
 #endif
 
-    free(ctx);
+    cml_free(ctx);
     if (ctx == g_dispatch_ctx)
         g_dispatch_ctx = NULL;
 }

--- a/src/ops/ir/execution.c
+++ b/src/ops/ir/execution.c
@@ -29,6 +29,7 @@
 
 #ifdef __AVX__
 #include <immintrin.h>
+#include "alloc/cml_allocator.h"
 #endif
 
 static CMLBlasContext* g_exec_blas_ctx = NULL;
@@ -112,7 +113,7 @@ void* cml_buffer_cache_alloc(size_t size) {
     if (bucket_idx < 0) {
         g_buffer_cache.cache_misses++;
         g_buffer_cache.bytes_allocated += size;
-        return malloc(size);
+        return cml_malloc(size);
     }
 
     BufferBucket* bucket = &g_buffer_cache.buckets[bucket_idx];
@@ -123,7 +124,7 @@ void* cml_buffer_cache_alloc(size_t size) {
         bucket->count--;
 
         void* data = cached->data;
-        free(cached);
+        cml_free(cached);
 
         g_buffer_cache.cache_hits++;
         g_buffer_cache.bytes_cached -= bucket->bucket_size;
@@ -135,7 +136,7 @@ void* cml_buffer_cache_alloc(size_t size) {
 
     g_buffer_cache.cache_misses++;
     g_buffer_cache.bytes_allocated += bucket->bucket_size;
-    return malloc(bucket->bucket_size);
+    return cml_malloc(bucket->bucket_size);
 }
 
 void cml_buffer_cache_free(void* ptr, size_t size) {
@@ -146,20 +147,20 @@ void cml_buffer_cache_free(void* ptr, size_t size) {
 
     int bucket_idx = get_bucket_index(size);
     if (bucket_idx < 0) {
-        free(ptr);
+        cml_free(ptr);
         return;
     }
 
     BufferBucket* bucket = &g_buffer_cache.buckets[bucket_idx];
 
     if (bucket->count >= BUFFER_CACHE_MAX_PER_BUCKET) {
-        free(ptr);
+        cml_free(ptr);
         return;
     }
 
-    CachedBuffer* cached = (CachedBuffer*)malloc(sizeof(CachedBuffer));
+    CachedBuffer* cached = (CachedBuffer*)cml_malloc(sizeof(CachedBuffer));
     if (!cached) {
-        free(ptr);
+        cml_free(ptr);
         return;
     }
 
@@ -179,8 +180,8 @@ void cml_cleanup_buffer_cache(void) {
         CachedBuffer* current = bucket->free_list;
         while (current) {
             CachedBuffer* next = current->next;
-            free(current->data);
-            free(current);
+            cml_free(current->data);
+            cml_free(current);
             current = next;
         }
         bucket->free_list = NULL;
@@ -360,13 +361,13 @@ static int winograd_conv2d_blas(CMLBlasContext* blas, const float* input, const 
     size_t U_sz  = (size_t)16 * oc_pg * ic_pg;
     size_t V_sz  = (size_t)16 * ic_pg * total_tiles;
     size_t M_sz  = (size_t)16 * oc_pg * total_tiles;
-    float* U_buf = (float*)malloc(U_sz * sizeof(float));
-    float* V_buf = (float*)malloc(V_sz * sizeof(float));
-    float* M_buf = (float*)malloc(M_sz * sizeof(float));
+    float* U_buf = (float*)cml_malloc(U_sz * sizeof(float));
+    float* V_buf = (float*)cml_malloc(V_sz * sizeof(float));
+    float* M_buf = (float*)cml_malloc(M_sz * sizeof(float));
     if (!U_buf || !V_buf || !M_buf) {
-        free(U_buf);
-        free(V_buf);
-        free(M_buf);
+        cml_free(U_buf);
+        cml_free(V_buf);
+        cml_free(M_buf);
         return -1;
     }
 
@@ -480,9 +481,9 @@ static int winograd_conv2d_blas(CMLBlasContext* blas, const float* input, const 
         }
     }
 
-    free(U_buf);
-    free(V_buf);
-    free(M_buf);
+    cml_free(U_buf);
+    cml_free(V_buf);
+    cml_free(M_buf);
     return 0;
 }
 
@@ -622,7 +623,7 @@ int cpu_execute_node(struct IRNode* node) {
             /* Detached leaf tensor with no data — allocate zero-filled */
             if (inp->numel > 0) {
                 size_t sz      = inp->numel * cml_dtype_size(inp->dtype);
-                inp->data      = calloc(1, sz);
+                inp->data      = cml_calloc(1, sz);
                 inp->owns_data = true;
             }
         }
@@ -1759,7 +1760,7 @@ int cpu_execute_node(struct IRNode* node) {
 
         if (node->inputs[0]->ndim == 1) {
             int n      = node->inputs[0]->shape[0];
-            float* tmp = malloc((size_t)n * sizeof(float));
+            float* tmp = cml_malloc((size_t)n * sizeof(float));
             if (!tmp)
                 return -1;
             memcpy(tmp, in1_data, (size_t)n * sizeof(float));
@@ -1774,7 +1775,7 @@ int cpu_execute_node(struct IRNode* node) {
                 tmp[best]   = t;
                 out_data[i] = tmp[i];
             }
-            free(tmp);
+            cml_free(tmp);
         } else {
             int copy_n = k < (int)in1_numel ? k : (int)in1_numel;
             memcpy(out_data, in1_data, (size_t)copy_n * sizeof(float));
@@ -3207,8 +3208,8 @@ int cpu_execute_node(struct IRNode* node) {
 
         if (conv_blas && conv_blas->initialized) {
             if (needed > s_col_buf_size) {
-                free(s_col_buf);
-                s_col_buf      = (float*)malloc(needed);
+                cml_free(s_col_buf);
+                s_col_buf      = (float*)cml_malloc(needed);
                 s_col_buf_size = s_col_buf ? needed : 0;
             }
             col_buf = s_col_buf;
@@ -3239,8 +3240,8 @@ int cpu_execute_node(struct IRNode* node) {
             static size_t s_gemm_buf_size = 0;
             size_t gemm_sz                = (size_t)out_channels * total_col_w * sizeof(float);
             if (gemm_sz > s_gemm_buf_size) {
-                free(s_gemm_buf);
-                s_gemm_buf      = (float*)malloc(gemm_sz);
+                cml_free(s_gemm_buf);
+                s_gemm_buf      = (float*)cml_malloc(gemm_sz);
                 s_gemm_buf_size = s_gemm_buf ? gemm_sz : 0;
             }
 

--- a/src/ops/ir/export.c
+++ b/src/ops/ir/export.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 static void append_json_string(char** buffer, size_t* offset, size_t* capacity, const char* str) {
     if (!str)
@@ -14,7 +15,7 @@ static void append_json_string(char** buffer, size_t* offset, size_t* capacity, 
     size_t needed = strlen(str) * 6 + 10;
     while (*offset + needed >= *capacity) {
         *capacity *= 2;
-        char* new_buffer = realloc(*buffer, *capacity);
+        char* new_buffer = cml_realloc(*buffer, *capacity);
         if (!new_buffer)
             return;
         *buffer = new_buffer;
@@ -76,7 +77,7 @@ static void append_format(char** buffer, size_t* offset, size_t* capacity, const
     // Ensure capacity
     while (*offset + (size_t)needed + 1 >= *capacity) {
         *capacity *= 2;
-        char* new_buffer = realloc(*buffer, *capacity);
+        char* new_buffer = cml_realloc(*buffer, *capacity);
         if (!new_buffer) {
             va_end(args);
             return;
@@ -98,7 +99,7 @@ static char* generate_kernel_code_snippet(struct IRNode* node) {
         return NULL;
 
     size_t buffer_size = 1024;
-    char* code         = malloc(buffer_size);
+    char* code         = cml_malloc(buffer_size);
     if (!code)
         return NULL;
 
@@ -309,7 +310,7 @@ static char* generate_fused_kernel_code(FusedKernel* kernel) {
         return NULL;
 
     size_t buffer_size = 2048;
-    char* code         = malloc(buffer_size);
+    char* code         = cml_malloc(buffer_size);
     if (!code)
         return NULL;
 
@@ -402,7 +403,7 @@ static void analyze_usage(CMLGraph_t ir) {
     if (count == 0)
         return;
 
-    struct IRNode** nodes = malloc(count * sizeof(struct IRNode*));
+    struct IRNode** nodes = cml_malloc(count * sizeof(struct IRNode*));
     if (!nodes)
         return;
 
@@ -431,7 +432,7 @@ static void analyze_usage(CMLGraph_t ir) {
         }
     }
 
-    free(nodes);
+    cml_free(nodes);
 }
 
 char* cml_ir_export_kernel_analysis(CMLGraph_t ir, bool optimized) {
@@ -441,7 +442,7 @@ char* cml_ir_export_kernel_analysis(CMLGraph_t ir, bool optimized) {
     analyze_usage(ir);
 
     size_t capacity = 8192;
-    char* buffer    = malloc(capacity);
+    char* buffer    = cml_malloc(capacity);
     if (!buffer)
         return NULL;
 
@@ -517,7 +518,7 @@ char* cml_ir_export_kernel_analysis(CMLGraph_t ir, bool optimized) {
         }
         append_json_string(&buffer, &offset, &capacity, code ? code : "// Code generation failed");
         if (code)
-            free(code);
+            cml_free(code);
         append_format(&buffer, &offset, &capacity, ",");
 
         append_format(&buffer, &offset, &capacity, "\"inputs\":[");
@@ -651,7 +652,7 @@ char* cml_ir_export_graph_json(CMLGraph_t ir) {
     if (!ir)
         return NULL;
 
-    char* buffer = malloc(1024 * 1024); // 1MB buffer
+    char* buffer = cml_malloc(1024 * 1024); // 1MB buffer
     if (!buffer)
         return NULL;
 
@@ -679,9 +680,9 @@ char* cml_ir_export_graph_json(CMLGraph_t ir) {
         temp = temp->next;
     }
 
-    struct IRNode** nodes = malloc(node_count * sizeof(struct IRNode*));
+    struct IRNode** nodes = cml_malloc(node_count * sizeof(struct IRNode*));
     if (!nodes) {
-        free(buffer);
+        cml_free(buffer);
         return NULL;
     }
 
@@ -749,6 +750,6 @@ char* cml_ir_export_graph_json(CMLGraph_t ir) {
 
     append_format(&buffer, &offset, &capacity, "}");
 
-    free(nodes);
+    cml_free(nodes);
     return buffer;
 }

--- a/src/ops/ir/fused_codegen.c
+++ b/src/ops/ir/fused_codegen.c
@@ -82,7 +82,7 @@ CMLLinearProgram* cml_linearize_group(const CMLFusionGroup* g) {
                 if (prog->num_ops >= prog->capacity) {
                     int nc = prog->capacity * 2;
                     CMLLinearOp* tmp = cml_realloc(prog->ops, (size_t)nc * sizeof(CMLLinearOp));
-                    if (!tmp) break;
+                    if (!tmp) goto oom;
                     prog->ops = tmp;
                     prog->capacity = nc;
                 }
@@ -114,7 +114,7 @@ CMLLinearProgram* cml_linearize_group(const CMLFusionGroup* g) {
         if (prog->num_ops >= prog->capacity) {
             int nc = prog->capacity * 2;
             CMLLinearOp* tmp = cml_realloc(prog->ops, (size_t)nc * sizeof(CMLLinearOp));
-            if (!tmp) break;
+            if (!tmp) goto oom;
             prog->ops = tmp;
             prog->capacity = nc;
         }
@@ -131,7 +131,7 @@ CMLLinearProgram* cml_linearize_group(const CMLFusionGroup* g) {
             if (prog->num_ops >= prog->capacity) {
                 int nc = prog->capacity * 2;
                 CMLLinearOp* tmp = cml_realloc(prog->ops, (size_t)nc * sizeof(CMLLinearOp));
-                if (!tmp) break;
+                if (!tmp) goto oom;
                 prog->ops = tmp;
                 prog->capacity = nc;
             }
@@ -141,6 +141,12 @@ CMLLinearProgram* cml_linearize_group(const CMLFusionGroup* g) {
 
     cml_free(node_vreg);
     return prog;
+
+oom:
+    cml_free(node_vreg);
+    cml_free(prog->ops);
+    cml_free(prog);
+    return NULL;
 }
 
 void cml_linear_program_free(CMLLinearProgram* prog) {

--- a/src/ops/ir/fused_codegen.c
+++ b/src/ops/ir/fused_codegen.c
@@ -10,21 +10,22 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
+#include "alloc/cml_allocator.h"
 
 #define FUSED_BUF_SIZE 16384
 
 CMLLinearProgram* cml_linearize_group(const CMLFusionGroup* g) {
     if (!g || g->num_nodes == 0) return NULL;
 
-    CMLLinearProgram* prog = calloc(1, sizeof(CMLLinearProgram));
+    CMLLinearProgram* prog = cml_calloc(1, sizeof(CMLLinearProgram));
     if (!prog) return NULL;
     prog->capacity = 32;
-    prog->ops = calloc((size_t)prog->capacity, sizeof(CMLLinearOp));
-    if (!prog->ops) { free(prog); return NULL; }
+    prog->ops = cml_calloc((size_t)prog->capacity, sizeof(CMLLinearOp));
+    if (!prog->ops) { cml_free(prog); return NULL; }
 
     /* Map node index -> vreg */
-    int* node_vreg = calloc((size_t)g->num_nodes, sizeof(int));
-    if (!node_vreg) { free(prog->ops); free(prog); return NULL; }
+    int* node_vreg = cml_calloc((size_t)g->num_nodes, sizeof(int));
+    if (!node_vreg) { cml_free(prog->ops); cml_free(prog); return NULL; }
     for (int i = 0; i < g->num_nodes; i++) node_vreg[i] = -1;
 
     /* Track loaded external tensors */
@@ -80,7 +81,7 @@ CMLLinearProgram* cml_linearize_group(const CMLFusionGroup* g) {
                 /* Emit */
                 if (prog->num_ops >= prog->capacity) {
                     int nc = prog->capacity * 2;
-                    CMLLinearOp* tmp = realloc(prog->ops, (size_t)nc * sizeof(CMLLinearOp));
+                    CMLLinearOp* tmp = cml_realloc(prog->ops, (size_t)nc * sizeof(CMLLinearOp));
                     if (!tmp) break;
                     prog->ops = tmp;
                     prog->capacity = nc;
@@ -112,7 +113,7 @@ CMLLinearProgram* cml_linearize_group(const CMLFusionGroup* g) {
         /* Emit compute */
         if (prog->num_ops >= prog->capacity) {
             int nc = prog->capacity * 2;
-            CMLLinearOp* tmp = realloc(prog->ops, (size_t)nc * sizeof(CMLLinearOp));
+            CMLLinearOp* tmp = cml_realloc(prog->ops, (size_t)nc * sizeof(CMLLinearOp));
             if (!tmp) break;
             prog->ops = tmp;
             prog->capacity = nc;
@@ -129,7 +130,7 @@ CMLLinearProgram* cml_linearize_group(const CMLFusionGroup* g) {
 
             if (prog->num_ops >= prog->capacity) {
                 int nc = prog->capacity * 2;
-                CMLLinearOp* tmp = realloc(prog->ops, (size_t)nc * sizeof(CMLLinearOp));
+                CMLLinearOp* tmp = cml_realloc(prog->ops, (size_t)nc * sizeof(CMLLinearOp));
                 if (!tmp) break;
                 prog->ops = tmp;
                 prog->capacity = nc;
@@ -138,14 +139,14 @@ CMLLinearProgram* cml_linearize_group(const CMLFusionGroup* g) {
         }
     }
 
-    free(node_vreg);
+    cml_free(node_vreg);
     return prog;
 }
 
 void cml_linear_program_free(CMLLinearProgram* prog) {
     if (!prog) return;
-    free(prog->ops);
-    free(prog);
+    cml_free(prog->ops);
+    cml_free(prog);
 }
 
 static const char* linop_kind_str(CMLLinearOpKind k) {
@@ -199,7 +200,7 @@ static bool uop_is_unary(UOpType uop) {
 }
 
 static char* fused_codegen_c(const CMLLinearProgram* prog, size_t work_size) {
-    char* buf = malloc(FUSED_BUF_SIZE);
+    char* buf = cml_malloc(FUSED_BUF_SIZE);
     if (!buf) return NULL;
     int pos = 0;
 
@@ -327,7 +328,7 @@ static char* fused_codegen_c(const CMLLinearProgram* prog, size_t work_size) {
 }
 
 char* cml_ptx_gen_fused_kernel(const CMLLinearProgram* prog, size_t work_size) {
-    char* buf = malloc(FUSED_BUF_SIZE);
+    char* buf = cml_malloc(FUSED_BUF_SIZE);
     if (!buf) return NULL;
     int pos = 0;
 
@@ -596,7 +597,7 @@ uint32_t* cml_spirv_gen_fused_kernel(const CMLLinearProgram* prog,
 
     /* Allocate generous buffer for SPIR-V words */
     int max_words = 1024 + prog->num_ops * 32 + num_buffers * 64;
-    uint32_t* words = calloc((size_t)max_words, sizeof(uint32_t));
+    uint32_t* words = cml_calloc((size_t)max_words, sizeof(uint32_t));
     if (!words) return NULL;
 
     uint32_t* w = words;
@@ -915,7 +916,7 @@ uint32_t* cml_spirv_gen_fused_kernel(const CMLLinearProgram* prog,
 }
 
 static char* fused_codegen_wgsl(const CMLLinearProgram* prog, size_t work_size) {
-    char* buf = malloc(FUSED_BUF_SIZE);
+    char* buf = cml_malloc(FUSED_BUF_SIZE);
     if (!buf) return NULL;
     int pos = 0;
 
@@ -1048,7 +1049,7 @@ CMLFusedKernel* cml_fused_codegen(const CMLLinearProgram* prog,
                                     size_t work_size) {
     if (!prog || prog->num_ops == 0) return NULL;
 
-    CMLFusedKernel* kernel = calloc(1, sizeof(CMLFusedKernel));
+    CMLFusedKernel* kernel = cml_calloc(1, sizeof(CMLFusedKernel));
     if (!kernel) return NULL;
 
     kernel->backend = backend;
@@ -1064,30 +1065,30 @@ CMLFusedKernel* cml_fused_codegen(const CMLLinearProgram* prog,
     switch (backend) {
     case CML_FUSED_BACKEND_C:
         kernel->source = fused_codegen_c(prog, work_size);
-        if (!kernel->source) { free(kernel); return NULL; }
+        if (!kernel->source) { cml_free(kernel); return NULL; }
         break;
 
     case CML_FUSED_BACKEND_PTX:
         kernel->source = cml_ptx_gen_fused_kernel(prog, work_size);
-        if (!kernel->source) { free(kernel); return NULL; }
+        if (!kernel->source) { cml_free(kernel); return NULL; }
         break;
 
     case CML_FUSED_BACKEND_SPIRV:
         kernel->spirv_words = cml_spirv_gen_fused_kernel(prog, work_size,
                                                           &kernel->spirv_num_words);
-        if (!kernel->spirv_words) { free(kernel); return NULL; }
+        if (!kernel->spirv_words) { cml_free(kernel); return NULL; }
         break;
 
     case CML_FUSED_BACKEND_WGSL:
         kernel->source = fused_codegen_wgsl(prog, work_size);
-        if (!kernel->source) { free(kernel); return NULL; }
+        if (!kernel->source) { cml_free(kernel); return NULL; }
         break;
 
     default:
         LOG_WARNING("Fused codegen: unsupported backend %d, falling back to C", backend);
         kernel->backend = CML_FUSED_BACKEND_C;
         kernel->source = fused_codegen_c(prog, work_size);
-        if (!kernel->source) { free(kernel); return NULL; }
+        if (!kernel->source) { cml_free(kernel); return NULL; }
         break;
     }
 
@@ -1118,9 +1119,9 @@ CMLFusedKernel* cml_fused_codegen_group(const CMLFusionGroup* group,
 
 void cml_fused_kernel_free(CMLFusedKernel* kernel) {
     if (!kernel) return;
-    free(kernel->source);
-    free(kernel->spirv_words);
-    free(kernel);
+    cml_free(kernel->source);
+    cml_free(kernel->spirv_words);
+    cml_free(kernel);
 }
 
 void cml_fused_kernel_print(const CMLFusedKernel* kernel) {

--- a/src/ops/ir/fusion_patterns.c
+++ b/src/ops/ir/fusion_patterns.c
@@ -3,6 +3,7 @@
 #include "core/logging.h"
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 static FusionMatch* match_matmul_bias_relu(struct IRNode* start, struct CMLGraph* ir) {
     (void)ir;
@@ -30,14 +31,14 @@ static FusionMatch* match_matmul_bias_relu(struct IRNode* start, struct CMLGraph
         return NULL;
     }
 
-    FusionMatch* match = calloc(1, sizeof(FusionMatch));
+    FusionMatch* match = cml_calloc(1, sizeof(FusionMatch));
     if (!match)
         return NULL;
 
     match->num_matched = 3;
-    match->matched_nodes = malloc(3 * sizeof(struct IRNode*));
+    match->matched_nodes = cml_malloc(3 * sizeof(struct IRNode*));
     if (!match->matched_nodes) {
-        free(match);
+        cml_free(match);
         return NULL;
     }
     match->matched_nodes[0] = start;
@@ -111,14 +112,14 @@ static FusionMatch* match_elementwise_chain(struct IRNode* start, struct CMLGrap
     if (chain_len < 2)
         return NULL;
 
-    FusionMatch* match = calloc(1, sizeof(FusionMatch));
+    FusionMatch* match = cml_calloc(1, sizeof(FusionMatch));
     if (!match)
         return NULL;
 
     match->num_matched = chain_len;
-    match->matched_nodes = malloc(chain_len * sizeof(struct IRNode*));
+    match->matched_nodes = cml_malloc(chain_len * sizeof(struct IRNode*));
     if (!match->matched_nodes) {
-        free(match);
+        cml_free(match);
         return NULL;
     }
     memcpy(match->matched_nodes, chain, chain_len * sizeof(struct IRNode*));
@@ -166,12 +167,12 @@ static FusionMatch* match_softmax_ce_bwd(struct IRNode* start, struct CMLGraph* 
         sub_node = mul_node->users[0];
     if (!sub_node || sub_node->type != UOP_SUB) return NULL;
 
-    FusionMatch* match = calloc(1, sizeof(FusionMatch));
+    FusionMatch* match = cml_calloc(1, sizeof(FusionMatch));
     if (!match) return NULL;
 
     match->num_matched = 5;
-    match->matched_nodes = malloc(5 * sizeof(struct IRNode*));
-    if (!match->matched_nodes) { free(match); return NULL; }
+    match->matched_nodes = cml_malloc(5 * sizeof(struct IRNode*));
+    if (!match->matched_nodes) { cml_free(match); return NULL; }
     match->matched_nodes[0] = start;
     match->matched_nodes[1] = sum_node;
     match->matched_nodes[2] = recip_node;
@@ -236,12 +237,12 @@ static FusionMatch* match_layernorm_bwd(struct IRNode* start, struct CMLGraph* i
     }
     if (!rsqrt) return NULL;
 
-    FusionMatch* match = calloc(1, sizeof(FusionMatch));
+    FusionMatch* match = cml_calloc(1, sizeof(FusionMatch));
     if (!match) return NULL;
 
     match->num_matched = 5;
-    match->matched_nodes = malloc(5 * sizeof(struct IRNode*));
-    if (!match->matched_nodes) { free(match); return NULL; }
+    match->matched_nodes = cml_malloc(5 * sizeof(struct IRNode*));
+    if (!match->matched_nodes) { cml_free(match); return NULL; }
     match->matched_nodes[0] = start;
     match->matched_nodes[1] = sub;
     match->matched_nodes[2] = sq;
@@ -270,12 +271,12 @@ static FusionMatch* match_gelu_bwd(struct IRNode* start, struct CMLGraph* ir) {
 
     if (start->type == UOP_QUICK_GELU || start->type == UOP_SILU) {
         if (start->backward_node || (start->use_count > 0 && start->users)) {
-            FusionMatch* match = calloc(1, sizeof(FusionMatch));
+            FusionMatch* match = cml_calloc(1, sizeof(FusionMatch));
             if (!match) return NULL;
 
             match->num_matched = 1;
-            match->matched_nodes = malloc(sizeof(struct IRNode*));
-            if (!match->matched_nodes) { free(match); return NULL; }
+            match->matched_nodes = cml_malloc(sizeof(struct IRNode*));
+            if (!match->matched_nodes) { cml_free(match); return NULL; }
             match->matched_nodes[0] = start;
 
             LOG_DEBUG("Fusion pattern matched: GELU/SiLU + backward");
@@ -299,7 +300,7 @@ static int emit_gelu_bwd(FusionMatch* match, struct CMLGraph* ir) {
 static FusionPatternRegistry* g_default_registry = NULL;
 
 FusionPatternRegistry* cml_fusion_registry_create(void) {
-    FusionPatternRegistry* reg = calloc(1, sizeof(FusionPatternRegistry));
+    FusionPatternRegistry* reg = cml_calloc(1, sizeof(FusionPatternRegistry));
     if (!reg)
         return NULL;
 
@@ -346,11 +347,11 @@ void cml_fusion_registry_free(FusionPatternRegistry* registry) {
         FusionPattern* p = registry->patterns[t];
         while (p) {
             FusionPattern* next = p->next;
-            free(p);
+            cml_free(p);
             p = next;
         }
     }
-    free(registry);
+    cml_free(registry);
 }
 
 FusionPatternRegistry* cml_fusion_registry_get_default(void) {
@@ -369,7 +370,7 @@ int cml_fusion_register_pattern(FusionPatternRegistry* registry,
     if (!registry || !match || !emit || target >= FUSION_TARGET_COUNT)
         return -1;
 
-    FusionPattern* pattern = calloc(1, sizeof(FusionPattern));
+    FusionPattern* pattern = cml_calloc(1, sizeof(FusionPattern));
     if (!pattern)
         return -1;
 
@@ -426,7 +427,7 @@ int cml_fusion_apply_patterns(FusionPatternRegistry* registry,
 void cml_fusion_match_free(FusionMatch* match) {
     if (!match)
         return;
-    free(match->matched_nodes);
-    free(match->match_data);
-    free(match);
+    cml_free(match->matched_nodes);
+    cml_free(match->match_data);
+    cml_free(match);
 }

--- a/src/ops/ir/fusion_schedule.c
+++ b/src/ops/ir/fusion_schedule.c
@@ -332,12 +332,20 @@ CMLFusionSchedule* cml_fusion_schedule_create(CMLGraph_t graph,
             int* in_degree = cml_calloc((size_t)ng, sizeof(int));
             int** deps = cml_calloc((size_t)ng, sizeof(int*));
             int* dep_counts = cml_calloc((size_t)ng, sizeof(int));
+            int* queue = NULL;
+            int bfs_ok = (in_degree && deps && dep_counts);
 
-            if (in_degree && deps && dep_counts) {
+            if (bfs_ok) {
                 for (int i = 0; i < ng; i++) {
                     deps[i] = cml_calloc((size_t)ng, sizeof(int));
+                    if (!deps[i]) {
+                        bfs_ok = 0;
+                        break;
+                    }
                 }
+            }
 
+            if (bfs_ok) {
                 for (int i = 0; i < ng; i++) {
                     CMLFusionGroup* consumer = sched->groups[i];
                     if (!consumer) continue;
@@ -366,7 +374,13 @@ CMLFusionSchedule* cml_fusion_schedule_create(CMLGraph_t graph,
                     }
                 }
 
-                int* queue = cml_calloc((size_t)ng, sizeof(int));
+                queue = cml_calloc((size_t)ng, sizeof(int));
+                if (!queue) {
+                    bfs_ok = 0;
+                }
+            }
+
+            if (bfs_ok && queue) {
                 int qhead = 0, qtail = 0;
 
                 for (int i = 0; i < ng; i++) {
@@ -395,13 +409,23 @@ CMLFusionSchedule* cml_fusion_schedule_create(CMLGraph_t graph,
                 }
 
                 sched->num_ordered = ordered;
-                cml_free(queue);
             }
 
-            for (int i = 0; i < ng; i++) cml_free(deps[i]);
+            cml_free(queue);
+            if (deps) {
+                for (int i = 0; i < ng; i++) cml_free(deps[i]);
+            }
             cml_free(deps);
             cml_free(dep_counts);
             cml_free(in_degree);
+
+            /* Fall back to sequential order if BFS temporaries could not be allocated */
+            if (!bfs_ok || sched->num_ordered == 0) {
+                for (int i = 0; i < sched->num_groups; i++) {
+                    sched->execution_order[i] = i;
+                }
+                sched->num_ordered = sched->num_groups;
+            }
         } else {
             for (int i = 0; i < sched->num_groups; i++) {
                 sched->execution_order[i] = i;

--- a/src/ops/ir/fusion_schedule.c
+++ b/src/ops/ir/fusion_schedule.c
@@ -17,6 +17,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include "alloc/cml_allocator.h"
 
 /** Classify a UOp into a schedule item type (mirrors schedule.c) */
 static CMLScheduleItemType classify_fusion_op(UOpType type) {
@@ -52,15 +53,15 @@ static size_t tensor_elems(const Tensor* t) {
 }
 
 static CMLFusionGroup* fusion_group_create(void) {
-    CMLFusionGroup* g = calloc(1, sizeof(CMLFusionGroup));
+    CMLFusionGroup* g = cml_calloc(1, sizeof(CMLFusionGroup));
     if (!g) return NULL;
     g->node_capacity = 8;
-    g->nodes = calloc((size_t)g->node_capacity, sizeof(struct IRNode*));
-    if (!g->nodes) { free(g); return NULL; }
+    g->nodes = cml_calloc((size_t)g->node_capacity, sizeof(struct IRNode*));
+    if (!g->nodes) { cml_free(g); return NULL; }
 
     g->elim_capacity = 4;
-    g->eliminated_buffers = calloc((size_t)g->elim_capacity, sizeof(int));
-    if (!g->eliminated_buffers) { free(g->nodes); free(g); return NULL; }
+    g->eliminated_buffers = cml_calloc((size_t)g->elim_capacity, sizeof(int));
+    if (!g->eliminated_buffers) { cml_free(g->nodes); cml_free(g); return NULL; }
 
     g->type = SCHED_MOVEMENT;  /* weakest type; promoted as nodes are added */
     return g;
@@ -70,7 +71,7 @@ static int fusion_group_add_node(CMLFusionGroup* g, struct IRNode* node) {
     if (!g || !node) return -1;
     if (g->num_nodes >= g->node_capacity) {
         int nc = g->node_capacity * 2;
-        struct IRNode** tmp = realloc(g->nodes,
+        struct IRNode** tmp = cml_realloc(g->nodes,
                                       (size_t)nc * sizeof(struct IRNode*));
         if (!tmp) return -1;
         g->nodes = tmp;
@@ -125,7 +126,7 @@ static void fusion_group_add_eliminated(CMLFusionGroup* g, int buffer_idx) {
     if (!g) return;
     if (g->num_eliminated >= g->elim_capacity) {
         int nc = g->elim_capacity * 2;
-        int* tmp = realloc(g->eliminated_buffers, (size_t)nc * sizeof(int));
+        int* tmp = cml_realloc(g->eliminated_buffers, (size_t)nc * sizeof(int));
         if (!tmp) return;
         g->eliminated_buffers = tmp;
         g->elim_capacity = nc;
@@ -135,9 +136,9 @@ static void fusion_group_add_eliminated(CMLFusionGroup* g, int buffer_idx) {
 
 static void fusion_group_free(CMLFusionGroup* g) {
     if (!g) return;
-    free(g->nodes);
-    free(g->eliminated_buffers);
-    free(g);
+    cml_free(g->nodes);
+    cml_free(g->eliminated_buffers);
+    cml_free(g);
 }
 
 CMLFusionAnalysis cml_schedule_analyze_fusion(struct IRNode* a,
@@ -173,7 +174,7 @@ CMLFusionSchedule* cml_fusion_schedule_create(CMLGraph_t graph,
         opts = &default_opts;
     }
 
-    CMLFusionSchedule* sched = calloc(1, sizeof(CMLFusionSchedule));
+    CMLFusionSchedule* sched = cml_calloc(1, sizeof(CMLFusionSchedule));
     if (!sched) return NULL;
 
     /* Handle NULL or empty graph */
@@ -192,8 +193,8 @@ CMLFusionSchedule* cml_fusion_schedule_create(CMLGraph_t graph,
 
     /* Allocate group list */
     int cap = graph->node_count < 16 ? 16 : graph->node_count;
-    sched->groups = calloc((size_t)cap, sizeof(CMLFusionGroup*));
-    if (!sched->groups) { free(sched); return NULL; }
+    sched->groups = cml_calloc((size_t)cap, sizeof(CMLFusionGroup*));
+    if (!sched->groups) { cml_free(sched); return NULL; }
     sched->group_capacity = cap;
 
     int total_ops = 0;
@@ -287,7 +288,7 @@ CMLFusionSchedule* cml_fusion_schedule_create(CMLGraph_t graph,
         if (cur) {
             if (sched->num_groups >= sched->group_capacity) {
                 int nc = sched->group_capacity * 2;
-                CMLFusionGroup** tmp = realloc(
+                CMLFusionGroup** tmp = cml_realloc(
                     sched->groups,
                     (size_t)nc * sizeof(CMLFusionGroup*));
                 if (tmp) {
@@ -312,7 +313,7 @@ CMLFusionSchedule* cml_fusion_schedule_create(CMLGraph_t graph,
     if (cur) {
         if (sched->num_groups >= sched->group_capacity) {
             int nc = sched->group_capacity * 2;
-            CMLFusionGroup** tmp = realloc(
+            CMLFusionGroup** tmp = cml_realloc(
                 sched->groups,
                 (size_t)nc * sizeof(CMLFusionGroup*));
             if (tmp) {
@@ -324,17 +325,17 @@ CMLFusionSchedule* cml_fusion_schedule_create(CMLGraph_t graph,
     }
 
     /* Build execution order */
-    sched->execution_order = calloc((size_t)sched->num_groups, sizeof(int));
+    sched->execution_order = cml_calloc((size_t)sched->num_groups, sizeof(int));
     if (sched->execution_order) {
         if (opts->schedule_order == CML_SCHEDULE_ORDER_BFS && sched->num_groups > 1) {
             int ng = sched->num_groups;
-            int* in_degree = calloc((size_t)ng, sizeof(int));
-            int** deps = calloc((size_t)ng, sizeof(int*));
-            int* dep_counts = calloc((size_t)ng, sizeof(int));
+            int* in_degree = cml_calloc((size_t)ng, sizeof(int));
+            int** deps = cml_calloc((size_t)ng, sizeof(int*));
+            int* dep_counts = cml_calloc((size_t)ng, sizeof(int));
 
             if (in_degree && deps && dep_counts) {
                 for (int i = 0; i < ng; i++) {
-                    deps[i] = calloc((size_t)ng, sizeof(int));
+                    deps[i] = cml_calloc((size_t)ng, sizeof(int));
                 }
 
                 for (int i = 0; i < ng; i++) {
@@ -365,7 +366,7 @@ CMLFusionSchedule* cml_fusion_schedule_create(CMLGraph_t graph,
                     }
                 }
 
-                int* queue = calloc((size_t)ng, sizeof(int));
+                int* queue = cml_calloc((size_t)ng, sizeof(int));
                 int qhead = 0, qtail = 0;
 
                 for (int i = 0; i < ng; i++) {
@@ -394,13 +395,13 @@ CMLFusionSchedule* cml_fusion_schedule_create(CMLGraph_t graph,
                 }
 
                 sched->num_ordered = ordered;
-                free(queue);
+                cml_free(queue);
             }
 
-            for (int i = 0; i < ng; i++) free(deps[i]);
-            free(deps);
-            free(dep_counts);
-            free(in_degree);
+            for (int i = 0; i < ng; i++) cml_free(deps[i]);
+            cml_free(deps);
+            cml_free(dep_counts);
+            cml_free(in_degree);
         } else {
             for (int i = 0; i < sched->num_groups; i++) {
                 sched->execution_order[i] = i;
@@ -421,9 +422,9 @@ CMLFusionSchedule* cml_fusion_schedule_create(CMLGraph_t graph,
     sched->memory_plan = NULL;
     if (sched->num_groups > 0) {
         int nb = sched->num_groups;
-        size_t* buf_sizes = calloc((size_t)nb, sizeof(size_t));
-        int* buf_first    = calloc((size_t)nb, sizeof(int));
-        int* buf_last     = calloc((size_t)nb, sizeof(int));
+        size_t* buf_sizes = cml_calloc((size_t)nb, sizeof(size_t));
+        int* buf_first    = cml_calloc((size_t)nb, sizeof(int));
+        int* buf_last     = cml_calloc((size_t)nb, sizeof(int));
 
         if (buf_sizes && buf_first && buf_last) {
             for (int i = 0; i < nb; i++) {
@@ -454,9 +455,9 @@ CMLFusionSchedule* cml_fusion_schedule_create(CMLGraph_t graph,
             sched->memory_plan = cml_memory_plan_create(nb, buf_sizes, buf_first, buf_last);
         }
 
-        free(buf_sizes);
-        free(buf_first);
-        free(buf_last);
+        cml_free(buf_sizes);
+        cml_free(buf_first);
+        cml_free(buf_last);
     }
 
     return sched;
@@ -468,10 +469,10 @@ void cml_fusion_schedule_free(CMLFusionSchedule* sched) {
     for (int i = 0; i < sched->num_groups; i++) {
         fusion_group_free(sched->groups[i]);
     }
-    free(sched->groups);
-    free(sched->execution_order);
+    cml_free(sched->groups);
+    cml_free(sched->execution_order);
     cml_memory_plan_free(sched->memory_plan);
-    free(sched);
+    cml_free(sched);
 }
 
 static const char* fusion_sched_type_name(CMLScheduleItemType type) {

--- a/src/ops/ir/gpu/adreno_backend.c
+++ b/src/ops/ir/gpu/adreno_backend.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <dlfcn.h>
 #include <stdint.h>
+#include "alloc/cml_allocator.h"
 
 #define CL_SUCCESS                  0
 #define CL_DEVICE_TYPE_GPU          (1 << 2)
@@ -122,11 +123,11 @@ static bool find_adreno_device(void** out_platform, void** out_device) {
         return false;
     }
 
-    void** platforms = (void**)calloc(num_platforms, sizeof(void*));
+    void** platforms = (void**)cml_calloc(num_platforms, sizeof(void*));
     if (!platforms) return false;
 
     if (fn_clGetPlatformIDs(num_platforms, platforms, NULL) != CL_SUCCESS) {
-        free(platforms);
+        cml_free(platforms);
         return false;
     }
 
@@ -140,11 +141,11 @@ static bool find_adreno_device(void** out_platform, void** out_device) {
             continue;
         }
 
-        void** devices = (void**)calloc(num_devices, sizeof(void*));
+        void** devices = (void**)cml_calloc(num_devices, sizeof(void*));
         if (!devices) continue;
 
         if (fn_clGetDeviceIDs(platforms[i], CL_DEVICE_TYPE_GPU, num_devices, devices, NULL) != CL_SUCCESS) {
-            free(devices);
+            cml_free(devices);
             continue;
         }
 
@@ -155,15 +156,15 @@ static bool find_adreno_device(void** out_platform, void** out_device) {
             if (strstr(dev_name, "Adreno") || strstr(name, "Qualcomm") || strstr(name, "QUALCOMM")) {
                 *out_platform = platforms[i];
                 *out_device = devices[j];
-                free(devices);
-                free(platforms);
+                cml_free(devices);
+                cml_free(platforms);
                 return true;
             }
         }
-        free(devices);
+        cml_free(devices);
     }
 
-    free(platforms);
+    cml_free(platforms);
     return false;
 }
 
@@ -187,7 +188,7 @@ bool cml_adreno_available(void) {
         return false;
     }
 
-    void** platforms = (void**)calloc(num_platforms, sizeof(void*));
+    void** platforms = (void**)cml_calloc(num_platforms, sizeof(void*));
     if (!platforms) { dlclose(lib); return false; }
 
     bool found = false;
@@ -202,7 +203,7 @@ bool cml_adreno_available(void) {
                 continue;
             }
 
-            void** devices = (void**)calloc(num_devices, sizeof(void*));
+            void** devices = (void**)cml_calloc(num_devices, sizeof(void*));
             if (!devices) continue;
 
             if (get_dev(platforms[i], CL_DEVICE_TYPE_GPU, num_devices, devices, NULL) == CL_SUCCESS) {
@@ -215,17 +216,17 @@ bool cml_adreno_available(void) {
                     }
                 }
             }
-            free(devices);
+            cml_free(devices);
         }
     }
 
-    free(platforms);
+    cml_free(platforms);
     dlclose(lib);
     return found;
 }
 
 CMLAdrenoBackend* cml_adreno_backend_create(void) {
-    CMLAdrenoBackend* b = (CMLAdrenoBackend*)calloc(1, sizeof(CMLAdrenoBackend));
+    CMLAdrenoBackend* b = (CMLAdrenoBackend*)cml_calloc(1, sizeof(CMLAdrenoBackend));
     if (!b) {
         LOG_ERROR("Failed to allocate CMLAdrenoBackend");
     }
@@ -333,7 +334,7 @@ void cml_adreno_backend_free(CMLAdrenoBackend* backend) {
     }
 
     backend->initialized = false;
-    free(backend);
+    cml_free(backend);
 }
 
 int cml_adreno_execute(CMLAdrenoBackend* backend, CMLGraph_t ir) {

--- a/src/ops/ir/gpu/am_driver.c
+++ b/src/ops/ir/gpu/am_driver.c
@@ -28,6 +28,7 @@
 
 #ifdef CML_AM_MOCK_GPU
 #include "ops/ir/gpu/am_mock.h"
+#include "alloc/cml_allocator.h"
 #define open(...)    cml_am_mock_open(__VA_ARGS__)
 #define close(...)   cml_am_mock_close(__VA_ARGS__)
 #define ioctl(...)   cml_am_mock_ioctl(__VA_ARGS__)
@@ -451,8 +452,8 @@ int cml_am_enumerate_gpus(CMLAMGPUInfo** gpus, int* count) {
 
         if (num >= cap) {
             cap = cap ? cap * 2 : 4;
-            CMLAMGPUInfo* tmp = realloc(list, (size_t)cap * sizeof(CMLAMGPUInfo));
-            if (!tmp) { free(list); closedir(dir); return -1; }
+            CMLAMGPUInfo* tmp = cml_realloc(list, (size_t)cap * sizeof(CMLAMGPUInfo));
+            if (!tmp) { cml_free(list); closedir(dir); return -1; }
             list = tmp;
         }
         list[num++] = info;
@@ -545,7 +546,7 @@ bool cml_am_driver_available(void) {
 
 
 CMLAMDriver* cml_am_driver_create(void) {
-    CMLAMDriver* drv = (CMLAMDriver*)calloc(1, sizeof(CMLAMDriver));
+    CMLAMDriver* drv = (CMLAMDriver*)cml_calloc(1, sizeof(CMLAMDriver));
     if (!drv) {
         LOG_ERROR("AM driver: failed to allocate driver context");
         return NULL;
@@ -654,7 +655,7 @@ int cml_am_driver_init(CMLAMDriver* drv) {
             snprintf(drv->device_name, sizeof(drv->device_name), "%s", gpus[0].name);
             snprintf(drv->gfx_version, sizeof(drv->gfx_version), "%s", gpus[0].gfx_version);
         }
-        free(gpus);
+        cml_free(gpus);
 
         if (drv->gpu_id == 0) {
             LOG_ERROR("AM driver: no GPU found via KFD topology");
@@ -809,7 +810,7 @@ void cml_am_driver_free(CMLAMDriver* drv) {
     if (drv->fd_kfd >= 0) close(drv->fd_kfd);
 #endif
 
-    free(drv);
+    cml_free(drv);
 }
 
 
@@ -1045,7 +1046,7 @@ CMLAMSignal* cml_am_signal_create(CMLAMDriver* drv, uint64_t initial_value) {
 #ifdef __linux__
     if (!drv || !drv->initialized) return NULL;
 
-    CMLAMSignal* sig = (CMLAMSignal*)calloc(1, sizeof(CMLAMSignal));
+    CMLAMSignal* sig = (CMLAMSignal*)cml_calloc(1, sizeof(CMLAMSignal));
     if (!sig) return NULL;
 
     uint64_t handle = 0, va = 0;
@@ -1055,7 +1056,7 @@ CMLAMSignal* cml_am_signal_create(CMLAMDriver* drv, uint64_t initial_value) {
                    | KFD_IOC_ALLOC_MEM_FLAGS_COHERENT;
 
     if (am_alloc_and_map(drv, sizeof(uint64_t) * 8, flags, &handle, &va, &addr) != 0) {
-        free(sig);
+        cml_free(sig);
         return NULL;
     }
 
@@ -1084,7 +1085,7 @@ void cml_am_signal_free(CMLAMDriver* drv, CMLAMSignal* signal) {
     }
 #endif
 
-    free(signal);
+    cml_free(signal);
 }
 
 int cml_am_signal_wait(CMLAMSignal* signal, uint64_t expected, uint64_t timeout_ns) {
@@ -1372,7 +1373,7 @@ CMLAMBuffer* cml_am_buffer_create(CMLAMDriver* drv, size_t size, bool vram) {
         return NULL;
     }
 
-    CMLAMBuffer* buf = (CMLAMBuffer*)calloc(1, sizeof(CMLAMBuffer));
+    CMLAMBuffer* buf = (CMLAMBuffer*)cml_calloc(1, sizeof(CMLAMBuffer));
     if (!buf) return NULL;
 
     uint32_t flags;
@@ -1391,7 +1392,7 @@ CMLAMBuffer* cml_am_buffer_create(CMLAMDriver* drv, size_t size, bool vram) {
     void* cpu_addr = NULL;
 
     if (am_alloc_and_map(drv, size, flags, &handle, &va, &cpu_addr) != 0) {
-        free(buf);
+        cml_free(buf);
         return NULL;
     }
 
@@ -1418,7 +1419,7 @@ void cml_am_buffer_free(CMLAMDriver* drv, CMLAMBuffer* buf) {
     }
 #endif
 
-    free(buf);
+    cml_free(buf);
 }
 
 int cml_am_buffer_upload(CMLAMDriver* drv, CMLAMBuffer* dst,
@@ -1632,7 +1633,7 @@ CMLAMKernel* cml_am_kernel_load(CMLAMDriver* drv, const void* code_object,
     if (!drv || !drv->initialized || !code_object || code_size == 0 || !kernel_name)
         return NULL;
 
-    CMLAMKernel* kernel = (CMLAMKernel*)calloc(1, sizeof(CMLAMKernel));
+    CMLAMKernel* kernel = (CMLAMKernel*)cml_calloc(1, sizeof(CMLAMKernel));
     if (!kernel) return NULL;
 
     uint64_t handle = 0, va = 0;
@@ -1643,7 +1644,7 @@ CMLAMKernel* cml_am_kernel_load(CMLAMDriver* drv, const void* code_object,
                    | KFD_IOC_ALLOC_MEM_FLAGS_EXECUTABLE;
 
     if (am_alloc_and_map(drv, code_size, flags, &handle, &va, &cpu_addr) != 0) {
-        free(kernel);
+        cml_free(kernel);
         return NULL;
     }
 
@@ -1652,17 +1653,17 @@ CMLAMKernel* cml_am_kernel_load(CMLAMDriver* drv, const void* code_object,
         am_mb();
     } else {
         am_free_and_unmap(drv, handle, cpu_addr, code_size);
-        free(kernel);
+        cml_free(kernel);
         return NULL;
     }
 
-    kernel->code_object = malloc(code_size);
+    kernel->code_object = cml_malloc(code_size);
     if (kernel->code_object)
         memcpy(kernel->code_object, code_object, code_size);
     kernel->code_size = code_size;
     kernel->gpu_addr  = va;
     kernel->handle    = (uint32_t)handle;
-    kernel->name      = strdup(kernel_name);
+    kernel->name      = cml_strdup(kernel_name);
 
     /* Try kernel descriptor parsing first */
     AMDGPUKernelDescriptor kd;
@@ -1796,9 +1797,9 @@ void cml_am_kernel_free(CMLAMDriver* drv, CMLAMKernel* kernel) {
     }
 #endif
 
-    free(kernel->code_object);
-    free(kernel->name);
-    free(kernel);
+    cml_free(kernel->code_object);
+    cml_free(kernel->name);
+    cml_free(kernel);
 }
 
 
@@ -2072,7 +2073,7 @@ int cml_am_execute_graph(CMLAMDriver* drv, CMLGraph_t ir) {
 
                 if (gpu_ok) {
                     if (!output->data)
-                        output->data = malloc(bytes);
+                        output->data = cml_malloc(bytes);
                     if (output->data)
                         cml_am_buffer_download(drv, buf_out, output->data, bytes);
                 }

--- a/src/ops/ir/gpu/am_mock.c
+++ b/src/ops/ir/gpu/am_mock.c
@@ -15,6 +15,7 @@
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <dirent.h>
+#include "alloc/cml_allocator.h"
 
 #define MOCK_FD_KFD  200
 #define MOCK_FD_DRM  201
@@ -52,7 +53,7 @@ void cml_am_mock_init(CMLAMMockGPU* config) {
     g_mock.next_queue_id = 1;
 
     g_mock.alloc_capacity = MOCK_ALLOC_INIT_CAP;
-    g_mock.alloc_table = (void**)calloc((size_t)g_mock.alloc_capacity, sizeof(void*));
+    g_mock.alloc_table = (void**)cml_calloc((size_t)g_mock.alloc_capacity, sizeof(void*));
     g_mock.num_allocs = 0;
 
     mock_create_topology();
@@ -63,9 +64,9 @@ void cml_am_mock_shutdown(void) {
     if (!g_mock_active) return;
 
     for (int i = 0; i < g_mock.num_allocs; i++) {
-        free(g_mock.alloc_table[i]);
+        cml_free(g_mock.alloc_table[i]);
     }
-    free(g_mock.alloc_table);
+    cml_free(g_mock.alloc_table);
     g_mock.alloc_table = NULL;
     g_mock.num_allocs = 0;
     g_mock.alloc_capacity = 0;
@@ -84,7 +85,7 @@ static void mock_track_alloc(void* ptr) {
 
     if (g_mock.num_allocs >= g_mock.alloc_capacity) {
         int new_cap = g_mock.alloc_capacity * 2;
-        void** tmp = (void**)realloc(g_mock.alloc_table,
+        void** tmp = (void**)cml_realloc(g_mock.alloc_table,
                                      (size_t)new_cap * sizeof(void*));
         if (!tmp) return;
         g_mock.alloc_table = tmp;
@@ -383,7 +384,7 @@ int cml_am_mock_munmap(void* addr, size_t length) {
     if (!g_mock_active) return munmap(addr, length);
 
     if (mock_untrack_alloc(addr)) {
-        free(addr);
+        cml_free(addr);
         return 0;
     }
 

--- a/src/ops/ir/gpu/amd_llvm.c
+++ b/src/ops/ir/gpu/amd_llvm.c
@@ -80,7 +80,7 @@ CMLAMDLLVMCompiler* cml_amd_llvm_create(const char* gpu_arch) {
         }
     }
 
-    CMLAMDLLVMCompiler* comp = calloc(1, sizeof(CMLAMDLLVMCompiler));
+    CMLAMDLLVMCompiler* comp = cml_calloc(1, sizeof(CMLAMDLLVMCompiler));
     if (!comp) return NULL;
 
     strncpy(comp->target_triple, "amdgcn-amd-amdhsa", sizeof(comp->target_triple) - 1);
@@ -95,7 +95,7 @@ CMLAMDLLVMCompiler* cml_amd_llvm_create(const char* gpu_arch) {
     comp->llvm_ctx = LLVMContextCreate();
     if (!comp->llvm_ctx) {
         LOG_ERROR("AMD LLVM: failed to create context");
-        free(comp);
+        cml_free(comp);
         return NULL;
     }
 
@@ -107,7 +107,7 @@ void cml_amd_llvm_free(CMLAMDLLVMCompiler* comp) {
     if (!comp) return;
     if (comp->llvm_ctx)
         LLVMContextDispose((LLVMContextRef)comp->llvm_ctx);
-    free(comp);
+    cml_free(comp);
 }
 
 static LLVMTargetMachineRef create_target_machine(CMLAMDLLVMCompiler* comp) {
@@ -217,7 +217,7 @@ int cml_amd_llvm_compile_ir(CMLAMDLLVMCompiler* comp,
     size_t obj_size = LLVMGetBufferSize(obj_buf);
     const char* obj_data = LLVMGetBufferStart(obj_buf);
 
-    void* result = malloc(obj_size);
+    void* result = cml_malloc(obj_size);
     if (!result) {
         LLVMDisposeMemoryBuffer(obj_buf);
         LLVMDisposeModule(mod);
@@ -324,7 +324,7 @@ int cml_amd_llvm_compile_source(CMLAMDLLVMCompiler* comp,
     size_t obj_size = LLVMGetBufferSize(obj_buf);
     const char* obj_data = LLVMGetBufferStart(obj_buf);
 
-    void* result = malloc(obj_size);
+    void* result = cml_malloc(obj_size);
     if (!result) {
         LLVMDisposeMemoryBuffer(obj_buf);
         LLVMDisposeModule(mod);
@@ -348,6 +348,7 @@ int cml_amd_llvm_compile_source(CMLAMDLLVMCompiler* comp,
 
 #include "ops/ir/gpu/amd_llvm.h"
 #include <stddef.h>
+#include "alloc/cml_allocator.h"
 
 bool cml_amd_llvm_available(void) { return false; }
 CMLAMDLLVMCompiler* cml_amd_llvm_create(const char* gpu_arch) { (void)gpu_arch; return NULL; }

--- a/src/ops/ir/gpu/amd_profiling.c
+++ b/src/ops/ir/gpu/amd_profiling.c
@@ -8,6 +8,7 @@
 #include <unistd.h>
 #include <sys/ioctl.h>
 #include <inttypes.h>
+#include "alloc/cml_allocator.h"
 
 #define PROFILE_INITIAL_CAPACITY 64
 #define SQTT_BUFFER_SIZE         (4 * 1024 * 1024)
@@ -47,14 +48,14 @@ static int profile_ensure_capacity(CMLAMDProfile* prof) {
     int new_cap = prof->capacity * 2;
     if (new_cap < PROFILE_INITIAL_CAPACITY) new_cap = PROFILE_INITIAL_CAPACITY;
 
-    uint64_t* ts = realloc(prof->timestamps, (size_t)new_cap * sizeof(uint64_t));
-    uint32_t* wc = realloc(prof->wave_counts, (size_t)new_cap * sizeof(uint32_t));
-    uint64_t* bc = realloc(prof->busy_cycles, (size_t)new_cap * sizeof(uint64_t));
-    uint64_t* mr = realloc(prof->mem_reads, (size_t)new_cap * sizeof(uint64_t));
-    uint64_t* mw = realloc(prof->mem_writes, (size_t)new_cap * sizeof(uint64_t));
+    uint64_t* ts = cml_realloc(prof->timestamps, (size_t)new_cap * sizeof(uint64_t));
+    uint32_t* wc = cml_realloc(prof->wave_counts, (size_t)new_cap * sizeof(uint32_t));
+    uint64_t* bc = cml_realloc(prof->busy_cycles, (size_t)new_cap * sizeof(uint64_t));
+    uint64_t* mr = cml_realloc(prof->mem_reads, (size_t)new_cap * sizeof(uint64_t));
+    uint64_t* mw = cml_realloc(prof->mem_writes, (size_t)new_cap * sizeof(uint64_t));
 
     if (!ts || !wc || !bc || !mr || !mw) {
-        free(ts); free(wc); free(bc); free(mr); free(mw);
+        cml_free(ts); cml_free(wc); cml_free(bc); cml_free(mr); cml_free(mw);
         return -1;
     }
 
@@ -68,15 +69,15 @@ static int profile_ensure_capacity(CMLAMDProfile* prof) {
 }
 
 CMLAMDProfile* cml_amd_profile_create(void) {
-    CMLAMDProfile* prof = calloc(1, sizeof(CMLAMDProfile));
+    CMLAMDProfile* prof = cml_calloc(1, sizeof(CMLAMDProfile));
     if (!prof) return NULL;
 
     prof->capacity = PROFILE_INITIAL_CAPACITY;
-    prof->timestamps  = calloc((size_t)prof->capacity, sizeof(uint64_t));
-    prof->wave_counts = calloc((size_t)prof->capacity, sizeof(uint32_t));
-    prof->busy_cycles = calloc((size_t)prof->capacity, sizeof(uint64_t));
-    prof->mem_reads   = calloc((size_t)prof->capacity, sizeof(uint64_t));
-    prof->mem_writes  = calloc((size_t)prof->capacity, sizeof(uint64_t));
+    prof->timestamps  = cml_calloc((size_t)prof->capacity, sizeof(uint64_t));
+    prof->wave_counts = cml_calloc((size_t)prof->capacity, sizeof(uint32_t));
+    prof->busy_cycles = cml_calloc((size_t)prof->capacity, sizeof(uint64_t));
+    prof->mem_reads   = cml_calloc((size_t)prof->capacity, sizeof(uint64_t));
+    prof->mem_writes  = cml_calloc((size_t)prof->capacity, sizeof(uint64_t));
 
     if (!prof->timestamps || !prof->wave_counts || !prof->busy_cycles ||
         !prof->mem_reads || !prof->mem_writes) {
@@ -138,12 +139,12 @@ int cml_amd_profile_stop(CMLAMDProfile* prof, CMLAMDriver* drv) {
 
 void cml_amd_profile_free(CMLAMDProfile* prof) {
     if (!prof) return;
-    free(prof->timestamps);
-    free(prof->wave_counts);
-    free(prof->busy_cycles);
-    free(prof->mem_reads);
-    free(prof->mem_writes);
-    free(prof);
+    cml_free(prof->timestamps);
+    cml_free(prof->wave_counts);
+    cml_free(prof->busy_cycles);
+    cml_free(prof->mem_reads);
+    cml_free(prof->mem_writes);
+    cml_free(prof);
 }
 
 int cml_amd_pmc_read(CMLAMDriver* drv, uint32_t counter_id, uint64_t* value) {
@@ -193,12 +194,12 @@ int cml_amd_pmc_read(CMLAMDriver* drv, uint32_t counter_id, uint64_t* value) {
 CMLAMDSQTTTrace* cml_amd_sqtt_capture(CMLAMDriver* drv, int num_dispatches) {
     if (!drv || !drv->initialized || num_dispatches <= 0) return NULL;
 
-    CMLAMDSQTTTrace* trace = calloc(1, sizeof(CMLAMDSQTTTrace));
+    CMLAMDSQTTTrace* trace = cml_calloc(1, sizeof(CMLAMDSQTTTrace));
     if (!trace) return NULL;
 
-    trace->data = calloc(1, SQTT_BUFFER_SIZE);
+    trace->data = cml_calloc(1, SQTT_BUFFER_SIZE);
     if (!trace->data) {
-        free(trace);
+        cml_free(trace);
         return NULL;
     }
     trace->size = SQTT_BUFFER_SIZE;
@@ -254,8 +255,8 @@ CMLAMDSQTTTrace* cml_amd_sqtt_capture(CMLAMDriver* drv, int num_dispatches) {
 
 void cml_amd_sqtt_free(CMLAMDSQTTTrace* trace) {
     if (!trace) return;
-    free(trace->data);
-    free(trace);
+    cml_free(trace->data);
+    cml_free(trace);
 }
 
 void cml_amd_profile_print(const CMLAMDProfile* prof) {

--- a/src/ops/ir/gpu/cuda_backend.c
+++ b/src/ops/ir/gpu/cuda_backend.c
@@ -17,6 +17,7 @@
 #define NVRTC_LIB_NAME NULL
 #elif defined(_WIN32)
 #include <windows.h>
+#include "alloc/cml_allocator.h"
 #define CUDA_LIB_NAME "nvcuda.dll"
 #define NVRTC_LIB_NAME "nvrtc64_*.dll"
 #endif
@@ -92,7 +93,7 @@ bool cml_cuda_available(void) {
 }
 
 CMLCUDABackend* cml_cuda_backend_create(void) {
-    CMLCUDABackend* backend = calloc(1, sizeof(CMLCUDABackend));
+    CMLCUDABackend* backend = cml_calloc(1, sizeof(CMLCUDABackend));
     if (!backend) {
         LOG_ERROR("Failed to allocate CUDA backend");
         return NULL;
@@ -266,7 +267,7 @@ void cml_cuda_backend_free(CMLCUDABackend* backend) {
         unload_library(backend->cuda_lib);
     }
 
-    free(backend);
+    cml_free(backend);
 }
 
 int cml_cuda_get_device_count(CMLCUDABackend* backend) {
@@ -285,7 +286,7 @@ CMLCUDAKernel* cml_cuda_compile_ptx(CMLCUDABackend* backend, const char* ptx_cod
         return NULL;
     }
 
-    CMLCUDAKernel* kernel = calloc(1, sizeof(CMLCUDAKernel));
+    CMLCUDAKernel* kernel = cml_calloc(1, sizeof(CMLCUDAKernel));
     if (!kernel) {
         LOG_ERROR("Failed to allocate CUDA kernel");
         return NULL;
@@ -294,7 +295,7 @@ CMLCUDAKernel* cml_cuda_compile_ptx(CMLCUDABackend* backend, const char* ptx_cod
     CUresult err = backend->cuModuleLoadData(&kernel->module, ptx_code);
     if (err != CUDA_SUCCESS) {
         LOG_ERROR("cuModuleLoadData failed with error %d", err);
-        free(kernel);
+        cml_free(kernel);
         return NULL;
     }
 
@@ -302,11 +303,11 @@ CMLCUDAKernel* cml_cuda_compile_ptx(CMLCUDABackend* backend, const char* ptx_cod
     if (err != CUDA_SUCCESS) {
         LOG_ERROR("cuModuleGetFunction failed for '%s' with error %d", kernel_name, err);
         backend->cuModuleUnload(kernel->module);
-        free(kernel);
+        cml_free(kernel);
         return NULL;
     }
 
-    kernel->kernel_name = strdup(kernel_name);
+    kernel->kernel_name = cml_strdup(kernel_name);
 
     kernel->grid_dim[0]  = 1;
     kernel->grid_dim[1]  = 1;
@@ -352,10 +353,10 @@ CMLCUDAKernel* cml_cuda_compile_source(CMLCUDABackend* backend, const char* cuda
         size_t log_size = 0;
         backend->nvrtcGetProgramLogSize(prog, &log_size);
         if (log_size > 1) {
-            char* log = malloc(log_size);
+            char* log = cml_malloc(log_size);
             backend->nvrtcGetProgramLog(prog, log);
             LOG_ERROR("NVRTC compilation failed:\n%s", log);
-            free(log);
+            cml_free(log);
         }
         backend->nvrtcDestroyProgram(&prog);
         return NULL;
@@ -363,14 +364,14 @@ CMLCUDAKernel* cml_cuda_compile_source(CMLCUDABackend* backend, const char* cuda
 
     size_t ptx_size = 0;
     backend->nvrtcGetPTXSize(prog, &ptx_size);
-    char* ptx = malloc(ptx_size);
+    char* ptx = cml_malloc(ptx_size);
     backend->nvrtcGetPTX(prog, ptx);
     backend->nvrtcDestroyProgram(&prog);
 
     cml_process_replay_record(kernel_name, ptx, ptx_size);
 
     CMLCUDAKernel* kernel = cml_cuda_compile_ptx(backend, ptx, kernel_name);
-    free(ptx);
+    cml_free(ptx);
 
     return kernel;
 }
@@ -382,8 +383,8 @@ void cml_cuda_kernel_free(CMLCUDABackend* backend, CMLCUDAKernel* kernel) {
     if (kernel->module && backend->cuModuleUnload) {
         backend->cuModuleUnload(kernel->module);
     }
-    free(kernel->kernel_name);
-    free(kernel);
+    cml_free(kernel->kernel_name);
+    cml_free(kernel);
 }
 
 void cml_cuda_kernel_set_launch_config(CMLCUDAKernel* kernel, int grid_x, int grid_y, int grid_z,
@@ -497,7 +498,7 @@ int cml_cuda_download_tensor(CMLCUDABackend* backend, Tensor* tensor) {
     size_t size = tensor->numel * cml_dtype_size(tensor->dtype);
 
     if (!tensor->data) {
-        tensor->data = malloc(size);
+        tensor->data = cml_malloc(size);
         if (!tensor->data)
             return -1;
         tensor->owns_data = true;

--- a/src/ops/ir/gpu/cuda_graph_replay.c
+++ b/src/ops/ir/gpu/cuda_graph_replay.c
@@ -18,6 +18,7 @@ static int load_graph_symbols(CMLCUDAGraphBackend* gb) {
 #define GET_SYM(name) dlsym(lib, #name)
 #elif defined(_WIN32)
 #include <windows.h>
+#include "alloc/cml_allocator.h"
 #define GET_SYM(name) (void*)GetProcAddress((HMODULE)lib, #name)
 #else
 #define GET_SYM(name) NULL
@@ -46,7 +47,7 @@ static int load_graph_symbols(CMLCUDAGraphBackend* gb) {
 CMLCUDAGraphBackend* cml_cuda_graph_backend_create(CMLCUDABackend* backend) {
     if (!backend || !backend->initialized) return NULL;
 
-    CMLCUDAGraphBackend* gb = calloc(1, sizeof(CMLCUDAGraphBackend));
+    CMLCUDAGraphBackend* gb = cml_calloc(1, sizeof(CMLCUDAGraphBackend));
     if (!gb) return NULL;
 
     gb->backend = backend;
@@ -60,7 +61,7 @@ CMLCUDAGraphBackend* cml_cuda_graph_backend_create(CMLCUDABackend* backend) {
 
 void cml_cuda_graph_backend_free(CMLCUDAGraphBackend* gb) {
     if (!gb) return;
-    free(gb);
+    cml_free(gb);
 }
 
 int cml_cuda_graph_begin_capture(CMLCUDAGraphBackend* gb) {
@@ -170,5 +171,5 @@ void cml_cuda_graph_capture_free(void* ctx) {
     CUDAGraphCaptureCtx* c = ctx;
     if (!c) return;
     if (c->target) cml_cuda_graph_free(c->target);
-    free(c);
+    cml_free(c);
 }

--- a/src/ops/ir/gpu/gpu_codegen.c
+++ b/src/ops/ir/gpu/gpu_codegen.c
@@ -17,6 +17,7 @@
 #include <math.h>
 #include <float.h>
 #include <stdbool.h>
+#include "alloc/cml_allocator.h"
 
 static bool g_nvptx_initialized = false;
 static bool g_amdgpu_initialized = false;
@@ -42,7 +43,7 @@ static void init_amdgpu_target(void) {
 CMLGPUCodegen* cml_gpu_codegen_create(GPUTarget target, void* backend) {
     if (!backend) return NULL;
 
-    CMLGPUCodegen* cg = calloc(1, sizeof(CMLGPUCodegen));
+    CMLGPUCodegen* cg = cml_calloc(1, sizeof(CMLGPUCodegen));
     if (!cg) return NULL;
 
     cg->target = target;
@@ -70,7 +71,7 @@ CMLGPUCodegen* cml_gpu_codegen_create(GPUTarget target, void* backend) {
 }
 
 void cml_gpu_codegen_destroy(CMLGPUCodegen* cg) {
-    free(cg);
+    cml_free(cg);
 }
 
 // NVPTX calling convention for kernels
@@ -1213,7 +1214,7 @@ static char* emit_gpu_code(CMLGPUCodegen* cg, LLVMModuleRef mod, size_t* out_siz
     size_t size = LLVMGetBufferSize(buf);
     const char* data = LLVMGetBufferStart(buf);
 
-    char* result = malloc(size + 1);
+    char* result = cml_malloc(size + 1);
     memcpy(result, data, size);
     result[size] = '\0';  // null-terminate for PTX text
 
@@ -1271,7 +1272,7 @@ static void* gpu_upload(CMLGPUCodegen* cg, float* host_data, size_t numel) {
 
 static void* gpu_alloc_zero(CMLGPUCodegen* cg, size_t numel) {
     size_t size = numel * sizeof(float);
-    float* zeros = calloc(numel, sizeof(float));
+    float* zeros = cml_calloc(numel, sizeof(float));
     if (!zeros) return NULL;
 
     void* dptr = NULL;
@@ -1288,13 +1289,13 @@ static void* gpu_alloc_zero(CMLGPUCodegen* cg, size_t numel) {
             dptr = hptr;
         }
     }
-    free(zeros);
+    cml_free(zeros);
     return dptr;
 }
 
 static void* gpu_alloc_filled(CMLGPUCodegen* cg, size_t numel, float fill_val) {
     size_t size = numel * sizeof(float);
-    float* buf = malloc(size);
+    float* buf = cml_malloc(size);
     if (!buf) return NULL;
     for (size_t i = 0; i < numel; i++) buf[i] = fill_val;
 
@@ -1312,7 +1313,7 @@ static void* gpu_alloc_filled(CMLGPUCodegen* cg, size_t numel, float fill_val) {
             dptr = hptr;
         }
     }
-    free(buf);
+    cml_free(buf);
     return dptr;
 }
 
@@ -1384,7 +1385,7 @@ static int gpu_compile_and_launch(CMLGPUCodegen* cg, LLVMModuleRef mod,
         }
     }
 
-    free(code);
+    cml_free(code);
     return result;
 }
 

--- a/src/ops/ir/gpu/hexagon_backend.c
+++ b/src/ops/ir/gpu/hexagon_backend.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <dlfcn.h>
 #include <stdint.h>
+#include "alloc/cml_allocator.h"
 
 typedef int (*remote_handle_open_fn)(const char* name, uint32_t* handle);
 typedef int (*remote_handle_invoke_fn)(uint32_t handle, uint32_t method_id, void* args, int nargs);
@@ -39,7 +40,7 @@ bool cml_hexagon_available(void) {
 }
 
 CMLHexagonBackend* cml_hexagon_backend_create(void) {
-    CMLHexagonBackend* b = (CMLHexagonBackend*)calloc(1, sizeof(CMLHexagonBackend));
+    CMLHexagonBackend* b = (CMLHexagonBackend*)cml_calloc(1, sizeof(CMLHexagonBackend));
     if (!b) {
         LOG_ERROR("Failed to allocate CMLHexagonBackend");
     }
@@ -121,7 +122,7 @@ void cml_hexagon_backend_free(CMLHexagonBackend* backend) {
     }
 
     backend->initialized = false;
-    free(backend);
+    cml_free(backend);
 }
 
 int cml_hexagon_execute(CMLHexagonBackend* backend, CMLGraph_t ir) {

--- a/src/ops/ir/gpu/hexagon_sim.c
+++ b/src/ops/ir/gpu/hexagon_sim.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <inttypes.h>
+#include "alloc/cml_allocator.h"
 
 #define HVX_VECTOR_SIZE 128
 
@@ -93,12 +94,12 @@ static inline void mem_write32(CMLHexagonSim* sim, uint64_t addr, uint32_t val) 
 CMLHexagonSim* cml_hexagon_sim_create(size_t mem_size) {
     if (mem_size == 0) mem_size = 1024 * 1024;
 
-    CMLHexagonSim* sim = calloc(1, sizeof(CMLHexagonSim));
+    CMLHexagonSim* sim = cml_calloc(1, sizeof(CMLHexagonSim));
     if (!sim) return NULL;
 
-    sim->memory = calloc(1, mem_size);
+    sim->memory = cml_calloc(1, mem_size);
     if (!sim->memory) {
-        free(sim);
+        cml_free(sim);
         return NULL;
     }
 
@@ -110,8 +111,8 @@ CMLHexagonSim* cml_hexagon_sim_create(size_t mem_size) {
 
 void cml_hexagon_sim_free(CMLHexagonSim* sim) {
     if (!sim) return;
-    free(sim->memory);
-    free(sim);
+    cml_free(sim->memory);
+    cml_free(sim);
 }
 
 int cml_hexagon_sim_load(CMLHexagonSim* sim, const void* program, size_t size, uint64_t load_addr) {

--- a/src/ops/ir/gpu/nak_backend.c
+++ b/src/ops/ir/gpu/nak_backend.c
@@ -8,6 +8,7 @@
 #include <dlfcn.h>
 #else
 #include <windows.h>
+#include "alloc/cml_allocator.h"
 #define dlopen(path, flags) ((void*)LoadLibraryA(path))
 #define dlsym(handle, sym)  ((void*)GetProcAddress((HMODULE)(handle), (sym)))
 #define dlclose(handle)     FreeLibrary((HMODULE)(handle))
@@ -84,7 +85,7 @@ bool cml_nak_available(void) {
 }
 
 CMLNAKBackend* cml_nak_create(int gpu_arch) {
-    CMLNAKBackend* nak = calloc(1, sizeof(CMLNAKBackend));
+    CMLNAKBackend* nak = cml_calloc(1, sizeof(CMLNAKBackend));
     if (!nak) return NULL;
 
     nak->gpu_arch = gpu_arch;
@@ -111,7 +112,7 @@ void cml_nak_free(CMLNAKBackend* nak) {
     if (!nak) return;
     if (nak->nak_lib)
         dlclose(nak->nak_lib);
-    free(nak);
+    cml_free(nak);
 }
 
 int cml_nak_compile(CMLNAKBackend* nak, const void* nir_shader,
@@ -137,7 +138,7 @@ int cml_nak_compile(CMLNAKBackend* nak, const void* nir_shader,
         return -1;
     }
 
-    void* result = malloc(size);
+    void* result = cml_malloc(size);
     if (!result) {
         g_nak_fns.shader_free(compiled);
         return -1;

--- a/src/ops/ir/gpu/nv_driver.c
+++ b/src/ops/ir/gpu/nv_driver.c
@@ -24,6 +24,7 @@
 
 #ifdef CML_NV_MOCK_GPU
 #include "ops/ir/gpu/nv_mock.h"
+#include "alloc/cml_allocator.h"
 #define open(...)   cml_nv_mock_open(__VA_ARGS__)
 #define close(...)  cml_nv_mock_close(__VA_ARGS__)
 #define ioctl(...)  cml_nv_mock_ioctl(__VA_ARGS__)
@@ -314,7 +315,7 @@ static int nv_setup_vaspace(CMLNVDriver *drv) {
 }
 
 static CMLNVBuffer *nv_alloc_gpu_buffer(CMLNVDriver *drv, size_t size, bool host_visible) {
-    CMLNVBuffer *buf = (CMLNVBuffer *)calloc(1, sizeof(CMLNVBuffer));
+    CMLNVBuffer *buf = (CMLNVBuffer *)cml_calloc(1, sizeof(CMLNVBuffer));
     if (!buf) return NULL;
 
     size_t aligned = NV_ALIGN(size, 4096);
@@ -358,7 +359,7 @@ static CMLNVBuffer *nv_alloc_gpu_buffer(CMLNVDriver *drv, size_t size, bool host
     buf->gpu_va = nv_va_alloc(drv, aligned, 4096);
     if (buf->gpu_va == 0) {
         nv_rm_free(drv->fd_ctl, drv->client_handle, drv->device_handle, buf->handle);
-        free(buf);
+        cml_free(buf);
         return NULL;
     }
 
@@ -382,7 +383,7 @@ fallback_mmap:
     buf->handle = 0;
     buf->gpu_va = nv_va_alloc(drv, aligned, 4096);
     if (buf->gpu_va == 0) {
-        free(buf);
+        cml_free(buf);
         return NULL;
     }
     if (host_visible) {
@@ -390,7 +391,7 @@ fallback_mmap:
                              MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
         if (buf->cpu_addr == MAP_FAILED) {
             buf->cpu_addr = NULL;
-            free(buf);
+            cml_free(buf);
             return NULL;
         }
         memset(buf->cpu_addr, 0, aligned);
@@ -598,7 +599,7 @@ bool cml_nv_driver_available(void) {
 
 
 CMLNVDriver* cml_nv_driver_create(void) {
-    CMLNVDriver *drv = (CMLNVDriver *)calloc(1, sizeof(CMLNVDriver));
+    CMLNVDriver *drv = (CMLNVDriver *)cml_calloc(1, sizeof(CMLNVDriver));
     if (!drv) {
         LOG_ERROR("NV driver: failed to allocate context");
         return NULL;
@@ -758,7 +759,7 @@ void cml_nv_driver_free(CMLNVDriver *drv) {
     }
 #endif
 
-    free(drv);
+    cml_free(drv);
 }
 
 
@@ -802,7 +803,7 @@ void cml_nv_buffer_free(CMLNVDriver *drv, CMLNVBuffer *buf) {
     }
 #endif
 
-    free(buf);
+    cml_free(buf);
 }
 
 int cml_nv_buffer_upload(CMLNVDriver *drv, CMLNVBuffer *dst,
@@ -908,12 +909,12 @@ CMLNVKernel* cml_nv_kernel_compile_ptx(CMLNVDriver *drv, const char *ptx_code,
     if (drv && drv->compute_cap_major > 0)
         sm = drv->compute_cap_major * 10 + drv->compute_cap_minor;
 
-    CMLNVKernel *kernel = (CMLNVKernel *)calloc(1, sizeof(CMLNVKernel));
+    CMLNVKernel *kernel = (CMLNVKernel *)cml_calloc(1, sizeof(CMLNVKernel));
     if (!kernel) return NULL;
 
-    kernel->name = strdup(kernel_name);
+    kernel->name = cml_strdup(kernel_name);
     if (!kernel->name) {
-        free(kernel);
+        cml_free(kernel);
         return NULL;
     }
 
@@ -925,8 +926,8 @@ CMLNVKernel* cml_nv_kernel_compile_ptx(CMLNVDriver *drv, const char *ptx_code,
     FILE *ptx_file = fopen(ptx_path, "w");
     if (!ptx_file) {
         LOG_ERROR("NV driver: failed to write PTX temp file: %s", strerror(errno));
-        free(kernel->name);
-        free(kernel);
+        cml_free(kernel->name);
+        cml_free(kernel);
         return NULL;
     }
     fputs(ptx_code, ptx_file);
@@ -939,8 +940,8 @@ CMLNVKernel* cml_nv_kernel_compile_ptx(CMLNVDriver *drv, const char *ptx_code,
     if (!proc) {
         LOG_ERROR("NV driver: failed to run ptxas: %s", strerror(errno));
         unlink(ptx_path);
-        free(kernel->name);
-        free(kernel);
+        cml_free(kernel->name);
+        cml_free(kernel);
         return NULL;
     }
 
@@ -959,16 +960,16 @@ CMLNVKernel* cml_nv_kernel_compile_ptx(CMLNVDriver *drv, const char *ptx_code,
     if (status != 0) {
         LOG_ERROR("NV driver: ptxas failed (status %d): %s", status, output);
         unlink(cubin_path);
-        free(kernel->name);
-        free(kernel);
+        cml_free(kernel->name);
+        cml_free(kernel);
         return NULL;
     }
 
     FILE *cubin_file = fopen(cubin_path, "rb");
     if (!cubin_file) {
         LOG_ERROR("NV driver: failed to read CUBIN file %s", cubin_path);
-        free(kernel->name);
-        free(kernel);
+        cml_free(kernel->name);
+        cml_free(kernel);
         return NULL;
     }
 
@@ -979,17 +980,17 @@ CMLNVKernel* cml_nv_kernel_compile_ptx(CMLNVDriver *drv, const char *ptx_code,
     if (cubin_len <= 0) {
         fclose(cubin_file);
         unlink(cubin_path);
-        free(kernel->name);
-        free(kernel);
+        cml_free(kernel->name);
+        cml_free(kernel);
         return NULL;
     }
 
-    kernel->cubin_data = malloc((size_t)cubin_len);
+    kernel->cubin_data = cml_malloc((size_t)cubin_len);
     if (!kernel->cubin_data) {
         fclose(cubin_file);
         unlink(cubin_path);
-        free(kernel->name);
-        free(kernel);
+        cml_free(kernel->name);
+        cml_free(kernel);
         return NULL;
     }
 
@@ -997,9 +998,9 @@ CMLNVKernel* cml_nv_kernel_compile_ptx(CMLNVDriver *drv, const char *ptx_code,
     if (fread(kernel->cubin_data, 1, kernel->cubin_size, cubin_file) != kernel->cubin_size) {
         fclose(cubin_file);
         unlink(cubin_path);
-        free(kernel->cubin_data);
-        free(kernel->name);
-        free(kernel);
+        cml_free(kernel->cubin_data);
+        cml_free(kernel->name);
+        cml_free(kernel);
         return NULL;
     }
     fclose(cubin_file);
@@ -1041,19 +1042,19 @@ CMLNVKernel* cml_nv_kernel_load_cubin(CMLNVDriver *drv, const void *cubin, size_
                                         const char *kernel_name) {
     if (!cubin || size == 0 || !kernel_name) return NULL;
 
-    CMLNVKernel *kernel = (CMLNVKernel *)calloc(1, sizeof(CMLNVKernel));
+    CMLNVKernel *kernel = (CMLNVKernel *)cml_calloc(1, sizeof(CMLNVKernel));
     if (!kernel) return NULL;
 
-    kernel->name = strdup(kernel_name);
+    kernel->name = cml_strdup(kernel_name);
     if (!kernel->name) {
-        free(kernel);
+        cml_free(kernel);
         return NULL;
     }
 
-    kernel->cubin_data = malloc(size);
+    kernel->cubin_data = cml_malloc(size);
     if (!kernel->cubin_data) {
-        free(kernel->name);
-        free(kernel);
+        cml_free(kernel->name);
+        cml_free(kernel);
         return NULL;
     }
     memcpy(kernel->cubin_data, cubin, size);
@@ -1102,9 +1103,9 @@ void cml_nv_kernel_free(CMLNVDriver *drv, CMLNVKernel *kernel) {
     (void)drv;
 #endif
 
-    free(kernel->cubin_data);
-    free(kernel->name);
-    free(kernel);
+    cml_free(kernel->cubin_data);
+    cml_free(kernel->name);
+    cml_free(kernel);
 }
 
 
@@ -1238,7 +1239,7 @@ static char* nv_gen_ptx_for_node(struct IRNode *node, int sm) {
     case UOP_NEG: case UOP_EXP: case UOP_LOG: case UOP_SQRT:
     case UOP_ABS: case UOP_SIN: case UOP_COS: case UOP_TANH:
     case UOP_SIGMOID: case UOP_RECIP: case UOP_SILU: {
-        ptx = (char *)malloc(buf_size);
+        ptx = (char *)cml_malloc(buf_size);
         if (!ptx) return NULL;
         const char *op_ptx;
         switch (node->type) {
@@ -1285,7 +1286,7 @@ static char* nv_gen_ptx_for_node(struct IRNode *node, int sm) {
     }
 
     case UOP_ADD: case UOP_SUB: case UOP_MUL: case UOP_DIV: {
-        ptx = (char *)malloc(buf_size);
+        ptx = (char *)cml_malloc(buf_size);
         if (!ptx) return NULL;
         const char *op_ptx;
         switch (node->type) {
@@ -1411,7 +1412,7 @@ int cml_nv_execute_graph(CMLNVDriver *drv, CMLGraph_t ir) {
                         if (cml_nv_kernel_launch(drv, kernel, grid_dim, block_dim, kargs, 3) == 0) {
                             cml_nv_synchronize(drv);
                             if (!output->data)
-                                output->data = malloc(bytes);
+                                output->data = cml_malloc(bytes);
                             if (output->data) {
                                 cml_nv_buffer_download(drv, buf_out, output->data, bytes);
                                 gpu_ok = true;
@@ -1444,7 +1445,7 @@ int cml_nv_execute_graph(CMLNVDriver *drv, CMLGraph_t ir) {
                         if (cml_nv_kernel_launch(drv, kernel, grid_dim, block_dim, kargs, 4) == 0) {
                             cml_nv_synchronize(drv);
                             if (!output->data)
-                                output->data = malloc(bytes);
+                                output->data = cml_malloc(bytes);
                             if (output->data) {
                                 cml_nv_buffer_download(drv, buf_out, output->data, bytes);
                                 gpu_ok = true;
@@ -1459,7 +1460,7 @@ int cml_nv_execute_graph(CMLNVDriver *drv, CMLGraph_t ir) {
 
                 cml_nv_kernel_free(drv, kernel);
             }
-            free(ptx);
+            cml_free(ptx);
         }
 
         if (!gpu_ok) {

--- a/src/ops/ir/gpu/nv_mock.c
+++ b/src/ops/ir/gpu/nv_mock.c
@@ -11,6 +11,7 @@
 #include <unistd.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
+#include "alloc/cml_allocator.h"
 
 #define MOCK_FD_CTL  100
 #define MOCK_FD_DEV  101
@@ -71,7 +72,7 @@ static bool g_mock_active = false;
 static void mock_track_alloc(void *ptr) {
     if (g_mock.num_allocs >= g_mock.alloc_capacity) {
         int new_cap = g_mock.alloc_capacity * 2;
-        void **new_table = (void **)realloc(g_mock.alloc_table, (size_t)new_cap * sizeof(void *));
+        void **new_table = (void **)cml_realloc(g_mock.alloc_table, (size_t)new_cap * sizeof(void *));
         if (!new_table) return;
         g_mock.alloc_table = new_table;
         g_mock.alloc_capacity = new_cap;
@@ -114,7 +115,7 @@ void cml_nv_mock_init(CMLNVMockGPU *config) {
 
     g_mock.next_handle = 1;
     g_mock.alloc_capacity = MOCK_INITIAL_ALLOC_CAP;
-    g_mock.alloc_table = (void **)calloc((size_t)g_mock.alloc_capacity, sizeof(void *));
+    g_mock.alloc_table = (void **)cml_calloc((size_t)g_mock.alloc_capacity, sizeof(void *));
     g_mock.num_allocs = 0;
     g_mock.last_semaphore = NULL;
     g_mock.last_semaphore_value = 0;
@@ -126,9 +127,9 @@ void cml_nv_mock_shutdown(void) {
     if (!g_mock_active) return;
 
     for (int i = 0; i < g_mock.num_allocs; i++)
-        free(g_mock.alloc_table[i]);
+        cml_free(g_mock.alloc_table[i]);
 
-    free(g_mock.alloc_table);
+    cml_free(g_mock.alloc_table);
     memset(&g_mock, 0, sizeof(g_mock));
     g_mock_active = false;
 }
@@ -276,7 +277,7 @@ int cml_nv_mock_munmap(void *addr, size_t length) {
         return munmap(addr, length);
 
     if (mock_untrack_alloc(addr)) {
-        free(addr);
+        cml_free(addr);
         return 0;
     }
 

--- a/src/ops/ir/gpu/opencl_ir_backend.c
+++ b/src/ops/ir/gpu/opencl_ir_backend.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include "alloc/cml_allocator.h"
 
 #ifdef CML_HAS_OPENCL
 
@@ -381,7 +382,7 @@ static int ocl_download(CMLOpenCLIRBackend* b, Tensor* t) {
     size_t bytes = t->numel * cml_dtype_size(t->dtype);
 
     if (!t->data) {
-        t->data = malloc(bytes);
+        t->data = cml_malloc(bytes);
         if (!t->data) return -1;
         t->owns_data = true;
     }
@@ -416,7 +417,7 @@ static void ocl_release_all_buffers(CMLOpenCLIRBackend* b) {
 /* ─── BEAM autotuner for GEMM kernels ─────────────────────────────────── */
 
 /* Generate OpenCL source for a parameterized GEMM kernel.
- * Returns heap-allocated string. Caller must free(). */
+ * Returns heap-allocated string. Caller must cml_free(). */
 static char* ocl_beam_generate_gemm(const CMLGemmVariantParams* p, int id) {
     int wg_x = p->tsn / p->reg_n;
     int wg_y = p->tsm / p->reg_m;
@@ -429,7 +430,7 @@ static char* ocl_beam_generate_gemm(const CMLGemmVariantParams* p, int id) {
     int slm_h_a = p->transpose_a ? p->tsk : p->tsm;
     int slm_w_b = p->tsn + p->slm_pad;
 
-    char* buf = (char*)malloc(16384);
+    char* buf = (char*)cml_malloc(16384);
     if (!buf) return NULL;
     int off = 0;
 
@@ -567,7 +568,7 @@ static void ocl_beam_compile_variants(CMLOpenCLIRBackend* b) {
 
         cl_int err;
         cl_program prog = clCreateProgramWithSource(b->context, 1, (const char**)&src, NULL, &err);
-        free(src);
+        cml_free(src);
         if (err != CL_SUCCESS) continue;
 
         err = clBuildProgram(prog, 1, &b->device, "-cl-mad-enable -cl-fast-relaxed-math", NULL, NULL);
@@ -746,7 +747,7 @@ bool cml_opencl_ir_available(void) {
 }
 
 CMLOpenCLIRBackend* cml_opencl_ir_backend_create(void) {
-    CMLOpenCLIRBackend* b = (CMLOpenCLIRBackend*)calloc(1, sizeof(CMLOpenCLIRBackend));
+    CMLOpenCLIRBackend* b = (CMLOpenCLIRBackend*)cml_calloc(1, sizeof(CMLOpenCLIRBackend));
     return b;
 }
 
@@ -916,7 +917,7 @@ void cml_opencl_ir_backend_free(CMLOpenCLIRBackend* b) {
     if (b->queue)   clReleaseCommandQueue(b->queue);
     if (b->context) clReleaseContext(b->context);
 
-    free(b);
+    cml_free(b);
 }
 
 /* ─── Node execution helpers ───────────────────────────────────────────── */

--- a/src/ops/ir/gpu/ptx_codegen.c
+++ b/src/ops/ir/gpu/ptx_codegen.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 #define PTX_BUF_SIZE 8192
 #define CUDA_SRC_BUF_SIZE 16384
@@ -157,7 +158,7 @@ static bool ptx_is_reduction(UOpType t) {
 }
 
 CMLPTXCodegen* cml_ptx_codegen_create(int sm_version, struct CMLCUDABackend* cuda) {
-    CMLPTXCodegen* cg = (CMLPTXCodegen*)calloc(1, sizeof(CMLPTXCodegen));
+    CMLPTXCodegen* cg = (CMLPTXCodegen*)cml_calloc(1, sizeof(CMLPTXCodegen));
     if (!cg) return NULL;
     cg->sm_version = sm_version > 0 ? sm_version : 50;
     cg->kernel_count = 0;
@@ -167,13 +168,13 @@ CMLPTXCodegen* cml_ptx_codegen_create(int sm_version, struct CMLCUDABackend* cud
 }
 
 void cml_ptx_codegen_destroy(CMLPTXCodegen* cg) {
-    free(cg);
+    cml_free(cg);
 }
 
 char* cml_ptx_gen_unary(CMLPTXCodegen* cg, UOpType op, const char* kernel_name) {
     if (!cg || !kernel_name) return NULL;
 
-    char* ptx = (char*)malloc(PTX_BUF_SIZE);
+    char* ptx = (char*)cml_malloc(PTX_BUF_SIZE);
     if (!ptx) return NULL;
 
     int pos = 0;
@@ -316,7 +317,7 @@ char* cml_ptx_gen_unary(CMLPTXCodegen* cg, UOpType op, const char* kernel_name) 
             "    selp.f32 %%f1, %%f0, %%f1, %%p1;\n\n");    // x > 3 ? x : result
         break;
     default:
-        free(ptx);
+        cml_free(ptx);
         return NULL;
     }
 
@@ -328,7 +329,7 @@ char* cml_ptx_gen_unary(CMLPTXCodegen* cg, UOpType op, const char* kernel_name) 
 char* cml_ptx_gen_binary(CMLPTXCodegen* cg, UOpType op, const char* kernel_name) {
     if (!cg || !kernel_name) return NULL;
 
-    char* ptx = (char*)malloc(PTX_BUF_SIZE);
+    char* ptx = (char*)cml_malloc(PTX_BUF_SIZE);
     if (!ptx) return NULL;
 
     int pos = 0;
@@ -386,7 +387,7 @@ char* cml_ptx_gen_binary(CMLPTXCodegen* cg, UOpType op, const char* kernel_name)
             "    cvt.rmi.f32.f32 %%f2, %%f2;\n\n");      // floor(a / b)
         break;
     default:
-        free(ptx);
+        cml_free(ptx);
         return NULL;
     }
 
@@ -401,7 +402,7 @@ char* cml_ptx_gen_fill(CMLPTXCodegen* cg, float value, const char* kernel_name) 
     char hex[16];
     float_to_ptx_hex(value, hex, sizeof(hex));
 
-    char* ptx = (char*)malloc(PTX_BUF_SIZE);
+    char* ptx = (char*)cml_malloc(PTX_BUF_SIZE);
     if (!ptx) return NULL;
 
     int pos = 0;
@@ -441,7 +442,7 @@ char* cml_ptx_gen_fill(CMLPTXCodegen* cg, float value, const char* kernel_name) 
 char* cml_ptx_gen_where(CMLPTXCodegen* cg, const char* kernel_name) {
     if (!cg || !kernel_name) return NULL;
 
-    char* ptx = (char*)malloc(PTX_BUF_SIZE);
+    char* ptx = (char*)cml_malloc(PTX_BUF_SIZE);
     if (!ptx) return NULL;
 
     int pos = 0;
@@ -500,7 +501,7 @@ char* cml_ptx_gen_reduction(CMLPTXCodegen* cg, UOpType op, const char* kernel_na
         return NULL;
     }
 
-    char* ptx = (char*)malloc(PTX_BUF_SIZE);
+    char* ptx = (char*)cml_malloc(PTX_BUF_SIZE);
     if (!ptx) return NULL;
 
     int pos = 0;
@@ -611,7 +612,7 @@ char* cml_ptx_gen_reduction(CMLPTXCodegen* cg, UOpType op, const char* kernel_na
 char* cml_ptx_gen_matmul(CMLPTXCodegen* cg, const char* kernel_name) {
     if (!cg || !kernel_name) return NULL;
 
-    char* ptx = (char*)malloc(PTX_BUF_SIZE);
+    char* ptx = (char*)cml_malloc(PTX_BUF_SIZE);
     if (!ptx) return NULL;
 
     int pos = 0;
@@ -694,7 +695,7 @@ char* cml_ptx_gen_matmul(CMLPTXCodegen* cg, const char* kernel_name) {
 char* cml_ptx_gen_tiled_matmul(CMLPTXCodegen* cg, const char* kernel_name) {
     if (!cg || !kernel_name) return NULL;
 
-    char* src = (char*)malloc(CUDA_SRC_BUF_SIZE);
+    char* src = (char*)cml_malloc(CUDA_SRC_BUF_SIZE);
     if (!src) return NULL;
 
     // Generate CUDA C source for 16x16 tiled matmul using shared memory.
@@ -757,7 +758,7 @@ char* cml_ptx_gen_tiled_matmul(CMLPTXCodegen* cg, const char* kernel_name) {
 char* cml_ptx_gen_conv2d(CMLPTXCodegen* cg, const char* kernel_name) {
     if (!cg || !kernel_name) return NULL;
 
-    char* src = (char*)malloc(CUDA_SRC_BUF_SIZE);
+    char* src = (char*)cml_malloc(CUDA_SRC_BUF_SIZE);
     if (!src) return NULL;
 
     // Generate CUDA C source for direct conv2d kernel.
@@ -856,7 +857,7 @@ static int ptx_execute_node(CMLPTXCodegen* cg, struct IRNode* node) {
         if (!ptx_code) return -1;
 
         CMLCUDAKernel* kernel = cml_cuda_compile_ptx(cuda, ptx_code, fn_name);
-        free(ptx_code);
+        cml_free(ptx_code);
         if (!kernel) return -1;
 
         size_t in_bytes = node->inputs[0]->numel * sizeof(float);
@@ -894,7 +895,7 @@ static int ptx_execute_node(CMLPTXCodegen* cg, struct IRNode* node) {
         if (!ptx_code) return -1;
 
         CMLCUDAKernel* kernel = cml_cuda_compile_ptx(cuda, ptx_code, fn_name);
-        free(ptx_code);
+        cml_free(ptx_code);
         if (!kernel) return -1;
 
         size_t a_bytes = node->inputs[0]->numel * sizeof(float);
@@ -935,7 +936,7 @@ static int ptx_execute_node(CMLPTXCodegen* cg, struct IRNode* node) {
         if (!ptx_code) return -1;
 
         CMLCUDAKernel* kernel = cml_cuda_compile_ptx(cuda, ptx_code, fn_name);
-        free(ptx_code);
+        cml_free(ptx_code);
         if (!kernel) return -1;
 
         size_t in_bytes = node->inputs[0]->numel * sizeof(float);
@@ -987,7 +988,7 @@ static int ptx_execute_node(CMLPTXCodegen* cg, struct IRNode* node) {
         if (!ptx_code) return -1;
 
         CMLCUDAKernel* kernel = cml_cuda_compile_ptx(cuda, ptx_code, fn_name);
-        free(ptx_code);
+        cml_free(ptx_code);
         if (!kernel) return -1;
 
         size_t out_bytes = out->numel * sizeof(float);
@@ -1021,7 +1022,7 @@ static int ptx_execute_node(CMLPTXCodegen* cg, struct IRNode* node) {
         if (!ptx_code) return -1;
 
         CMLCUDAKernel* kernel = cml_cuda_compile_ptx(cuda, ptx_code, fn_name);
-        free(ptx_code);
+        cml_free(ptx_code);
         if (!kernel) return -1;
 
         size_t c_bytes = node->inputs[0]->numel * sizeof(float);
@@ -1070,7 +1071,7 @@ static int ptx_execute_node(CMLPTXCodegen* cg, struct IRNode* node) {
         if (!ptx_code) return -1;
 
         CMLCUDAKernel* kernel = cml_cuda_compile_ptx(cuda, ptx_code, fn_name);
-        free(ptx_code);
+        cml_free(ptx_code);
         if (!kernel) return -1;
 
         size_t a_bytes = a->numel * sizeof(float);

--- a/src/ops/ir/gpu/rdna3_emu.c
+++ b/src/ops/ir/gpu/rdna3_emu.c
@@ -2,6 +2,7 @@
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 /* ── RDNA3 encoding format constants ────────────────────────────────────── */
 
@@ -179,32 +180,32 @@ static uint64_t read_sgpr_pair(CMLRDNA3Wave* w, int idx) {
 /* ── Create / Free ─────────────────────────────────────────────────────── */
 
 CMLRDNA3Emu* cml_rdna3_emu_create(size_t mem_size) {
-    CMLRDNA3Emu* emu = calloc(1, sizeof(CMLRDNA3Emu));
+    CMLRDNA3Emu* emu = cml_calloc(1, sizeof(CMLRDNA3Emu));
     if (!emu) return NULL;
 
     if (mem_size == 0) mem_size = 64 * 1024 * 1024;
 
-    emu->memory = calloc(1, mem_size);
-    if (!emu->memory) { free(emu); return NULL; }
+    emu->memory = cml_calloc(1, mem_size);
+    if (!emu->memory) { cml_free(emu); return NULL; }
     emu->mem_size = mem_size;
 
-    emu->lds = calloc(1, RDNA3_LDS_SIZE);
-    if (!emu->lds) { free(emu->memory); free(emu); return NULL; }
+    emu->lds = cml_calloc(1, RDNA3_LDS_SIZE);
+    if (!emu->lds) { cml_free(emu->memory); cml_free(emu); return NULL; }
     emu->lds_size = RDNA3_LDS_SIZE;
 
     emu->wave_capacity = 64;
-    emu->waves = calloc(emu->wave_capacity, sizeof(CMLRDNA3Wave));
-    if (!emu->waves) { free(emu->lds); free(emu->memory); free(emu); return NULL; }
+    emu->waves = cml_calloc(emu->wave_capacity, sizeof(CMLRDNA3Wave));
+    if (!emu->waves) { cml_free(emu->lds); cml_free(emu->memory); cml_free(emu); return NULL; }
 
     return emu;
 }
 
 void cml_rdna3_emu_free(CMLRDNA3Emu* emu) {
     if (!emu) return;
-    free(emu->waves);
-    free(emu->lds);
-    free(emu->memory);
-    free(emu);
+    cml_free(emu->waves);
+    cml_free(emu->lds);
+    cml_free(emu->memory);
+    cml_free(emu);
 }
 
 int cml_rdna3_emu_load(CMLRDNA3Emu* emu, const void* binary, size_t size, uint64_t addr) {
@@ -241,7 +242,7 @@ int cml_rdna3_emu_dispatch(CMLRDNA3Emu* emu, uint32_t grid[3], uint32_t block[3]
 
     if ((int)total_waves > emu->wave_capacity) {
         int new_cap = (int)total_waves + 16;
-        CMLRDNA3Wave* tmp = realloc(emu->waves, new_cap * sizeof(CMLRDNA3Wave));
+        CMLRDNA3Wave* tmp = cml_realloc(emu->waves, new_cap * sizeof(CMLRDNA3Wave));
         if (!tmp) return -1;
         emu->waves = tmp;
         emu->wave_capacity = new_cap;

--- a/src/ops/ir/gpu/rocm_backend.c
+++ b/src/ops/ir/gpu/rocm_backend.c
@@ -8,6 +8,7 @@
 
 #ifdef __linux__
 #include <dlfcn.h>
+#include "alloc/cml_allocator.h"
 #define HIP_LIB_NAME "libamdhip64.so"
 #define HIPRTC_LIB_NAME "libhiprtc.so"
 #else
@@ -60,7 +61,7 @@ bool cml_rocm_available(void) {
 }
 
 CMLROCmBackend* cml_rocm_backend_create(void) {
-    CMLROCmBackend* backend = calloc(1, sizeof(CMLROCmBackend));
+    CMLROCmBackend* backend = cml_calloc(1, sizeof(CMLROCmBackend));
     if (!backend)
         LOG_ERROR("Failed to allocate ROCm backend");
     return backend;
@@ -146,7 +147,7 @@ void cml_rocm_backend_free(CMLROCmBackend* backend) {
 
     unload_library(backend->hiprtc_lib);
     unload_library(backend->hip_lib);
-    free(backend);
+    cml_free(backend);
 }
 
 CMLROCmKernel* cml_rocm_compile_hsaco(CMLROCmBackend* backend, const char* hsaco_code,
@@ -154,24 +155,24 @@ CMLROCmKernel* cml_rocm_compile_hsaco(CMLROCmBackend* backend, const char* hsaco
     if (!backend || !backend->initialized || !hsaco_code || !kernel_name)
         return NULL;
 
-    CMLROCmKernel* kernel = calloc(1, sizeof(CMLROCmKernel));
+    CMLROCmKernel* kernel = cml_calloc(1, sizeof(CMLROCmKernel));
     if (!kernel)
         return NULL;
 
     hipError_t err = backend->hipModuleLoadData(&kernel->module, hsaco_code);
     if (err != HIP_SUCCESS) {
-        free(kernel);
+        cml_free(kernel);
         return NULL;
     }
 
     err = backend->hipModuleGetFunction(&kernel->function, kernel->module, kernel_name);
     if (err != HIP_SUCCESS) {
         backend->hipModuleUnload(kernel->module);
-        free(kernel);
+        cml_free(kernel);
         return NULL;
     }
 
-    kernel->kernel_name = strdup(kernel_name);
+    kernel->kernel_name = cml_strdup(kernel_name);
     kernel->grid_dim[0] = kernel->grid_dim[1] = kernel->grid_dim[2] = 1;
     kernel->block_dim[0]                                            = 256;
     kernel->block_dim[1] = kernel->block_dim[2] = 1;
@@ -184,8 +185,8 @@ void cml_rocm_kernel_free(CMLROCmBackend* backend, CMLROCmKernel* kernel) {
         return;
     if (kernel->module)
         backend->hipModuleUnload(kernel->module);
-    free(kernel->kernel_name);
-    free(kernel);
+    cml_free(kernel->kernel_name);
+    cml_free(kernel);
 }
 
 int cml_rocm_launch_kernel(CMLROCmBackend* backend, CMLROCmKernel* kernel, void** args,
@@ -256,7 +257,7 @@ int cml_rocm_download_tensor(CMLROCmBackend* backend, Tensor* tensor) {
         return -1;
     size_t size = tensor->numel * cml_dtype_size(tensor->dtype);
     if (!tensor->data) {
-        tensor->data = malloc(size);
+        tensor->data = cml_malloc(size);
         if (!tensor->data)
             return -1;
         tensor->owns_data = true;

--- a/src/ops/ir/gpu/spirv_codegen.c
+++ b/src/ops/ir/gpu/spirv_codegen.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 
 #define SPIRV_MAGIC       0x07230203
@@ -130,11 +131,11 @@
 
 
 SPIRVBuilder* spirv_builder_create(void) {
-    SPIRVBuilder* b = (SPIRVBuilder*)calloc(1, sizeof(SPIRVBuilder));
+    SPIRVBuilder* b = (SPIRVBuilder*)cml_calloc(1, sizeof(SPIRVBuilder));
     if (!b) return NULL;
     b->cap = 4096;
-    b->words = (uint32_t*)malloc(b->cap * sizeof(uint32_t));
-    if (!b->words) { free(b); return NULL; }
+    b->words = (uint32_t*)cml_malloc(b->cap * sizeof(uint32_t));
+    if (!b->words) { cml_free(b); return NULL; }
     b->len = 0;
     b->next_id = 1;
     return b;
@@ -142,14 +143,14 @@ SPIRVBuilder* spirv_builder_create(void) {
 
 void spirv_builder_destroy(SPIRVBuilder* b) {
     if (!b) return;
-    free(b->words);
-    free(b);
+    cml_free(b->words);
+    cml_free(b);
 }
 
 void spirv_builder_emit(SPIRVBuilder* b, uint32_t word) {
     if (b->len >= b->cap) {
         b->cap *= 2;
-        b->words = (uint32_t*)realloc(b->words, b->cap * sizeof(uint32_t));
+        b->words = (uint32_t*)cml_realloc(b->words, b->cap * sizeof(uint32_t));
     }
     b->words[b->len++] = word;
 }
@@ -255,7 +256,7 @@ static uint32_t __attribute__((unused)) emit_uint_constant(SPIRVBuilder* b, uint
 }
 
 uint32_t* spirv_builder_finalize(SPIRVBuilder* b, size_t* out_size) {
-    uint32_t* result = (uint32_t*)malloc(b->len * sizeof(uint32_t));
+    uint32_t* result = (uint32_t*)cml_malloc(b->len * sizeof(uint32_t));
     if (!result) return NULL;
     memcpy(result, b->words, b->len * sizeof(uint32_t));
     *out_size = b->len * sizeof(uint32_t);
@@ -264,7 +265,7 @@ uint32_t* spirv_builder_finalize(SPIRVBuilder* b, size_t* out_size) {
 
 
 CMLSPIRVCodegen* cml_spirv_codegen_create(void) {
-    CMLSPIRVCodegen* cg = (CMLSPIRVCodegen*)calloc(1, sizeof(CMLSPIRVCodegen));
+    CMLSPIRVCodegen* cg = (CMLSPIRVCodegen*)cml_calloc(1, sizeof(CMLSPIRVCodegen));
     if (!cg) return NULL;
     cg->local_size_x = 256;
     cg->local_size_y = 1;
@@ -274,7 +275,7 @@ CMLSPIRVCodegen* cml_spirv_codegen_create(void) {
 }
 
 void cml_spirv_codegen_destroy(CMLSPIRVCodegen* cg) {
-    free(cg);
+    cml_free(cg);
 }
 
 /*

--- a/src/ops/ir/gpu/vulkan_backend.c
+++ b/src/ops/ir/gpu/vulkan_backend.c
@@ -15,6 +15,7 @@
 #define VULKAN_LIB_NAME "libvulkan.so.1"
 #elif defined(__APPLE__)
 #include <dlfcn.h>
+#include "alloc/cml_allocator.h"
 #define VULKAN_LIB_NAME "libvulkan.1.dylib"
 #else
 #define VULKAN_LIB_NAME NULL
@@ -425,7 +426,7 @@ bool cml_vulkan_available(void) {
 
 
 CMLVulkanBackend* cml_vulkan_backend_create(void) {
-    CMLVulkanBackend* backend = (CMLVulkanBackend*)calloc(1, sizeof(CMLVulkanBackend));
+    CMLVulkanBackend* backend = (CMLVulkanBackend*)cml_calloc(1, sizeof(CMLVulkanBackend));
     if (!backend) {
         LOG_ERROR("Failed to allocate Vulkan backend");
         return NULL;
@@ -491,10 +492,10 @@ int cml_vulkan_backend_init(CMLVulkanBackend* backend) {
         return -1;
     }
 
-    VkPhysicalDevice* devices = (VkPhysicalDevice*)calloc(dev_count, sizeof(VkPhysicalDevice));
+    VkPhysicalDevice* devices = (VkPhysicalDevice*)cml_calloc(dev_count, sizeof(VkPhysicalDevice));
     backend->vkEnumeratePhysicalDevices(backend->instance, &dev_count, devices);
     backend->physical_device = devices[0]; /* Use first device */
-    free(devices);
+    cml_free(devices);
 
     VkPhysicalDeviceProperties_t props = {0};
     backend->vkGetPhysicalDeviceProperties(backend->physical_device, &props);
@@ -519,7 +520,7 @@ int cml_vulkan_backend_init(CMLVulkanBackend* backend) {
     uint32_t qf_count = 0;
     backend->vkGetPhysicalDeviceQueueFamilyProperties(backend->physical_device, &qf_count, NULL);
     VkQueueFamilyProperties_t* qf_props =
-        (VkQueueFamilyProperties_t*)calloc(qf_count, sizeof(VkQueueFamilyProperties_t));
+        (VkQueueFamilyProperties_t*)cml_calloc(qf_count, sizeof(VkQueueFamilyProperties_t));
     backend->vkGetPhysicalDeviceQueueFamilyProperties(backend->physical_device, &qf_count,
                                                        qf_props);
 
@@ -530,7 +531,7 @@ int cml_vulkan_backend_init(CMLVulkanBackend* backend) {
             break;
         }
     }
-    free(qf_props);
+    cml_free(qf_props);
 
     if (backend->compute_queue_family == UINT32_MAX) {
         LOG_ERROR("No Vulkan compute queue family found");
@@ -606,7 +607,7 @@ void cml_vulkan_backend_free(CMLVulkanBackend* backend) {
     if (backend->vulkan_lib)
         vk_unload_library(backend->vulkan_lib);
 
-    free(backend);
+    cml_free(backend);
 }
 
 
@@ -614,7 +615,7 @@ CMLVulkanBuffer* cml_vulkan_buffer_create(CMLVulkanBackend* backend, VkDeviceSiz
                                            bool device_local) {
     if (!backend || !backend->initialized || size == 0) return NULL;
 
-    CMLVulkanBuffer* buf = (CMLVulkanBuffer*)calloc(1, sizeof(CMLVulkanBuffer));
+    CMLVulkanBuffer* buf = (CMLVulkanBuffer*)cml_calloc(1, sizeof(CMLVulkanBuffer));
     if (!buf) return NULL;
 
     buf->size = size;
@@ -630,7 +631,7 @@ CMLVulkanBuffer* cml_vulkan_buffer_create(CMLVulkanBackend* backend, VkDeviceSiz
 
     VkResult res = backend->vkCreateBuffer(backend->device, &buf_info, NULL, &buf->buffer);
     if (res != VK_SUCCESS) {
-        free(buf);
+        cml_free(buf);
         return NULL;
     }
 
@@ -646,7 +647,7 @@ CMLVulkanBuffer* cml_vulkan_buffer_create(CMLVulkanBackend* backend, VkDeviceSiz
     res = backend->vkAllocateMemory(backend->device, &alloc_info, NULL, &buf->memory);
     if (res != VK_SUCCESS) {
         backend->vkDestroyBuffer(backend->device, buf->buffer, NULL);
-        free(buf);
+        cml_free(buf);
         return NULL;
     }
 
@@ -654,7 +655,7 @@ CMLVulkanBuffer* cml_vulkan_buffer_create(CMLVulkanBackend* backend, VkDeviceSiz
     if (res != VK_SUCCESS) {
         backend->vkFreeMemory(backend->device, buf->memory, NULL);
         backend->vkDestroyBuffer(backend->device, buf->buffer, NULL);
-        free(buf);
+        cml_free(buf);
         return NULL;
     }
 
@@ -677,7 +678,7 @@ void cml_vulkan_buffer_free(CMLVulkanBackend* backend, CMLVulkanBuffer* buf) {
         backend->vkFreeMemory(backend->device, buf->memory, NULL);
     if (buf->buffer)
         backend->vkDestroyBuffer(backend->device, buf->buffer, NULL);
-    free(buf);
+    cml_free(buf);
 }
 
 int cml_vulkan_buffer_upload(CMLVulkanBackend* backend, CMLVulkanBuffer* dst,
@@ -779,10 +780,10 @@ CMLVulkanKernel* cml_vulkan_kernel_create(CMLVulkanBackend* backend, const uint3
     if (!backend || !backend->initialized || !spirv || spirv_size == 0) return NULL;
     if (num_buffers < 1 || num_buffers > VK_MAX_BUFFERS_PER_KERNEL) return NULL;
 
-    CMLVulkanKernel* kernel = (CMLVulkanKernel*)calloc(1, sizeof(CMLVulkanKernel));
+    CMLVulkanKernel* kernel = (CMLVulkanKernel*)cml_calloc(1, sizeof(CMLVulkanKernel));
     if (!kernel) return NULL;
     kernel->num_buffers = num_buffers;
-    kernel->name = strdup(entry_point ? entry_point : "main");
+    kernel->name = cml_strdup(entry_point ? entry_point : "main");
 
     VkShaderModuleCreateInfo_t sm_info = {0};
     sm_info.sType = 16;
@@ -794,7 +795,7 @@ CMLVulkanKernel* cml_vulkan_kernel_create(CMLVulkanBackend* backend, const uint3
     if (res != VK_SUCCESS) goto fail;
 
     VkDescriptorSetLayoutBinding_t* bindings =
-        (VkDescriptorSetLayoutBinding_t*)calloc(num_buffers,
+        (VkDescriptorSetLayoutBinding_t*)cml_calloc(num_buffers,
                                                   sizeof(VkDescriptorSetLayoutBinding_t));
     for (int i = 0; i < num_buffers; i++) {
         bindings[i].binding = (uint32_t)i;
@@ -810,7 +811,7 @@ CMLVulkanKernel* cml_vulkan_kernel_create(CMLVulkanBackend* backend, const uint3
 
     res = backend->vkCreateDescriptorSetLayout(backend->device, &dsl_info, NULL,
                                                  &kernel->desc_layout);
-    free(bindings);
+    cml_free(bindings);
     if (res != VK_SUCCESS) goto fail;
 
     VkPipelineLayoutCreateInfo_t pl_info = {0};
@@ -875,8 +876,8 @@ void cml_vulkan_kernel_free(CMLVulkanBackend* backend, CMLVulkanKernel* kernel) 
         backend->vkDestroyDescriptorSetLayout(backend->device, kernel->desc_layout, NULL);
     if (kernel->shader_module)
         backend->vkDestroyShaderModule(backend->device, kernel->shader_module, NULL);
-    free(kernel->name);
-    free(kernel);
+    cml_free(kernel->name);
+    cml_free(kernel);
 }
 
 int cml_vulkan_kernel_bind_buffer(CMLVulkanBackend* backend, CMLVulkanKernel* kernel,
@@ -970,7 +971,7 @@ int cml_vulkan_execute_graph(CMLVulkanBackend* backend, CMLGraph_t ir) {
     while (node && result == 0) {
         if (!node->output || !node->output->data) {
             if (node->output && node->output->numel > 0 && !node->output->data) {
-                node->output->data = calloc(node->output->numel, sizeof(float));
+                node->output->data = cml_calloc(node->output->numel, sizeof(float));
             }
         }
 
@@ -997,7 +998,7 @@ int cml_vulkan_execute_graph(CMLVulkanBackend* backend, CMLGraph_t ir) {
 
         CMLVulkanKernel* kernel = cml_vulkan_kernel_create(backend, spirv, spirv_size,
                                                              "main", num_bufs);
-        free(spirv);
+        cml_free(spirv);
         if (!kernel) {
             node = node->next;
             continue;

--- a/src/ops/ir/gpu/webgpu_backend.c
+++ b/src/ops/ir/gpu/webgpu_backend.c
@@ -15,6 +15,7 @@
 #define WGPU_LIB_NAME "libwgpu_native.dylib"
 #elif defined(_WIN32)
 #include <windows.h>
+#include "alloc/cml_allocator.h"
 #define WGPU_LIB_NAME "wgpu_native.dll"
 #endif
 
@@ -161,7 +162,7 @@ bool cml_webgpu_available(void) {
 
 
 CMLWebGPUBackend* cml_webgpu_backend_create(void) {
-    CMLWebGPUBackend* backend = (CMLWebGPUBackend*)calloc(1, sizeof(CMLWebGPUBackend));
+    CMLWebGPUBackend* backend = (CMLWebGPUBackend*)cml_calloc(1, sizeof(CMLWebGPUBackend));
     if (!backend) {
         LOG_ERROR("Failed to allocate WebGPU backend");
         return NULL;
@@ -169,13 +170,13 @@ CMLWebGPUBackend* cml_webgpu_backend_create(void) {
 
 #ifndef WGPU_LIB_NAME
     LOG_ERROR("WebGPU not supported on this platform");
-    free(backend);
+    cml_free(backend);
     return NULL;
 #else
     backend->lib_handle = wgpu_load_library(WGPU_LIB_NAME);
     if (!backend->lib_handle) {
         LOG_ERROR("Failed to load wgpu-native library: %s", WGPU_LIB_NAME);
-        free(backend);
+        cml_free(backend);
         return NULL;
     }
 
@@ -331,7 +332,7 @@ void cml_webgpu_backend_free(CMLWebGPUBackend* backend) {
         backend->lib_handle = NULL;
     }
 
-    free(backend);
+    cml_free(backend);
 }
 
 
@@ -441,7 +442,7 @@ CMLWebGPUKernel* cml_webgpu_compile_wgsl(CMLWebGPUBackend* backend,
         return NULL;
     }
 
-    CMLWebGPUKernel* kernel = (CMLWebGPUKernel*)calloc(1, sizeof(CMLWebGPUKernel));
+    CMLWebGPUKernel* kernel = (CMLWebGPUKernel*)cml_calloc(1, sizeof(CMLWebGPUKernel));
     if (!kernel) {
         LOG_ERROR("Failed to allocate CMLWebGPUKernel");
         return NULL;
@@ -464,7 +465,7 @@ void cml_webgpu_kernel_free(CMLWebGPUKernel* kernel) {
      * wgpu-native; dropping our handle is sufficient.  We do not call
      * explicit release here to avoid double-free in case the caller
      * still holds references through bind groups.  */
-    free(kernel);
+    cml_free(kernel);
 }
 
 
@@ -531,7 +532,7 @@ int cml_webgpu_launch_kernel(CMLWebGPUBackend* backend,
                 void* textureView;
             };
 
-            struct BindGroupEntry* entries = (struct BindGroupEntry*)calloc(
+            struct BindGroupEntry* entries = (struct BindGroupEntry*)cml_calloc(
                 (size_t)num_buffers, sizeof(struct BindGroupEntry));
 
             if (entries) {
@@ -559,7 +560,7 @@ int cml_webgpu_launch_kernel(CMLWebGPUBackend* backend,
                 bg_desc.entries = entries;
 
                 bind_group = createBG(backend->device, &bg_desc);
-                free(entries);
+                cml_free(entries);
             }
         }
     }

--- a/src/ops/ir/gpu/wgsl_codegen.c
+++ b/src/ops/ir/gpu/wgsl_codegen.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
+#include "alloc/cml_allocator.h"
 
 #define WGSL_BUF_INIT_SIZE 4096
 
@@ -23,7 +24,7 @@ static void wgsl_appendf(char** buf, size_t* cap, size_t* len,
 
     while (*len + (size_t)needed + 1 > *cap) {
         *cap *= 2;
-        char* tmp = (char*)realloc(*buf, *cap);
+        char* tmp = (char*)cml_realloc(*buf, *cap);
         if (!tmp) {
             LOG_ERROR("wgsl_codegen: realloc failed");
             return;
@@ -41,7 +42,7 @@ static void wgsl_appendf(char** buf, size_t* cap, size_t* len,
 static char* wgsl_buf_new(size_t* cap, size_t* len) {
     *cap = WGSL_BUF_INIT_SIZE;
     *len = 0;
-    char* buf = (char*)malloc(*cap);
+    char* buf = (char*)cml_malloc(*cap);
     if (buf) buf[0] = '\0';
     return buf;
 }
@@ -825,7 +826,7 @@ int cml_webgpu_execute_graph(CMLWebGPUBackend* backend, CMLGraph_t graph) {
 
         CMLWebGPUKernel* kernel =
             cml_webgpu_compile_wgsl(backend, wgsl_src, "main");
-        free(wgsl_src);
+        cml_free(wgsl_src);
         if (!kernel) {
             LOG_ERROR("webgpu_execute_graph: compile failed for UOp %d",
                       (int)node->type);
@@ -846,11 +847,11 @@ int cml_webgpu_execute_graph(CMLWebGPUBackend* backend, CMLGraph_t graph) {
             out_size *= sizeof(float);
         }
 
-        gpu_buffers  = (void**)calloc((size_t)total_buffers, sizeof(void*));
-        buffer_sizes = (size_t*)calloc((size_t)total_buffers, sizeof(size_t));
+        gpu_buffers  = (void**)cml_calloc((size_t)total_buffers, sizeof(void*));
+        buffer_sizes = (size_t*)cml_calloc((size_t)total_buffers, sizeof(size_t));
         if (!gpu_buffers || !buffer_sizes) {
-            free(gpu_buffers);
-            free(buffer_sizes);
+            cml_free(gpu_buffers);
+            cml_free(buffer_sizes);
             cml_webgpu_kernel_free(kernel);
             LOG_ERROR("webgpu_execute_graph: alloc failed");
             return -1;
@@ -898,8 +899,8 @@ int cml_webgpu_execute_graph(CMLWebGPUBackend* backend, CMLGraph_t graph) {
                 cml_webgpu_free(backend, gpu_buffers[i]);
             }
         }
-        free(gpu_buffers);
-        free(buffer_sizes);
+        cml_free(gpu_buffers);
+        cml_free(buffer_sizes);
         cml_webgpu_kernel_free(kernel);
 
         if (ok != 0) {

--- a/src/ops/ir/gpu/wmma.c
+++ b/src/ops/ir/gpu/wmma.c
@@ -9,6 +9,7 @@
 
 #include "ops/ir/gpu/cuda_backend.h"
 #include "ops/ir/dispatch.h"
+#include "alloc/cml_allocator.h"
 
 static CMLCUDABackend* wmma_get_cuda_backend(void) {
     CMLDispatchContext* ctx = cml_dispatch_get_global();
@@ -94,7 +95,7 @@ static void src_appendf(char** buf, size_t* cap, size_t* len,
 
     while (*len + (size_t)needed + 1 > *cap) {
         *cap *= 2;
-        char* tmp = (char*)realloc(*buf, *cap);
+        char* tmp = (char*)cml_realloc(*buf, *cap);
         if (!tmp) {
             LOG_ERROR("wmma: realloc failed");
             return;
@@ -114,7 +115,7 @@ char* cml_wmma_generate_kernel(const WMMAConfig* config, int M, int N, int K) {
 
     size_t cap = WMMA_SRC_MAX;
     size_t len = 0;
-    char* src = (char*)malloc(cap);
+    char* src = (char*)cml_malloc(cap);
     if (!src) return NULL;
     src[0] = '\0';
 
@@ -228,7 +229,7 @@ int cml_wmma_matmul(const void* A, const void* B, void* C,
     }
 
     CMLCUDAKernel* kernel = cml_cuda_compile_source(cuda, kernel_src, "wmma_matmul");
-    free(kernel_src);
+    cml_free(kernel_src);
 
     if (!kernel) {
         LOG_ERROR("WMMA kernel compilation failed");

--- a/src/ops/ir/graph_cache.c
+++ b/src/ops/ir/graph_cache.c
@@ -225,7 +225,7 @@ CMLExecutionPlan* cml_create_execution_plan(CMLGraph_t ir) {
             plan->output_tensors[idx] = node->output;
             size_t nbytes             = (size_t)node->output->numel * sizeof(float);
             plan->buffers[idx] =
-                aligned_alloc(32, cml_alloc_size_aligned(nbytes, 32));
+                cml_aligned_alloc(cml_alloc_size_aligned(nbytes, 32), 32);
             if (!plan->buffers[idx]) {
                 cml_free_execution_plan(plan);
                 return NULL;
@@ -256,7 +256,7 @@ static void free_execution_plan_impl(CMLExecutionPlan* plan, bool detach_tensor_
                         t->is_executed = false;
                     }
                 }
-                cml_free(plan->buffers[i]);
+                cml_aligned_free(plan->buffers[i]);
             }
         }
         cml_free(plan->buffers);

--- a/src/ops/ir/graph_cache.c
+++ b/src/ops/ir/graph_cache.c
@@ -12,6 +12,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <stdio.h>
+#include "alloc/cml_allocator.h"
 
 #define CACHE_NUM_BUCKETS 64
 #define FNV_OFFSET 0xcbf29ce484222325ULL
@@ -57,14 +58,14 @@ uint64_t cml_graph_compute_signature(CMLGraph_t ir) {
 }
 
 CMLGraphCache* cml_graph_cache_create(size_t max_entries) {
-    CMLGraphCache* cache = calloc(1, sizeof(CMLGraphCache));
+    CMLGraphCache* cache = cml_calloc(1, sizeof(CMLGraphCache));
     if (!cache)
         return NULL;
 
     cache->num_buckets = CACHE_NUM_BUCKETS;
-    cache->buckets     = calloc(cache->num_buckets, sizeof(CMLGraphCacheEntry*));
+    cache->buckets     = cml_calloc(cache->num_buckets, sizeof(CMLGraphCacheEntry*));
     if (!cache->buckets) {
-        free(cache);
+        cml_free(cache);
         return NULL;
     }
 
@@ -88,13 +89,13 @@ void cml_graph_cache_destroy(CMLGraphCache* cache) {
         while (entry) {
             CMLGraphCacheEntry* next = entry->next;
             free_execution_plan_impl(entry->plan, false);
-            free(entry);
+            cml_free(entry);
             entry = next;
         }
     }
 
-    free(cache->buckets);
-    free(cache);
+    cml_free(cache->buckets);
+    cml_free(cache);
 }
 
 CMLExecutionPlan* cml_graph_cache_lookup(CMLGraphCache* cache, uint64_t signature) {
@@ -148,7 +149,7 @@ static void evict_lru_entry(CMLGraphCache* cache) {
             cache->buckets[oldest_bucket] = oldest_entry->next;
         }
         free_execution_plan_impl(oldest_entry->plan, true);
-        free(oldest_entry);
+        cml_free(oldest_entry);
         cache->count--;
         cml_cpu_execute_cache_reset();
     }
@@ -164,7 +165,7 @@ int cml_graph_cache_insert(CMLGraphCache* cache, uint64_t signature, CMLExecutio
 
     size_t bucket = signature % cache->num_buckets;
 
-    CMLGraphCacheEntry* entry = calloc(1, sizeof(CMLGraphCacheEntry));
+    CMLGraphCacheEntry* entry = cml_calloc(1, sizeof(CMLGraphCacheEntry));
     if (!entry)
         return -1;
 
@@ -192,20 +193,20 @@ CMLExecutionPlan* cml_create_execution_plan(CMLGraph_t ir) {
     if (!ir)
         return NULL;
 
-    CMLExecutionPlan* plan = calloc(1, sizeof(CMLExecutionPlan));
+    CMLExecutionPlan* plan = cml_calloc(1, sizeof(CMLExecutionPlan));
     if (!plan)
         return NULL;
 
     plan->num_nodes = count_nodes(ir);
     if (plan->num_nodes == 0) {
-        free(plan);
+        cml_free(plan);
         return NULL;
     }
 
-    plan->nodes           = calloc(plan->num_nodes, sizeof(struct IRNode*));
-    plan->buffers         = calloc(plan->num_nodes, sizeof(float*));
-    plan->buffer_sizes    = calloc(plan->num_nodes, sizeof(size_t));
-    plan->output_tensors  = calloc(plan->num_nodes, sizeof(Tensor*));
+    plan->nodes           = cml_calloc(plan->num_nodes, sizeof(struct IRNode*));
+    plan->buffers         = cml_calloc(plan->num_nodes, sizeof(float*));
+    plan->buffer_sizes    = cml_calloc(plan->num_nodes, sizeof(size_t));
+    plan->output_tensors  = cml_calloc(plan->num_nodes, sizeof(Tensor*));
 
     if (!plan->nodes || !plan->buffers || !plan->buffer_sizes || !plan->output_tensors) {
         cml_free_execution_plan(plan);
@@ -255,16 +256,16 @@ static void free_execution_plan_impl(CMLExecutionPlan* plan, bool detach_tensor_
                         t->is_executed = false;
                     }
                 }
-                free(plan->buffers[i]);
+                cml_free(plan->buffers[i]);
             }
         }
-        free(plan->buffers);
+        cml_free(plan->buffers);
     }
 
-    free(plan->output_tensors);
-    free(plan->nodes);
-    free(plan->buffer_sizes);
-    free(plan);
+    cml_free(plan->output_tensors);
+    cml_free(plan->nodes);
+    cml_free(plan->buffer_sizes);
+    cml_free(plan);
 }
 
 void cml_free_execution_plan(CMLExecutionPlan* plan) {
@@ -653,7 +654,7 @@ void cml_graph_cache_reset_global(void) {
         while (entry) {
             CMLGraphCacheEntry* next = entry->next;
             free_execution_plan_impl(entry->plan, false);
-            free(entry);
+            cml_free(entry);
             entry = next;
         }
         g_graph_cache->buckets[i] = NULL;

--- a/src/ops/ir/graph_capture.c
+++ b/src/ops/ir/graph_capture.c
@@ -8,6 +8,7 @@
 
 #ifdef _POSIX_C_SOURCE
 #include <time.h>
+#include "alloc/cml_allocator.h"
 static double get_time_ms(void) {
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
@@ -18,12 +19,12 @@ static double get_time_ms(void) { return 0.0; }
 #endif
 
 CMLCapturedGraph* cml_graph_capture_create(void) {
-    CMLCapturedGraph* g = (CMLCapturedGraph*)calloc(1, sizeof(CMLCapturedGraph));
+    CMLCapturedGraph* g = (CMLCapturedGraph*)cml_calloc(1, sizeof(CMLCapturedGraph));
     if (!g) return NULL;
 
     g->node_capacity = 32;
-    g->nodes = (CMLCapturedNode*)calloc((size_t)g->node_capacity, sizeof(CMLCapturedNode));
-    if (!g->nodes) { free(g); return NULL; }
+    g->nodes = (CMLCapturedNode*)cml_calloc((size_t)g->node_capacity, sizeof(CMLCapturedNode));
+    if (!g->nodes) { cml_free(g); return NULL; }
 
     g->state = CML_CAPTURE_IDLE;
     return g;
@@ -33,12 +34,12 @@ void cml_graph_capture_free(CMLCapturedGraph* graph) {
     if (!graph) return;
 
     for (int i = 0; i < graph->num_nodes; i++) {
-        free(graph->nodes[i].kernel_args);
+        cml_free(graph->nodes[i].kernel_args);
     }
-    free(graph->nodes);
-    free(graph->input_bindings);
-    free(graph->output_bindings);
-    free(graph);
+    cml_free(graph->nodes);
+    cml_free(graph->input_bindings);
+    cml_free(graph->output_bindings);
+    cml_free(graph);
 }
 
 int cml_graph_capture_begin(CMLCapturedGraph* graph) {
@@ -46,7 +47,7 @@ int cml_graph_capture_begin(CMLCapturedGraph* graph) {
     if (graph->state == CML_CAPTURE_RECORDING) return -1;
 
     for (int i = 0; i < graph->num_nodes; i++) {
-        free(graph->nodes[i].kernel_args);
+        cml_free(graph->nodes[i].kernel_args);
     }
     graph->num_nodes = 0;
     graph->state = CML_CAPTURE_RECORDING;
@@ -68,7 +69,7 @@ int cml_graph_capture_record(CMLCapturedGraph* graph, UOpType op,
             graph->state = CML_CAPTURE_ERROR;
             return -1;
         }
-        CMLCapturedNode* new_nodes = (CMLCapturedNode*)realloc(
+        CMLCapturedNode* new_nodes = (CMLCapturedNode*)cml_realloc(
             graph->nodes, (size_t)new_cap * sizeof(CMLCapturedNode));
         if (!new_nodes) { graph->state = CML_CAPTURE_ERROR; return -1; }
         graph->nodes = new_nodes;
@@ -85,7 +86,7 @@ int cml_graph_capture_record(CMLCapturedGraph* graph, UOpType op,
     node->num_args = num_args;
 
     if (num_args > 0 && args) {
-        node->kernel_args = (void**)malloc((size_t)num_args * sizeof(void*));
+        node->kernel_args = (void**)cml_malloc((size_t)num_args * sizeof(void*));
         if (!node->kernel_args) { graph->state = CML_CAPTURE_ERROR; return -1; }
         memcpy(node->kernel_args, args, (size_t)num_args * sizeof(void*));
     }
@@ -135,7 +136,7 @@ int cml_graph_capture_bind_input(CMLCapturedGraph* graph, int index, Tensor* ten
 
     if (index >= graph->num_input_bindings) {
         int new_count = index + 1;
-        Tensor** new_bindings = (Tensor**)realloc(
+        Tensor** new_bindings = (Tensor**)cml_realloc(
             graph->input_bindings, (size_t)new_count * sizeof(Tensor*));
         if (!new_bindings) return -1;
         for (int i = graph->num_input_bindings; i < new_count; i++)
@@ -152,7 +153,7 @@ int cml_graph_capture_bind_output(CMLCapturedGraph* graph, int index, Tensor* te
 
     if (index >= graph->num_output_bindings) {
         int new_count = index + 1;
-        Tensor** new_bindings = (Tensor**)realloc(
+        Tensor** new_bindings = (Tensor**)cml_realloc(
             graph->output_bindings, (size_t)new_count * sizeof(Tensor*));
         if (!new_bindings) return -1;
         for (int i = graph->num_output_bindings; i < new_count; i++)
@@ -168,7 +169,7 @@ int cml_graph_capture_reset(CMLCapturedGraph* graph) {
     if (!graph) return -1;
 
     for (int i = 0; i < graph->num_nodes; i++)
-        free(graph->nodes[i].kernel_args);
+        cml_free(graph->nodes[i].kernel_args);
     graph->num_nodes = 0;
     graph->state = CML_CAPTURE_IDLE;
     graph->replay_count = 0;

--- a/src/ops/ir/hcq.c
+++ b/src/ops/ir/hcq.c
@@ -3,6 +3,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 #ifdef CML_HAS_CUDA
 extern CMLHCQQueue*  cml_hcq_cuda_queue_create(void);
@@ -113,19 +114,19 @@ CMLHCQQueue* cml_hcq_queue_create(CMLHCQBackendType backend) {
         return cml_hcq_opencl_queue_create();
 #endif
     case CML_HCQ_VULKAN: {
-        CMLHCQQueue* vq = calloc(1, sizeof(CMLHCQQueue));
+        CMLHCQQueue* vq = cml_calloc(1, sizeof(CMLHCQQueue));
         if (!vq) return NULL;
         vq->backend = CML_HCQ_VULKAN;
-        if (cml_hcq_vulkan_queue_init(vq) != 0) { free(vq); return NULL; }
+        if (cml_hcq_vulkan_queue_init(vq) != 0) { cml_free(vq); return NULL; }
         return vq;
     }
     case CML_HCQ_NV:
         return cml_hcq_nv_queue_create();
     case CML_HCQ_AM: {
-        CMLHCQQueue* aq = calloc(1, sizeof(CMLHCQQueue));
+        CMLHCQQueue* aq = cml_calloc(1, sizeof(CMLHCQQueue));
         if (!aq) return NULL;
         aq->backend = CML_HCQ_AM;
-        if (cml_hcq_am_queue_init(aq) != 0) { free(aq); return NULL; }
+        if (cml_hcq_am_queue_init(aq) != 0) { cml_free(aq); return NULL; }
         return aq;
     }
     case CML_HCQ_CPU:
@@ -136,7 +137,7 @@ CMLHCQQueue* cml_hcq_queue_create(CMLHCQBackendType backend) {
     }
 
     /* CPU fallback */
-    CMLHCQQueue* queue = (CMLHCQQueue*)calloc(1, sizeof(CMLHCQQueue));
+    CMLHCQQueue* queue = (CMLHCQQueue*)cml_calloc(1, sizeof(CMLHCQQueue));
     if (!queue) {
         LOG_ERROR("Failed to allocate CMLHCQQueue");
         return NULL;
@@ -164,20 +165,20 @@ void cml_hcq_queue_destroy(CMLHCQQueue* queue) {
 #endif
     case CML_HCQ_VULKAN:
         cml_hcq_vulkan_queue_destroy(queue);
-        free(queue);
+        cml_free(queue);
         return;
     case CML_HCQ_NV:
         cml_hcq_nv_queue_destroy(queue);
         return;
     case CML_HCQ_AM:
         cml_hcq_am_queue_destroy(queue);
-        free(queue);
+        cml_free(queue);
         return;
     default:
         break;
     }
     queue->active = false;
-    free(queue);
+    cml_free(queue);
 }
 
 int cml_hcq_submit_kernel(CMLHCQQueue* queue, const CMLHCQKernelDesc* desc) {
@@ -305,19 +306,19 @@ CMLHCQSignal* cml_hcq_signal_create(CMLHCQBackendType backend) {
         return cml_hcq_opencl_signal_create();
 #endif
     case CML_HCQ_VULKAN: {
-        CMLHCQSignal* vs = calloc(1, sizeof(CMLHCQSignal));
+        CMLHCQSignal* vs = cml_calloc(1, sizeof(CMLHCQSignal));
         if (!vs) return NULL;
         vs->backend = CML_HCQ_VULKAN;
-        if (cml_hcq_vulkan_signal_create(vs) != 0) { free(vs); return NULL; }
+        if (cml_hcq_vulkan_signal_create(vs) != 0) { cml_free(vs); return NULL; }
         return vs;
     }
     case CML_HCQ_NV:
         return cml_hcq_nv_signal_create();
     case CML_HCQ_AM: {
-        CMLHCQSignal* as = calloc(1, sizeof(CMLHCQSignal));
+        CMLHCQSignal* as = cml_calloc(1, sizeof(CMLHCQSignal));
         if (!as) return NULL;
         as->backend = CML_HCQ_AM;
-        if (cml_hcq_am_signal_create(as) != 0) { free(as); return NULL; }
+        if (cml_hcq_am_signal_create(as) != 0) { cml_free(as); return NULL; }
         return as;
     }
     case CML_HCQ_CPU:
@@ -327,7 +328,7 @@ CMLHCQSignal* cml_hcq_signal_create(CMLHCQBackendType backend) {
         return NULL;
     }
 
-    CMLHCQSignal* signal = (CMLHCQSignal*)calloc(1, sizeof(CMLHCQSignal));
+    CMLHCQSignal* signal = (CMLHCQSignal*)cml_calloc(1, sizeof(CMLHCQSignal));
     if (!signal) {
         LOG_ERROR("Failed to allocate CMLHCQSignal");
         return NULL;
@@ -355,19 +356,19 @@ void cml_hcq_signal_destroy(CMLHCQSignal* signal) {
 #endif
     case CML_HCQ_VULKAN:
         cml_hcq_vulkan_signal_destroy(signal);
-        free(signal);
+        cml_free(signal);
         return;
     case CML_HCQ_NV:
         cml_hcq_nv_signal_destroy(signal);
         return;
     case CML_HCQ_AM:
         cml_hcq_am_signal_destroy(signal);
-        free(signal);
+        cml_free(signal);
         return;
     default:
         break;
     }
-    free(signal);
+    cml_free(signal);
 }
 
 int cml_hcq_signal_record(CMLHCQQueue* queue, CMLHCQSignal* signal) {
@@ -525,7 +526,7 @@ int cml_hcq_queue_synchronize(CMLHCQQueue* queue) {
 
 CMLHCQPipeline* cml_hcq_pipeline_create(void) {
     CMLHCQPipeline* pipeline =
-        (CMLHCQPipeline*)calloc(1, sizeof(CMLHCQPipeline));
+        (CMLHCQPipeline*)cml_calloc(1, sizeof(CMLHCQPipeline));
     if (!pipeline) {
         LOG_ERROR("Failed to allocate CMLHCQPipeline");
         return NULL;
@@ -547,7 +548,7 @@ void cml_hcq_pipeline_destroy(CMLHCQPipeline* pipeline) {
     }
 
     LOG_DEBUG("Destroying HCQ pipeline %p", (void*)pipeline);
-    free(pipeline);
+    cml_free(pipeline);
 }
 
 int cml_hcq_pipeline_add_stage(CMLHCQPipeline* pipeline, CMLHCQQueue* queue) {

--- a/src/ops/ir/hcq_cuda.c
+++ b/src/ops/ir/hcq_cuda.c
@@ -7,6 +7,7 @@
 
 #include <stdlib.h>
 #include <stdint.h>
+#include "alloc/cml_allocator.h"
 
 CMLHCQQueue* cml_hcq_cuda_queue_create(void) {
     CMLCUDABackend* cuda = cml_dispatch_get_cuda_backend();
@@ -15,7 +16,7 @@ CMLHCQQueue* cml_hcq_cuda_queue_create(void) {
         return NULL;
     }
 
-    CMLHCQQueue* queue = (CMLHCQQueue*)calloc(1, sizeof(CMLHCQQueue));
+    CMLHCQQueue* queue = (CMLHCQQueue*)cml_calloc(1, sizeof(CMLHCQQueue));
     if (!queue) {
         LOG_ERROR("CUDA HCQ: failed to allocate queue");
         return NULL;
@@ -27,7 +28,7 @@ CMLHCQQueue* cml_hcq_cuda_queue_create(void) {
     CUresult err = cuda->cuStreamCreate(&stream, 0);
     if (err != 0) {
         LOG_ERROR("CUDA HCQ: cuStreamCreate failed (CUresult=%d)", err);
-        free(queue);
+        cml_free(queue);
         return NULL;
     }
 
@@ -47,7 +48,7 @@ void cml_hcq_cuda_queue_destroy(CMLHCQQueue* queue) {
         }
     }
 
-    free(queue);
+    cml_free(queue);
 }
 
 int cml_hcq_cuda_submit_kernel(CMLHCQQueue* queue,
@@ -139,7 +140,7 @@ CMLHCQSignal* cml_hcq_cuda_signal_create(void) {
         return NULL;
     }
 
-    CMLHCQSignal* signal = (CMLHCQSignal*)calloc(1, sizeof(CMLHCQSignal));
+    CMLHCQSignal* signal = (CMLHCQSignal*)cml_calloc(1, sizeof(CMLHCQSignal));
     if (!signal) {
         LOG_ERROR("CUDA HCQ: failed to allocate signal");
         return NULL;
@@ -151,7 +152,7 @@ CMLHCQSignal* cml_hcq_cuda_signal_create(void) {
     CUresult err = cuda->cuEventCreate(&event, 0);
     if (err != 0) {
         LOG_ERROR("CUDA HCQ: cuEventCreate failed (CUresult=%d)", err);
-        free(signal);
+        cml_free(signal);
         return NULL;
     }
 
@@ -171,7 +172,7 @@ void cml_hcq_cuda_signal_destroy(CMLHCQSignal* signal) {
         }
     }
 
-    free(signal);
+    cml_free(signal);
 }
 
 int cml_hcq_cuda_signal_record(CMLHCQQueue* queue, CMLHCQSignal* signal) {

--- a/src/ops/ir/hcq_nv.c
+++ b/src/ops/ir/hcq_nv.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include "alloc/cml_allocator.h"
 
 extern CMLNVDriver* cml_dispatch_get_nv_driver(void);
 
@@ -27,12 +28,12 @@ CMLHCQQueue* cml_hcq_nv_queue_create(void) {
         return NULL;
     }
 
-    CMLHCQQueue *queue = (CMLHCQQueue *)calloc(1, sizeof(CMLHCQQueue));
+    CMLHCQQueue *queue = (CMLHCQQueue *)cml_calloc(1, sizeof(CMLHCQQueue));
     if (!queue) return NULL;
 
-    NVQueueData *qd = (NVQueueData *)calloc(1, sizeof(NVQueueData));
+    NVQueueData *qd = (NVQueueData *)cml_calloc(1, sizeof(NVQueueData));
     if (!qd) {
-        free(queue);
+        cml_free(queue);
         return NULL;
     }
 
@@ -44,10 +45,10 @@ CMLHCQQueue* cml_hcq_nv_queue_create(void) {
 
 void cml_hcq_nv_queue_destroy(CMLHCQQueue *queue) {
     if (!queue) return;
-    free(queue->native_handle);
+    cml_free(queue->native_handle);
     queue->native_handle = NULL;
     queue->active = false;
-    free(queue);
+    cml_free(queue);
 }
 
 int cml_hcq_nv_submit_kernel(CMLHCQQueue *queue,
@@ -115,12 +116,12 @@ CMLHCQSignal* cml_hcq_nv_signal_create(void) {
     CMLNVDriver *nv = cml_dispatch_get_nv_driver();
     if (!nv || !nv->initialized) return NULL;
 
-    CMLHCQSignal *signal = (CMLHCQSignal *)calloc(1, sizeof(CMLHCQSignal));
+    CMLHCQSignal *signal = (CMLHCQSignal *)cml_calloc(1, sizeof(CMLHCQSignal));
     if (!signal) return NULL;
 
-    NVSignalData *sd = (NVSignalData *)calloc(1, sizeof(NVSignalData));
+    NVSignalData *sd = (NVSignalData *)cml_calloc(1, sizeof(NVSignalData));
     if (!sd) {
-        free(signal);
+        cml_free(signal);
         return NULL;
     }
 
@@ -134,9 +135,9 @@ CMLHCQSignal* cml_hcq_nv_signal_create(void) {
 
 void cml_hcq_nv_signal_destroy(CMLHCQSignal *signal) {
     if (!signal) return;
-    free(signal->native_handle);
+    cml_free(signal->native_handle);
     signal->native_handle = NULL;
-    free(signal);
+    cml_free(signal);
 }
 
 int cml_hcq_nv_signal_record(CMLHCQQueue *queue, CMLHCQSignal *signal) {

--- a/src/ops/ir/hcq_opencl.c
+++ b/src/ops/ir/hcq_opencl.c
@@ -13,6 +13,7 @@
 #define CL_TARGET_OPENCL_VERSION 300
 #endif
 #include <CL/cl.h>
+#include "alloc/cml_allocator.h"
 #endif
 
 static struct {
@@ -61,7 +62,7 @@ CMLHCQQueue* cml_hcq_opencl_queue_create(void) {
         return NULL;
     }
 
-    CMLHCQQueue* queue = (CMLHCQQueue*)calloc(1, sizeof(CMLHCQQueue));
+    CMLHCQQueue* queue = (CMLHCQQueue*)cml_calloc(1, sizeof(CMLHCQQueue));
     if (!queue) {
         LOG_ERROR("OpenCL HCQ: failed to allocate queue");
         return NULL;
@@ -79,7 +80,7 @@ CMLHCQQueue* cml_hcq_opencl_queue_create(void) {
 #endif
     if (err != CL_SUCCESS) {
         LOG_ERROR("OpenCL HCQ: clCreateCommandQueue failed (err=%d)", err);
-        free(queue);
+        cml_free(queue);
         return NULL;
     }
 
@@ -98,7 +99,7 @@ void cml_hcq_opencl_queue_destroy(CMLHCQQueue* queue) {
         }
     }
 
-    free(queue);
+    cml_free(queue);
 }
 
 int cml_hcq_opencl_submit_kernel(CMLHCQQueue* queue,
@@ -174,7 +175,7 @@ int cml_hcq_opencl_memcpy_d2h(CMLHCQQueue* queue, void* dst,
 }
 
 CMLHCQSignal* cml_hcq_opencl_signal_create(void) {
-    CMLHCQSignal* signal = (CMLHCQSignal*)calloc(1, sizeof(CMLHCQSignal));
+    CMLHCQSignal* signal = (CMLHCQSignal*)cml_calloc(1, sizeof(CMLHCQSignal));
     if (!signal) {
         LOG_ERROR("OpenCL HCQ: failed to allocate signal");
         return NULL;
@@ -196,7 +197,7 @@ void cml_hcq_opencl_signal_destroy(CMLHCQSignal* signal) {
         }
     }
 
-    free(signal);
+    cml_free(signal);
 }
 
 int cml_hcq_opencl_signal_record(CMLHCQQueue* queue, CMLHCQSignal* signal) {

--- a/src/ops/ir/intern.c
+++ b/src/ops/ir/intern.c
@@ -44,6 +44,7 @@ uint64_t cml_intern_hash_node(int op_type, int dtype, struct IRNode** inputs,
 }
 
 #include "tensor/tensor.h"
+#include "alloc/cml_allocator.h"
 
 uint64_t cml_intern_hash_node_ex(int op_type, int dtype, struct IRNode** inputs,
                                  Tensor** raw_inputs, int num_inputs,
@@ -122,14 +123,14 @@ static int entries_match_ex(struct IRNode* node, uint64_t hash, int op_type, int
 }
 
 CMLInternTable* cml_intern_table_create(void) {
-    CMLInternTable* table = calloc(1, sizeof(CMLInternTable));
+    CMLInternTable* table = cml_calloc(1, sizeof(CMLInternTable));
     if (!table)
         return NULL;
 
     table->capacity = INTERN_INITIAL_CAPACITY;
-    table->entries  = calloc(table->capacity, sizeof(CMLInternEntry));
+    table->entries  = cml_calloc(table->capacity, sizeof(CMLInternEntry));
     if (!table->entries) {
-        free(table);
+        cml_free(table);
         return NULL;
     }
     table->count = 0;
@@ -139,8 +140,8 @@ CMLInternTable* cml_intern_table_create(void) {
 void cml_intern_table_free(CMLInternTable* table) {
     if (!table)
         return;
-    free(table->entries);
-    free(table);
+    cml_free(table->entries);
+    cml_free(table);
 }
 
 static size_t probe_index(uint64_t hash, size_t capacity) {
@@ -149,7 +150,7 @@ static size_t probe_index(uint64_t hash, size_t capacity) {
 
 static int intern_resize(CMLInternTable* table) {
     size_t new_cap = table->capacity * 2;
-    CMLInternEntry* new_entries = calloc(new_cap, sizeof(CMLInternEntry));
+    CMLInternEntry* new_entries = cml_calloc(new_cap, sizeof(CMLInternEntry));
     if (!new_entries)
         return -1;
 
@@ -162,7 +163,7 @@ static int intern_resize(CMLInternTable* table) {
         new_entries[idx] = table->entries[i];
     }
 
-    free(table->entries);
+    cml_free(table->entries);
     table->entries  = new_entries;
     table->capacity = new_cap;
     return 0;

--- a/src/ops/ir/ir.c
+++ b/src/ops/ir/ir.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <stdatomic.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 const char* uop_type_to_string(UOpType type) {
     switch (type) {
@@ -266,7 +267,7 @@ const char* uop_type_to_string(UOpType type) {
 }
 
 CMLGraph_t cml_ir_new(IRTarget target) {
-    CMLGraph_t ir = malloc(sizeof(struct CMLGraph));
+    CMLGraph_t ir = cml_malloc(sizeof(struct CMLGraph));
     if (!ir)
         return NULL;
 
@@ -335,7 +336,7 @@ void cml_ir_free_node_params(struct IRNode* node) {
         break;
     case UOP_CLAMP: {
         ClampParams* p = (ClampParams*)node->params;
-        if (p) free(p);
+        if (p) cml_free(p);
         break;
     }
     case UOP_PROD:
@@ -346,27 +347,27 @@ void cml_ir_free_node_params(struct IRNode* node) {
     case UOP_MEAN: {
         ReduceParams* p = (ReduceParams*)node->params;
         if (p) {
-            if (p->dims) free(p->dims);
-            free(p);
+            if (p->dims) cml_free(p->dims);
+            cml_free(p);
         }
         break;
     }
     case UOP_CUMSUM: {
         CumsumParams* p = (CumsumParams*)node->params;
-        if (p) free(p);
+        if (p) cml_free(p);
         break;
     }
     case UOP_TRIU:
     case UOP_TRIL: {
         TriParams* p = (TriParams*)node->params;
-        if (p) free(p);
+        if (p) cml_free(p);
         break;
     }
     case UOP_PAD: {
         PadParams* p = (PadParams*)node->params;
         if (p) {
-            if (p->pad_widths) free(p->pad_widths);
-            free(p);
+            if (p->pad_widths) cml_free(p->pad_widths);
+            cml_free(p);
         }
         break;
     }
@@ -374,15 +375,15 @@ void cml_ir_free_node_params(struct IRNode* node) {
         FillParams* p = (FillParams*)node->params;
         if (p) {
             if (p->shape)
-                free(p->shape);
-            free(p);
+                cml_free(p->shape);
+            cml_free(p);
         }
         break;
     }
     case UOP_GATHER: {
         GatherParams* p = (GatherParams*)node->params;
         if (p) {
-            free(p);
+            cml_free(p);
         }
         break;
     }
@@ -390,8 +391,8 @@ void cml_ir_free_node_params(struct IRNode* node) {
         ReshapeParams* p = (ReshapeParams*)node->params;
         if (p) {
             if (p->new_shape)
-                free(p->new_shape);
-            free(p);
+                cml_free(p->new_shape);
+            cml_free(p);
         }
         break;
     }
@@ -399,8 +400,8 @@ void cml_ir_free_node_params(struct IRNode* node) {
         PermuteParams* p = (PermuteParams*)node->params;
         if (p) {
             if (p->perm)
-                free(p->perm);
-            free(p);
+                cml_free(p->perm);
+            cml_free(p);
         }
         break;
     }
@@ -408,8 +409,8 @@ void cml_ir_free_node_params(struct IRNode* node) {
         ExpandParams* p = (ExpandParams*)node->params;
         if (p) {
             if (p->new_shape)
-                free(p->new_shape);
-            free(p);
+                cml_free(p->new_shape);
+            cml_free(p);
         }
         break;
     }
@@ -417,8 +418,8 @@ void cml_ir_free_node_params(struct IRNode* node) {
         StrideParams* p = (StrideParams*)node->params;
         if (p) {
             if (p->new_strides)
-                free(p->new_strides);
-            free(p);
+                cml_free(p->new_strides);
+            cml_free(p);
         }
         break;
     }
@@ -426,12 +427,12 @@ void cml_ir_free_node_params(struct IRNode* node) {
         SliceParams* p = (SliceParams*)node->params;
         if (p) {
             if (p->start)
-                free(p->start);
+                cml_free(p->start);
             if (p->end)
-                free(p->end);
+                cml_free(p->end);
             if (p->step)
-                free(p->step);
-            free(p);
+                cml_free(p->step);
+            cml_free(p);
         }
         break;
     }
@@ -439,38 +440,38 @@ void cml_ir_free_node_params(struct IRNode* node) {
         Conv2DParams* p = (Conv2DParams*)node->params;
         if (p) {
             if (p->kernel_size)
-                free(p->kernel_size);
+                cml_free(p->kernel_size);
             if (p->stride)
-                free(p->stride);
+                cml_free(p->stride);
             if (p->padding)
-                free(p->padding);
+                cml_free(p->padding);
             if (p->dilation)
-                free(p->dilation);
-            free(p);
+                cml_free(p->dilation);
+            cml_free(p);
         }
         break;
     }
     case UOP_SORT:
     case UOP_ARGSORT: {
         SortParams* p = (SortParams*)node->params;
-        if (p) free(p);
+        if (p) cml_free(p);
         break;
     }
     case UOP_TOPK: {
         TopkParams* p = (TopkParams*)node->params;
-        if (p) free(p);
+        if (p) cml_free(p);
         break;
     }
     case UOP_CUMPROD:
     case UOP_CUMMAX:
     case UOP_CUMMIN: {
         CumsumParams* p = (CumsumParams*)node->params;
-        if (p) free(p);
+        if (p) cml_free(p);
         break;
     }
     case UOP_MASKED_FILL: {
         MaskedFillParams* p = (MaskedFillParams*)node->params;
-        if (p) free(p);
+        if (p) cml_free(p);
         break;
     }
     case UOP_MIN_REDUCE:
@@ -481,110 +482,110 @@ void cml_ir_free_node_params(struct IRNode* node) {
     case UOP_LOGSUMEXP: {
         ReduceParams* p = (ReduceParams*)node->params;
         if (p) {
-            if (p->dims) free(p->dims);
-            free(p);
+            if (p->dims) cml_free(p->dims);
+            cml_free(p);
         }
         break;
     }
     case UOP_CAT: {
         CatParams* p = (CatParams*)node->params;
-        if (p) free(p);
+        if (p) cml_free(p);
         break;
     }
     case UOP_STACK: {
         StackParams* p = (StackParams*)node->params;
-        if (p) free(p);
+        if (p) cml_free(p);
         break;
     }
     case UOP_SCATTER: {
         ScatterParams* p = (ScatterParams*)node->params;
-        if (p) free(p);
+        if (p) cml_free(p);
         break;
     }
     case UOP_ROLL: {
         RollParams* p = (RollParams*)node->params;
-        if (p) free(p);
+        if (p) cml_free(p);
         break;
     }
     case UOP_FLATTEN: {
         FlattenParams* p = (FlattenParams*)node->params;
-        if (p) free(p);
+        if (p) cml_free(p);
         break;
     }
     case UOP_UNFLATTEN: {
         UnflattenParams* p = (UnflattenParams*)node->params;
         if (p) {
-            if (p->sizes) free(p->sizes);
-            free(p);
+            if (p->sizes) cml_free(p->sizes);
+            cml_free(p);
         }
         break;
     }
     case UOP_DIAG: {
         DiagParams* p = (DiagParams*)node->params;
-        if (p) free(p);
+        if (p) cml_free(p);
         break;
     }
     case UOP_ONE_HOT: {
         OneHotParams* p = (OneHotParams*)node->params;
-        if (p) free(p);
+        if (p) cml_free(p);
         break;
     }
     case UOP_TILE: {
         TileParams* p = (TileParams*)node->params;
         if (p) {
-            if (p->repeats) free(p->repeats);
-            free(p);
+            if (p->repeats) cml_free(p->repeats);
+            cml_free(p);
         }
         break;
     }
     case UOP_REPEAT_INTERLEAVE: {
         RepeatInterleaveParams* p = (RepeatInterleaveParams*)node->params;
-        if (p) free(p);
+        if (p) cml_free(p);
         break;
     }
     case UOP_SHRINK: {
         ShrinkParams* p = (ShrinkParams*)node->params;
         if (p) {
-            if (p->starts) free(p->starts);
-            if (p->ends) free(p->ends);
-            free(p);
+            if (p->starts) cml_free(p->starts);
+            if (p->ends) cml_free(p->ends);
+            cml_free(p);
         }
         break;
     }
     case UOP_UNFOLD: {
         UnfoldParams* p = (UnfoldParams*)node->params;
-        if (p) free(p);
+        if (p) cml_free(p);
         break;
     }
     case UOP_MAXPOOL2D:
     case UOP_AVGPOOL2D: {
         Pool2DParams* p = (Pool2DParams*)node->params;
-        if (p) free(p);
+        if (p) cml_free(p);
         break;
     }
     case UOP_CONV3D: {
         Conv3DParams* p = (Conv3DParams*)node->params;
-        if (p) free(p);
+        if (p) cml_free(p);
         break;
     }
     case UOP_CONV_TRANSPOSE2D: {
         ConvTranspose2DParams* p = (ConvTranspose2DParams*)node->params;
-        if (p) free(p);
+        if (p) cml_free(p);
         break;
     }
     case UOP_CONV_TRANSPOSE3D: {
         ConvTranspose3DParams* p = (ConvTranspose3DParams*)node->params;
-        if (p) free(p);
+        if (p) cml_free(p);
         break;
     }
     case UOP_LOGCUMSUMEXP: {
         CumsumParams* p = (CumsumParams*)node->params;
-        if (p) free(p);
+        if (p) cml_free(p);
         break;
     }
     case UOP_CELU: {
         ClampParams* p = (ClampParams*)node->params;
-        if (p) free(p);
+        if (p) cml_free(p);
         break;
     }
     case UOP_ERFC:
@@ -633,41 +634,41 @@ void cml_ir_free_node_params(struct IRNode* node) {
     case UOP_CONST: {
         ConstParams* p = (ConstParams*)node->params;
         if (p) {
-            if (p->data)  free(p->data);
-            if (p->shape) free(p->shape);
-            free(p);
+            if (p->data)  cml_free(p->data);
+            if (p->shape) cml_free(p->shape);
+            cml_free(p);
         }
         break;
     }
     case UOP_RAND_UNIFORM:
     case UOP_RAND_NORMAL: {
         RandParams* p = (RandParams*)node->params;
-        if (p) free(p);
+        if (p) cml_free(p);
         break;
     }
     case UOP_ARANGE_OP: {
         ArangeParams* p = (ArangeParams*)node->params;
-        if (p) free(p);
+        if (p) cml_free(p);
         break;
     }
     case UOP_EYE_OP: {
         EyeParams* p = (EyeParams*)node->params;
-        if (p) free(p);
+        if (p) cml_free(p);
         break;
     }
     case UOP_RAND_INT: {
         RandIntParams* p = (RandIntParams*)node->params;
-        if (p) free(p);
+        if (p) cml_free(p);
         break;
     }
     case UOP_SGD_STEP: {
         SgdStepParams* p = (SgdStepParams*)node->params;
-        if (p) free(p);
+        if (p) cml_free(p);
         break;
     }
     case UOP_ADAM_STEP: {
         AdamStepParams* p = (AdamStepParams*)node->params;
-        if (p) free(p);
+        if (p) cml_free(p);
         break;
     }
     default:
@@ -693,58 +694,58 @@ static void free_ir_node(struct IRNode* node) {
     if (node->input_names && node->num_inputs >= 0 && node->num_inputs <= 1000) {
         for (int i = 0; i < node->num_inputs; i++) {
             if (node->input_names[i]) {
-                free(node->input_names[i]);
+                cml_free(node->input_names[i]);
                 node->input_names[i] = NULL;
             }
         }
-        free(node->input_names);
+        cml_free(node->input_names);
         node->input_names = NULL;
     } else if (node->input_names) {
-        free(node->input_names);
+        cml_free(node->input_names);
         node->input_names = NULL;
     }
 
     if (node->output_name) {
-        free(node->output_name);
+        cml_free(node->output_name);
         node->output_name = NULL;
     }
 
     if (node->users) {
-        free(node->users);
+        cml_free(node->users);
         node->users = NULL;
     }
 
     if (node->inputs) {
-        free(node->inputs);
+        cml_free(node->inputs);
         node->inputs = NULL;
     }
 
     if (node->input_shapes) {
-        free(node->input_shapes);
+        cml_free(node->input_shapes);
         node->input_shapes = NULL;
     }
     if (node->input_ndims) {
-        free(node->input_ndims);
+        cml_free(node->input_ndims);
         node->input_ndims = NULL;
     }
     if (node->output_shape) {
-        free(node->output_shape);
+        cml_free(node->output_shape);
         node->output_shape = NULL;
     }
 
     if (node->broadcast) {
         if (node->broadcast->broadcast_dims) {
-            free(node->broadcast->broadcast_dims);
+            cml_free(node->broadcast->broadcast_dims);
         }
         if (node->broadcast->broadcast_strides) {
-            free(node->broadcast->broadcast_strides);
+            cml_free(node->broadcast->broadcast_strides);
         }
-        free(node->broadcast);
+        cml_free(node->broadcast);
         node->broadcast = NULL;
     }
 
     if (node->saved_for_backward) {
-        free(node->saved_for_backward);
+        cml_free(node->saved_for_backward);
         node->saved_for_backward = NULL;
     }
 
@@ -755,7 +756,7 @@ static void free_ir_node(struct IRNode* node) {
     cml_ir_free_node_params(node);
 
     /* execution_result is owned by the tensor -- do not free here */
-    free(node);
+    cml_free(node);
 }
 
 void cml_ir_free(CMLGraph_t ir) {
@@ -816,7 +817,7 @@ void cml_ir_free(CMLGraph_t ir) {
                 ir->tensor_refs[i] = NULL;
             }
         }
-        free(ir->tensor_refs);
+        cml_free(ir->tensor_refs);
         ir->tensor_refs       = NULL;
         ir->tensor_refs_count = 0;
     }
@@ -861,22 +862,22 @@ void cml_ir_free(CMLGraph_t ir) {
     if (ir->tensor_names) {
         for (int i = 0; i < ir->tensor_count; i++) {
             if (ir->tensor_names[i]) {
-                free(ir->tensor_names[i]);
+                cml_free(ir->tensor_names[i]);
                 ir->tensor_names[i] = NULL;
             }
         }
-        free(ir->tensor_names);
+        cml_free(ir->tensor_names);
         ir->tensor_names = NULL;
         ir->tensor_count = 0;
     }
 
     if (ir->execution_results) {
-        free(ir->execution_results);
+        cml_free(ir->execution_results);
         ir->execution_results       = NULL;
         ir->execution_results_count = 0;
     }
 
-    free(ir);
+    cml_free(ir);
 }
 
 /** Undo refcount bumps on inputs wired as lazy tensors in this IR graph. */
@@ -927,7 +928,7 @@ int cml_ir_add_uop(CMLGraph_t ir, UOpType type, Tensor** inputs, int num_inputs,
         }
     }
 
-    struct IRNode* node = malloc(sizeof(struct IRNode));
+    struct IRNode* node = cml_malloc(sizeof(struct IRNode));
     if (!node)
         return -1;
 
@@ -937,9 +938,9 @@ int cml_ir_add_uop(CMLGraph_t ir, UOpType type, Tensor** inputs, int num_inputs,
     if (num_inputs == 0) {
         node->input_names = NULL;
     } else {
-        node->input_names = malloc((size_t)num_inputs * sizeof(char*));
+        node->input_names = cml_malloc((size_t)num_inputs * sizeof(char*));
         if (!node->input_names) {
-            free(node);
+            cml_free(node);
             return -1;
         }
     }
@@ -950,16 +951,16 @@ int cml_ir_add_uop(CMLGraph_t ir, UOpType type, Tensor** inputs, int num_inputs,
             new_capacity *= 2;
         }
 
-        Tensor** new_refs = realloc(ir->tensor_refs, (size_t)new_capacity * sizeof(Tensor*));
-        char** new_names  = realloc(ir->tensor_names, (size_t)new_capacity * sizeof(char*));
+        Tensor** new_refs = cml_realloc(ir->tensor_refs, (size_t)new_capacity * sizeof(Tensor*));
+        char** new_names  = cml_realloc(ir->tensor_names, (size_t)new_capacity * sizeof(char*));
 
         if (!new_refs || !new_names) {
             if (new_refs)
-                free(new_refs);
+                cml_free(new_refs);
             if (new_names)
-                free(new_names);
-            free(node->input_names);
-            free(node);
+                cml_free(new_names);
+            cml_free(node->input_names);
+            cml_free(node);
             return -1;
         }
 
@@ -975,48 +976,48 @@ int cml_ir_add_uop(CMLGraph_t ir, UOpType type, Tensor** inputs, int num_inputs,
 
         if (t) {
             if (t->ir_node && t->ir_context == ir && t->ir_node->output_name) {
-                name = strdup(t->ir_node->output_name);
+                name = cml_strdup(t->ir_node->output_name);
                 if (!name) {
                     cml_ir_release_same_graph_input_refs(ir, inputs, i);
                     for (int j = 0; j < i; j++)
-                        free(node->input_names[j]);
-                    free(node->input_names);
-                    free(node);
+                        cml_free(node->input_names[j]);
+                    cml_free(node->input_names);
+                    cml_free(node);
                     return -1;
                 }
                 t->ref_count++;
             } else {
                 for (int j = 0; j < ir->tensor_count; j++) {
                     if (ir->tensor_refs[j] == t) {
-                        name = strdup(ir->tensor_names[j]);
+                        name = cml_strdup(ir->tensor_names[j]);
                         break;
                     }
                 }
 
                 if (!name) {
-                    char* new_name = malloc(32);
+                    char* new_name = cml_malloc(32);
                     if (!new_name) {
                         cml_ir_release_same_graph_input_refs(ir, inputs, i);
                         for (int j = 0; j < i; j++)
-                            free(node->input_names[j]);
-                        free(node->input_names);
-                        free(node);
+                            cml_free(node->input_names[j]);
+                        cml_free(node->input_names);
+                        cml_free(node);
                         return -1;
                     }
                     snprintf(new_name, 32, "t%d", ir->tensor_count + ir->node_count);
                     ir->tensor_refs[ir->tensor_count] = t;
                     t->ref_count++;
                     ir->tensor_names[ir->tensor_count] = new_name;
-                    name                               = strdup(new_name);
+                    name                               = cml_strdup(new_name);
                     if (!name) {
-                        free(new_name);
+                        cml_free(new_name);
                         ir->tensor_refs[ir->tensor_count] = NULL;
                         t->ref_count--;
                         cml_ir_release_same_graph_input_refs(ir, inputs, i);
                         for (int j = 0; j < i; j++)
-                            free(node->input_names[j]);
-                        free(node->input_names);
-                        free(node);
+                            cml_free(node->input_names[j]);
+                        cml_free(node->input_names);
+                        cml_free(node);
                         return -1;
                     }
                     ir->tensor_count++;
@@ -1024,27 +1025,27 @@ int cml_ir_add_uop(CMLGraph_t ir, UOpType type, Tensor** inputs, int num_inputs,
                 }
             }
         } else {
-            name = strdup("null");
+            name = cml_strdup("null");
         }
 
         if (!name) {
             cml_ir_release_same_graph_input_refs(ir, inputs, i);
             for (int j = 0; j < i; j++)
-                free(node->input_names[j]);
-            free(node->input_names);
-            free(node);
+                cml_free(node->input_names[j]);
+            cml_free(node->input_names);
+            cml_free(node);
             return -1;
         }
         node->input_names[i] = name;
     }
 
-    char* output_name = malloc(32);
+    char* output_name = cml_malloc(32);
     if (!output_name) {
         cml_ir_release_same_graph_input_refs(ir, inputs, num_inputs);
         for (int i = 0; i < num_inputs; i++)
-            free(node->input_names[i]);
-        free(node->input_names);
-        free(node);
+            cml_free(node->input_names[i]);
+        cml_free(node->input_names);
+        cml_free(node);
         return -1;
     }
     snprintf(output_name, 32, "t%d", ir->tensor_count + ir->node_count);
@@ -1054,14 +1055,14 @@ int cml_ir_add_uop(CMLGraph_t ir, UOpType type, Tensor** inputs, int num_inputs,
     node->next   = NULL;
 
     if (num_inputs > 0) {
-        node->inputs = malloc((size_t)num_inputs * sizeof(Tensor*));
+        node->inputs = cml_malloc((size_t)num_inputs * sizeof(Tensor*));
         if (!node->inputs) {
             cml_ir_release_same_graph_input_refs(ir, inputs, num_inputs);
             for (int i = 0; i < num_inputs; i++) {
-                free(node->input_names[i]);
+                cml_free(node->input_names[i]);
             }
-            free(node->input_names);
-            free(node);
+            cml_free(node->input_names);
+            cml_free(node);
             return -1;
         }
         memcpy(node->inputs, inputs, (size_t)num_inputs * sizeof(Tensor*));
@@ -1153,7 +1154,7 @@ char* cml_ir_to_string(CMLGraph_t ir) {
         return NULL;
 
     size_t buffer_size = 2048;
-    char* str          = malloc(buffer_size);
+    char* str          = cml_malloc(buffer_size);
     if (!str)
         return NULL;
 
@@ -1185,20 +1186,20 @@ int cml_ir_compute_broadcast_shape(struct IRNode* node) {
     if (!node || node->num_inputs < 2)
         return -1;
 
-    int** input_shapes = malloc((size_t)node->num_inputs * sizeof(int*));
+    int** input_shapes = cml_malloc((size_t)node->num_inputs * sizeof(int*));
     if (!input_shapes)
         return -1;
 
-    int* input_ndims = malloc((size_t)node->num_inputs * sizeof(int));
+    int* input_ndims = cml_malloc((size_t)node->num_inputs * sizeof(int));
     if (!input_ndims) {
-        free(input_shapes);
+        cml_free(input_shapes);
         return -1;
     }
 
     for (int i = 0; i < node->num_inputs; i++) {
         if (!node->inputs[i]) {
-            free(input_shapes);
-            free(input_ndims);
+            cml_free(input_shapes);
+            cml_free(input_ndims);
             return -1;
         }
         input_shapes[i] = node->inputs[i]->shape;
@@ -1211,10 +1212,10 @@ int cml_ir_compute_broadcast_shape(struct IRNode* node) {
             max_ndim = input_ndims[i];
     }
 
-    int* output_shape = malloc((size_t)max_ndim * sizeof(int));
+    int* output_shape = cml_malloc((size_t)max_ndim * sizeof(int));
     if (!output_shape) {
-        free(input_shapes);
-        free(input_ndims);
+        cml_free(input_shapes);
+        cml_free(input_ndims);
         return -1;
     }
 
@@ -1225,9 +1226,9 @@ int cml_ir_compute_broadcast_shape(struct IRNode* node) {
             if (dim_idx >= 0) {
                 int dim = input_shapes[i][dim_idx];
                 if (dim != 1 && max_dim != 1 && dim != max_dim) {
-                    free(output_shape);
-                    free(input_shapes);
-                    free(input_ndims);
+                    cml_free(output_shape);
+                    cml_free(input_shapes);
+                    cml_free(input_ndims);
                     return -1;
                 }
                 if (dim > max_dim)

--- a/src/ops/ir/kernel_cache.c
+++ b/src/ops/ir/kernel_cache.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include "alloc/cml_allocator.h"
 
 #define DEFAULT_NUM_BUCKETS 256
 #define FNV_OFFSET_BASIS 0xcbf29ce484222325ULL
@@ -45,17 +46,17 @@ CMLKernelCache* cml_kernel_cache_create(size_t max_entries) {
 }
 
 CMLKernelCache* cml_kernel_cache_create_with_limits(size_t max_entries, size_t max_memory) {
-    CMLKernelCache* cache = (CMLKernelCache*)calloc(1, sizeof(CMLKernelCache));
+    CMLKernelCache* cache = (CMLKernelCache*)cml_calloc(1, sizeof(CMLKernelCache));
     if (!cache) {
         LOG_ERROR("Failed to allocate kernel cache");
         return NULL;
     }
 
     cache->num_buckets = DEFAULT_NUM_BUCKETS;
-    cache->buckets     = (CMLKernelEntry**)calloc(cache->num_buckets, sizeof(CMLKernelEntry*));
+    cache->buckets     = (CMLKernelEntry**)cml_calloc(cache->num_buckets, sizeof(CMLKernelEntry*));
     if (!cache->buckets) {
         LOG_ERROR("Failed to allocate kernel cache buckets");
-        free(cache);
+        cml_free(cache);
         return NULL;
     }
 
@@ -70,8 +71,8 @@ CMLKernelCache* cml_kernel_cache_create_with_limits(size_t max_entries, size_t m
 
     if (pthread_mutex_init(&cache->lock, NULL) != 0) {
         LOG_ERROR("Failed to initialize kernel cache mutex");
-        free(cache->buckets);
-        free(cache);
+        cml_free(cache->buckets);
+        cml_free(cache);
         return NULL;
     }
     cache->lock_initialized = true;
@@ -87,7 +88,7 @@ static void free_entry(CMLKernelEntry* entry) {
         g_kernel_free_fns[entry->backend](entry->compiled);
     }
 
-    free(entry);
+    cml_free(entry);
 }
 
 void cml_kernel_cache_free(CMLKernelCache* cache) {
@@ -100,8 +101,8 @@ void cml_kernel_cache_free(CMLKernelCache* cache) {
         pthread_mutex_destroy(&cache->lock);
     }
 
-    free(cache->buckets);
-    free(cache);
+    cml_free(cache->buckets);
+    cml_free(cache);
 }
 
 void kernel_cache_clear(CMLKernelCache* cache) {
@@ -221,7 +222,7 @@ int cml_kernel_cache_insert(CMLKernelCache* cache, uint64_t hash, CMLKernelBacke
         pthread_mutex_lock(&cache->lock);
     }
 
-    CMLKernelEntry* entry = (CMLKernelEntry*)calloc(1, sizeof(CMLKernelEntry));
+    CMLKernelEntry* entry = (CMLKernelEntry*)cml_calloc(1, sizeof(CMLKernelEntry));
     if (!entry) {
         pthread_mutex_unlock(&cache->lock);
         LOG_ERROR("Failed to allocate kernel cache entry");

--- a/src/ops/ir/late_passes.c
+++ b/src/ops/ir/late_passes.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include "alloc/cml_allocator.h"
 
 #define MAX_WORKGROUP_EXTENT 256
 
@@ -9,7 +10,7 @@ static int ensure_capacity(LinearProgram* prog, int needed) {
     if (prog->num_ops + needed <= prog->capacity) return 0;
     int nc = prog->capacity;
     while (nc < prog->num_ops + needed) nc *= 2;
-    LinearOp* tmp = realloc(prog->ops, (size_t)nc * sizeof(LinearOp));
+    LinearOp* tmp = cml_realloc(prog->ops, (size_t)nc * sizeof(LinearOp));
     if (!tmp) return -1;
     prog->ops = tmp;
     prog->capacity = nc;
@@ -158,7 +159,7 @@ int cml_expand_groups(struct LinearProgram* prog) {
             int body_len = endloop_idx - i - 1;
             LinearOp* body = NULL;
             if (body_len > 0) {
-                body = malloc((size_t)body_len * sizeof(LinearOp));
+                body = cml_malloc((size_t)body_len * sizeof(LinearOp));
                 if (!body) return -1;
                 memcpy(body, &prog->ops[i + 1], (size_t)body_len * sizeof(LinearOp));
             }
@@ -168,7 +169,7 @@ int cml_expand_groups(struct LinearProgram* prog) {
             int delta = total_new - old_block;
 
             if (delta > 0) {
-                if (ensure_capacity(prog, delta) != 0) { free(body); return -1; }
+                if (ensure_capacity(prog, delta) != 0) { cml_free(body); return -1; }
                 memmove(&prog->ops[i + total_new],
                         &prog->ops[endloop_idx + 1],
                         (size_t)(prog->num_ops - endloop_idx - 1) * sizeof(LinearOp));
@@ -201,7 +202,7 @@ int cml_expand_groups(struct LinearProgram* prog) {
                 prog->ops[pos++] = endloop;
             }
 
-            free(body);
+            cml_free(body);
             i = pos;
         } else {
             i++;

--- a/src/ops/ir/linearize.c
+++ b/src/ops/ir/linearize.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include "alloc/cml_allocator.h"
 
 static bool is_eliminated(const CMLFusionGroup* g, int node_idx) {
     if (!g) return false;
@@ -15,15 +16,15 @@ static bool is_eliminated(const CMLFusionGroup* g, int node_idx) {
 }
 
 LinearProgram* linear_program_create(void) {
-    LinearProgram* prog = calloc(1, sizeof(LinearProgram));
+    LinearProgram* prog = cml_calloc(1, sizeof(LinearProgram));
     if (!prog) return NULL;
     prog->capacity = 32;
-    prog->ops = calloc((size_t)prog->capacity, sizeof(LinearOp));
-    if (!prog->ops) { free(prog); return NULL; }
+    prog->ops = cml_calloc((size_t)prog->capacity, sizeof(LinearOp));
+    if (!prog->ops) { cml_free(prog); return NULL; }
     prog->next_vreg = 0;
     prog->axes_capacity = 8;
-    prog->loop_axes = calloc((size_t)prog->axes_capacity, sizeof(int));
-    if (!prog->loop_axes) { free(prog->ops); free(prog); return NULL; }
+    prog->loop_axes = cml_calloc((size_t)prog->axes_capacity, sizeof(int));
+    if (!prog->loop_axes) { cml_free(prog->ops); cml_free(prog); return NULL; }
     prog->group_dims[0] = 1;
     prog->group_dims[1] = 1;
     prog->group_dims[2] = 1;
@@ -32,16 +33,16 @@ LinearProgram* linear_program_create(void) {
 
 void linear_program_free(LinearProgram* prog) {
     if (!prog) return;
-    free(prog->loop_axes);
-    free(prog->ops);
-    free(prog);
+    cml_free(prog->loop_axes);
+    cml_free(prog->ops);
+    cml_free(prog);
 }
 
 int linear_program_emit(LinearProgram* prog, LinearOp op) {
     if (!prog) return -1;
     if (prog->num_ops >= prog->capacity) {
         int nc = prog->capacity * 2;
-        LinearOp* tmp = realloc(prog->ops, (size_t)nc * sizeof(LinearOp));
+        LinearOp* tmp = cml_realloc(prog->ops, (size_t)nc * sizeof(LinearOp));
         if (!tmp) return -1;
         prog->ops = tmp;
         prog->capacity = nc;
@@ -65,7 +66,7 @@ LinearProgram* linearize_group(const CMLFusionGroup* g) {
     LinearProgram* prog = linear_program_create();
     if (!prog) return NULL;
 
-    int* node_vreg = calloc((size_t)g->num_nodes, sizeof(int));
+    int* node_vreg = cml_calloc((size_t)g->num_nodes, sizeof(int));
     if (!node_vreg) { linear_program_free(prog); return NULL; }
     for (int i = 0; i < g->num_nodes; i++) node_vreg[i] = -1;
 
@@ -144,7 +145,7 @@ LinearProgram* linearize_group(const CMLFusionGroup* g) {
         }
     }
 
-    free(node_vreg);
+    cml_free(node_vreg);
     return prog;
 }
 

--- a/src/ops/ir/llvm/llvm_backend.c
+++ b/src/ops/ir/llvm/llvm_backend.c
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <math.h>
 #include <stdbool.h>
+#include "alloc/cml_allocator.h"
 
 struct CMLLLVMBackend {
     LLVMOrcLLJITRef jit;
@@ -39,7 +40,7 @@ CMLLLVMBackend* cml_llvm_backend_init(void) {
         g_llvm_targets_initialized = true;
     }
 
-    CMLLLVMBackend* b = calloc(1, sizeof(CMLLLVMBackend));
+    CMLLLVMBackend* b = cml_calloc(1, sizeof(CMLLLVMBackend));
     if (!b) return NULL;
 
     char* triple = LLVMGetDefaultTargetTriple();
@@ -49,7 +50,7 @@ CMLLLVMBackend* cml_llvm_backend_init(void) {
         LOG_ERROR("LLVM: Failed to get target: %s", err ? err : "unknown");
         LLVMDisposeMessage(err);
         LLVMDisposeMessage(triple);
-        free(b);
+        cml_free(b);
         return NULL;
     }
 
@@ -60,7 +61,7 @@ CMLLLVMBackend* cml_llvm_backend_init(void) {
 
     if (!b->tm) {
         LOG_ERROR("LLVM: Failed to create target machine");
-        free(b);
+        cml_free(b);
         return NULL;
     }
 
@@ -78,7 +79,7 @@ void cml_llvm_backend_destroy(CMLLLVMBackend* backend) {
     if (backend->tm) {
         LLVMDisposeTargetMachine(backend->tm);
     }
-    free(backend);
+    cml_free(backend);
 }
 
 // Emit a simple loop: for (i64 i = 0; i < n; i++) { body }

--- a/src/ops/ir/memory_planner.c
+++ b/src/ops/ir/memory_planner.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include "alloc/cml_allocator.h"
 
 typedef struct {
     int index;
@@ -31,15 +32,15 @@ CMLMemoryPlan* cml_memory_plan_create(int num_buffers, size_t* sizes,
     if (num_buffers <= 0 || !sizes || !first_use || !last_use)
         return NULL;
 
-    CMLMemoryPlan* plan = calloc(1, sizeof(CMLMemoryPlan));
+    CMLMemoryPlan* plan = cml_calloc(1, sizeof(CMLMemoryPlan));
     if (!plan) return NULL;
 
     plan->num_buffers    = num_buffers;
-    plan->buffer_sizes   = malloc((size_t)num_buffers * sizeof(size_t));
-    plan->buffer_offsets = calloc((size_t)num_buffers, sizeof(size_t));
-    plan->buffer_reuse_map = malloc((size_t)num_buffers * sizeof(int));
-    plan->buffer_first_use = malloc((size_t)num_buffers * sizeof(int));
-    plan->buffer_last_use  = malloc((size_t)num_buffers * sizeof(int));
+    plan->buffer_sizes   = cml_malloc((size_t)num_buffers * sizeof(size_t));
+    plan->buffer_offsets = cml_calloc((size_t)num_buffers, sizeof(size_t));
+    plan->buffer_reuse_map = cml_malloc((size_t)num_buffers * sizeof(int));
+    plan->buffer_first_use = cml_malloc((size_t)num_buffers * sizeof(int));
+    plan->buffer_last_use  = cml_malloc((size_t)num_buffers * sizeof(int));
 
     if (!plan->buffer_sizes || !plan->buffer_offsets || !plan->buffer_reuse_map ||
         !plan->buffer_first_use || !plan->buffer_last_use) {
@@ -59,7 +60,7 @@ CMLMemoryPlan* cml_memory_plan_create(int num_buffers, size_t* sizes,
         naive_total += sizes[i];
 
     /* Sort buffers by decreasing size for greedy coloring */
-    BufferEntry* sorted = malloc((size_t)num_buffers * sizeof(BufferEntry));
+    BufferEntry* sorted = cml_malloc((size_t)num_buffers * sizeof(BufferEntry));
     if (!sorted) {
         cml_memory_plan_free(plan);
         return NULL;
@@ -77,18 +78,18 @@ CMLMemoryPlan* cml_memory_plan_create(int num_buffers, size_t* sizes,
      * We cap at num_buffers slots (worst case: no reuse).
      */
     int num_slots = 0;
-    size_t* slot_sizes = calloc((size_t)num_buffers, sizeof(size_t));
-    int* slot_owner    = malloc((size_t)num_buffers * sizeof(int));
+    size_t* slot_sizes = cml_calloc((size_t)num_buffers, sizeof(size_t));
+    int* slot_owner    = cml_malloc((size_t)num_buffers * sizeof(int));
     /* For each slot, track the merged lifetime [earliest first_use, latest last_use] */
-    int* slot_first = malloc((size_t)num_buffers * sizeof(int));
-    int* slot_last  = malloc((size_t)num_buffers * sizeof(int));
+    int* slot_first = cml_malloc((size_t)num_buffers * sizeof(int));
+    int* slot_last  = cml_malloc((size_t)num_buffers * sizeof(int));
     /* Per-buffer slot assignment */
-    int* buf_slot = malloc((size_t)num_buffers * sizeof(int));
+    int* buf_slot = cml_malloc((size_t)num_buffers * sizeof(int));
 
     if (!slot_sizes || !slot_owner || !slot_first || !slot_last || !buf_slot) {
-        free(sorted);
-        free(slot_sizes); free(slot_owner);
-        free(slot_first); free(slot_last); free(buf_slot);
+        cml_free(sorted);
+        cml_free(slot_sizes); cml_free(slot_owner);
+        cml_free(slot_first); cml_free(slot_last); cml_free(buf_slot);
         cml_memory_plan_free(plan);
         return NULL;
     }
@@ -99,14 +100,14 @@ CMLMemoryPlan* cml_memory_plan_create(int num_buffers, size_t* sizes,
      * are overly conservative when a slot hosts multiple non-overlapping
      * buffers with a gap between them.
      */
-    int** slot_bufs   = calloc((size_t)num_buffers, sizeof(int*));
-    int*  slot_nbuf   = calloc((size_t)num_buffers, sizeof(int));
-    int*  slot_bufcap = calloc((size_t)num_buffers, sizeof(int));
+    int** slot_bufs   = cml_calloc((size_t)num_buffers, sizeof(int*));
+    int*  slot_nbuf   = cml_calloc((size_t)num_buffers, sizeof(int));
+    int*  slot_bufcap = cml_calloc((size_t)num_buffers, sizeof(int));
 
     if (!slot_bufs || !slot_nbuf || !slot_bufcap) {
-        free(sorted); free(slot_sizes); free(slot_owner);
-        free(slot_first); free(slot_last); free(buf_slot);
-        free(slot_bufs); free(slot_nbuf); free(slot_bufcap);
+        cml_free(sorted); cml_free(slot_sizes); cml_free(slot_owner);
+        cml_free(slot_first); cml_free(slot_last); cml_free(buf_slot);
+        cml_free(slot_bufs); cml_free(slot_nbuf); cml_free(slot_bufcap);
         cml_memory_plan_free(plan);
         return NULL;
     }
@@ -154,7 +155,7 @@ CMLMemoryPlan* cml_memory_plan_create(int num_buffers, size_t* sizes,
             /* Append to slot's buffer list */
             if (slot_nbuf[best_slot] >= slot_bufcap[best_slot]) {
                 int nc = slot_bufcap[best_slot] ? slot_bufcap[best_slot] * 2 : 4;
-                int* tmp = realloc(slot_bufs[best_slot], (size_t)nc * sizeof(int));
+                int* tmp = cml_realloc(slot_bufs[best_slot], (size_t)nc * sizeof(int));
                 if (tmp) {
                     slot_bufs[best_slot]   = tmp;
                     slot_bufcap[best_slot] = nc;
@@ -170,7 +171,7 @@ CMLMemoryPlan* cml_memory_plan_create(int num_buffers, size_t* sizes,
             buf_slot[idx] = s;
 
             slot_bufcap[s] = 4;
-            slot_bufs[s]   = malloc(4 * sizeof(int));
+            slot_bufs[s]   = cml_malloc(4 * sizeof(int));
             slot_nbuf[s]   = 1;
             if (slot_bufs[s])
                 slot_bufs[s][0] = idx;
@@ -209,28 +210,28 @@ CMLMemoryPlan* cml_memory_plan_create(int num_buffers, size_t* sizes,
     plan->peak_memory = peak;
 
     for (int s = 0; s < num_slots; s++)
-        free(slot_bufs[s]);
-    free(slot_bufs);
-    free(slot_nbuf);
-    free(slot_bufcap);
-    free(sorted);
-    free(slot_sizes);
-    free(slot_owner);
-    free(slot_first);
-    free(slot_last);
-    free(buf_slot);
+        cml_free(slot_bufs[s]);
+    cml_free(slot_bufs);
+    cml_free(slot_nbuf);
+    cml_free(slot_bufcap);
+    cml_free(sorted);
+    cml_free(slot_sizes);
+    cml_free(slot_owner);
+    cml_free(slot_first);
+    cml_free(slot_last);
+    cml_free(buf_slot);
 
     return plan;
 }
 
 void cml_memory_plan_free(CMLMemoryPlan* plan) {
     if (!plan) return;
-    free(plan->buffer_sizes);
-    free(plan->buffer_offsets);
-    free(plan->buffer_reuse_map);
-    free(plan->buffer_first_use);
-    free(plan->buffer_last_use);
-    free(plan);
+    cml_free(plan->buffer_sizes);
+    cml_free(plan->buffer_offsets);
+    cml_free(plan->buffer_reuse_map);
+    cml_free(plan->buffer_first_use);
+    cml_free(plan->buffer_last_use);
+    cml_free(plan);
 }
 
 void cml_memory_plan_print(const CMLMemoryPlan* plan) {

--- a/src/ops/ir/multi_output.c
+++ b/src/ops/ir/multi_output.c
@@ -3,6 +3,7 @@
 #include "core/logging.h"
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 #define MAX_INPUTS_TRACKED 32
 
@@ -83,7 +84,7 @@ int cml_multi_output_analyze(CMLFusionSchedule* sched, int** merge_groups, int* 
     int ng = sched->num_groups;
     if (ng < 2) return 0;
 
-    GroupSignature* sigs = calloc((size_t)ng, sizeof(GroupSignature));
+    GroupSignature* sigs = cml_calloc((size_t)ng, sizeof(GroupSignature));
     if (!sigs) return -1;
 
     for (int i = 0; i < ng; i++) {
@@ -91,12 +92,12 @@ int cml_multi_output_analyze(CMLFusionSchedule* sched, int** merge_groups, int* 
             collect_group_inputs(sched->groups[i], &sigs[i]);
     }
 
-    int* pairs = calloc((size_t)(ng * 2), sizeof(int));
-    if (!pairs) { free(sigs); return -1; }
+    int* pairs = cml_calloc((size_t)(ng * 2), sizeof(int));
+    if (!pairs) { cml_free(sigs); return -1; }
     int count = 0;
 
-    int* merged = calloc((size_t)ng, sizeof(int));
-    if (!merged) { free(sigs); free(pairs); return -1; }
+    int* merged = cml_calloc((size_t)ng, sizeof(int));
+    if (!merged) { cml_free(sigs); cml_free(pairs); return -1; }
 
     for (int i = 0; i < ng; i++) {
         if (merged[i]) continue;
@@ -118,16 +119,16 @@ int cml_multi_output_analyze(CMLFusionSchedule* sched, int** merge_groups, int* 
         }
     }
 
-    free(merged);
-    free(sigs);
+    cml_free(merged);
+    cml_free(sigs);
 
     if (count == 0) {
-        free(pairs);
+        cml_free(pairs);
         return 0;
     }
 
-    int* tmp = realloc(pairs, (size_t)(count * 2) * sizeof(int));
-    if (!tmp) { free(pairs); *merge_groups = NULL; *num_merges = 0; return 0; }
+    int* tmp = cml_realloc(pairs, (size_t)(count * 2) * sizeof(int));
+    if (!tmp) { cml_free(pairs); *merge_groups = NULL; *num_merges = 0; return 0; }
     *merge_groups = tmp;
     *num_merges = count;
     return count;
@@ -159,7 +160,7 @@ int cml_multi_output_fuse(CMLFusionSchedule* sched, int* merge_groups, int num_m
 
             if (primary->num_nodes >= primary->node_capacity) {
                 int nc = primary->node_capacity * 2;
-                struct IRNode** tmp = realloc(primary->nodes,
+                struct IRNode** tmp = cml_realloc(primary->nodes,
                                               (size_t)nc * sizeof(struct IRNode*));
                 if (!tmp) return -1;
                 primary->nodes = tmp;
@@ -170,9 +171,9 @@ int cml_multi_output_fuse(CMLFusionSchedule* sched, int* merge_groups, int num_m
             primary->total_memory += secondary->total_memory / secondary->num_nodes;
         }
 
-        free(secondary->nodes);
-        free(secondary->eliminated_buffers);
-        free(secondary);
+        cml_free(secondary->nodes);
+        cml_free(secondary->eliminated_buffers);
+        cml_free(secondary);
         sched->groups[gj] = NULL;
     }
 
@@ -186,8 +187,8 @@ int cml_multi_output_fuse(CMLFusionSchedule* sched, int* merge_groups, int num_m
     sched->total_groups_after = write;
 
     if (sched->execution_order) {
-        free(sched->execution_order);
-        sched->execution_order = calloc((size_t)write, sizeof(int));
+        cml_free(sched->execution_order);
+        sched->execution_order = cml_calloc((size_t)write, sizeof(int));
         if (sched->execution_order) {
             for (int i = 0; i < write; i++)
                 sched->execution_order[i] = i;

--- a/src/ops/ir/nir_compiler.c
+++ b/src/ops/ir/nir_compiler.c
@@ -3,6 +3,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 #ifndef _WIN32
 #include <dlfcn.h>
@@ -95,7 +96,7 @@ CMLNIRCompiler* cml_nir_compiler_create(CMLNIRTarget target) {
         return NULL;
     }
 
-    CMLNIRCompiler* c = (CMLNIRCompiler*)calloc(1, sizeof(CMLNIRCompiler));
+    CMLNIRCompiler* c = (CMLNIRCompiler*)cml_calloc(1, sizeof(CMLNIRCompiler));
     if (!c) return NULL;
 
     c->target = target;
@@ -125,7 +126,7 @@ void cml_nir_compiler_free(CMLNIRCompiler* compiler) {
     if (!compiler) return;
 
     if (compiler->spirv_output) {
-        free(compiler->spirv_output);
+        cml_free(compiler->spirv_output);
         compiler->spirv_output = NULL;
     }
 
@@ -138,7 +139,7 @@ void cml_nir_compiler_free(CMLNIRCompiler* compiler) {
         compiler->mesa_lib = NULL;
     }
 
-    free(compiler);
+    cml_free(compiler);
 }
 
 int cml_nir_emit_uop(CMLNIRCompiler* compiler, UOpType op, int num_inputs) {
@@ -215,7 +216,7 @@ int cml_nir_compile(CMLNIRCompiler* compiler, CMLGraph_t ir) {
 
     /* Free any previous SPIR-V output */
     if (compiler->spirv_output) {
-        free(compiler->spirv_output);
+        cml_free(compiler->spirv_output);
         compiler->spirv_output = NULL;
         compiler->spirv_size = 0;
     }

--- a/src/ops/ir/opt_transforms.c
+++ b/src/ops/ir/opt_transforms.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include "alloc/cml_allocator.h"
 
 #define OPT_MAX_LOCAL_MEM    49152  /* 48 KiB typical GPU shared memory */
 #define OPT_MAX_WORKGROUP    1024
@@ -33,25 +34,25 @@ const char* cml_opt_type_name(CMLOptType type) {
 }
 
 CMLOptList* cml_opt_list_create(void) {
-    CMLOptList* list = calloc(1, sizeof(CMLOptList));
+    CMLOptList* list = cml_calloc(1, sizeof(CMLOptList));
     if (!list) return NULL;
     list->capacity = 8;
-    list->opts = calloc((size_t)list->capacity, sizeof(CMLOpt));
-    if (!list->opts) { free(list); return NULL; }
+    list->opts = cml_calloc((size_t)list->capacity, sizeof(CMLOpt));
+    if (!list->opts) { cml_free(list); return NULL; }
     return list;
 }
 
 void cml_opt_list_free(CMLOptList* list) {
     if (!list) return;
-    free(list->opts);
-    free(list);
+    cml_free(list->opts);
+    cml_free(list);
 }
 
 void cml_opt_list_add(CMLOptList* list, CMLOptType type, int axis, int amount) {
     if (!list) return;
     if (list->num_opts >= list->capacity) {
         int nc = list->capacity * 2;
-        CMLOpt* tmp = realloc(list->opts, (size_t)nc * sizeof(CMLOpt));
+        CMLOpt* tmp = cml_realloc(list->opts, (size_t)nc * sizeof(CMLOpt));
         if (!tmp) return;
         list->opts = tmp;
         list->capacity = nc;
@@ -76,7 +77,7 @@ static int prog_add_axis(LinearProgram* prog, int extent) {
     if (!prog) return -1;
     if (prog->num_axes >= prog->axes_capacity) {
         int nc = prog->axes_capacity * 2;
-        int* tmp = realloc(prog->loop_axes, (size_t)nc * sizeof(int));
+        int* tmp = cml_realloc(prog->loop_axes, (size_t)nc * sizeof(int));
         if (!tmp) return -1;
         prog->loop_axes = tmp;
         prog->axes_capacity = nc;
@@ -334,7 +335,7 @@ int cml_opt_enumerate(struct LinearProgram* prog, CMLOptList*** out_lists,
     if (!prog || !out_lists || !out_count || max_combinations <= 0) return -1;
 
     int cap = max_combinations;
-    CMLOptList** lists = calloc((size_t)cap, sizeof(CMLOptList*));
+    CMLOptList** lists = cml_calloc((size_t)cap, sizeof(CMLOptList*));
     if (!lists) return -1;
     int count = 0;
 

--- a/src/ops/ir/optimization.c
+++ b/src/ops/ir/optimization.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
+#include "alloc/cml_allocator.h"
 
 static struct IRNode* find_node_by_output(CMLGraph_t ir, const char* output_name) {
     if (!ir || !output_name)
@@ -30,7 +31,7 @@ static int build_dependency_graph(CMLGraph_t ir) {
     while (node) {
         node->use_count = 0;
         if (node->users) {
-            free(node->users);
+            cml_free(node->users);
             node->users          = NULL;
             node->users_capacity = 0;
         }
@@ -46,7 +47,7 @@ static int build_dependency_graph(CMLGraph_t ir) {
                     int new_capacity =
                         producer->users_capacity == 0 ? 4 : producer->users_capacity * 2;
                     struct IRNode** new_users =
-                        realloc(producer->users, (size_t)new_capacity * sizeof(struct IRNode*));
+                        cml_realloc(producer->users, (size_t)new_capacity * sizeof(struct IRNode*));
                     if (!new_users)
                         return -1;
                     producer->users          = new_users;
@@ -73,7 +74,7 @@ static void mark_reachable_nodes(CMLGraph_t ir) {
 
     int stack_capacity = 256;
     int stack_top = 0;
-    struct IRNode** stack = malloc((size_t)stack_capacity * sizeof(struct IRNode*));
+    struct IRNode** stack = cml_malloc((size_t)stack_capacity * sizeof(struct IRNode*));
     if (!stack) {
         LOG_ERROR("Failed to allocate DCE stack; marking all nodes as used");
         node = ir->head;
@@ -99,7 +100,7 @@ static void mark_reachable_nodes(CMLGraph_t ir) {
                 if (stack_top >= stack_capacity) {
                     int new_capacity = stack_capacity * 2;
                     struct IRNode** new_stack =
-                        realloc(stack, (size_t)new_capacity * sizeof(struct IRNode*));
+                        cml_realloc(stack, (size_t)new_capacity * sizeof(struct IRNode*));
                     if (!new_stack) {
                         LOG_ERROR("Failed to grow DCE stack; node will be kept as used");
                         producer->is_used = true;
@@ -113,7 +114,7 @@ static void mark_reachable_nodes(CMLGraph_t ir) {
         }
     }
 
-    free(stack);
+    cml_free(stack);
 }
 
 static int remove_dead_nodes(CMLGraph_t ir) {
@@ -147,42 +148,42 @@ static int remove_dead_nodes(CMLGraph_t ir) {
             if (node->input_names) {
                 for (int i = 0; i < node->num_inputs; i++) {
                     if (node->input_names[i]) {
-                        free(node->input_names[i]);
+                        cml_free(node->input_names[i]);
                     }
                 }
-                free(node->input_names);
+                cml_free(node->input_names);
             }
             if (node->output_name) {
-                free(node->output_name);
+                cml_free(node->output_name);
             }
             if (node->users) {
-                free(node->users);
+                cml_free(node->users);
             }
             if (node->inputs) {
-                free(node->inputs);
+                cml_free(node->inputs);
             }
             if (node->input_shapes) {
-                free(node->input_shapes);
+                cml_free(node->input_shapes);
             }
             if (node->input_ndims) {
-                free(node->input_ndims);
+                cml_free(node->input_ndims);
             }
             if (node->output_shape) {
-                free(node->output_shape);
+                cml_free(node->output_shape);
             }
             if (node->broadcast) {
                 if (node->broadcast->broadcast_dims) {
-                    free(node->broadcast->broadcast_dims);
+                    cml_free(node->broadcast->broadcast_dims);
                 }
                 if (node->broadcast->broadcast_strides) {
-                    free(node->broadcast->broadcast_strides);
+                    cml_free(node->broadcast->broadcast_strides);
                 }
-                free(node->broadcast);
+                cml_free(node->broadcast);
             }
             if (node->saved_for_backward) {
-                free(node->saved_for_backward);
+                cml_free(node->saved_for_backward);
             }
-            free(node);
+            cml_free(node);
 
             ir->node_count--;
             removed++;
@@ -322,13 +323,13 @@ static FusedKernel* create_fused_kernel(struct IRNode** ops, int num_ops, Fusion
     if (!ops || num_ops < 2)
         return NULL;
 
-    FusedKernel* kernel = malloc(sizeof(FusedKernel));
+    FusedKernel* kernel = cml_malloc(sizeof(FusedKernel));
     if (!kernel)
         return NULL;
 
-    kernel->ops = malloc((size_t)num_ops * sizeof(struct IRNode*));
+    kernel->ops = cml_malloc((size_t)num_ops * sizeof(struct IRNode*));
     if (!kernel->ops) {
-        free(kernel);
+        cml_free(kernel);
         return NULL;
     }
 
@@ -352,9 +353,9 @@ void free_fused_kernel(FusedKernel* kernel) {
                 kernel->ops[i]->fused_kernel = NULL;
             }
         }
-        free(kernel->ops);
+        cml_free(kernel->ops);
     }
-    free(kernel);
+    cml_free(kernel);
 }
 
 static char* find_other_input(struct IRNode* producer, struct IRNode* consumer) {
@@ -405,16 +406,16 @@ static int apply_fusion(struct IRNode* node1, struct IRNode* node2, FusionType f
             // Swap inputs
             if (node2->input_names[0] && node1->output_name &&
                 strcmp(node2->input_names[0], node1->output_name) == 0) {
-                free(node2->input_names[0]);
-                node2->input_names[0] = malloc(32);
+                cml_free(node2->input_names[0]);
+                node2->input_names[0] = cml_malloc(32);
                 if (node2->input_names[0]) {
                     strncpy(node2->input_names[0], other_input, 31);
                     node2->input_names[0][31] = '\0';
                 }
 
                 if (node2->num_inputs >= 2) {
-                    free(node2->input_names[1]);
-                    node2->input_names[1] = malloc(32);
+                    cml_free(node2->input_names[1]);
+                    node2->input_names[1] = cml_malloc(32);
                     if (node2->input_names[1] && node1->input_names[0]) {
                         strncpy(node2->input_names[1], node1->input_names[0], 31);
                         node2->input_names[1][31] = '\0';
@@ -630,13 +631,13 @@ static int reorder_for_cache_locality(CMLGraph_t ir) {
 
     ir->node_count = actual_count;
 
-    int* in_degree = calloc((size_t)actual_count, sizeof(int));
+    int* in_degree = cml_calloc((size_t)actual_count, sizeof(int));
     if (!in_degree)
         return -1;
 
-    struct IRNode** all_nodes = malloc((size_t)actual_count * sizeof(struct IRNode*));
+    struct IRNode** all_nodes = cml_malloc((size_t)actual_count * sizeof(struct IRNode*));
     if (!all_nodes) {
-        free(in_degree);
+        cml_free(in_degree);
         return -1;
     }
 
@@ -657,10 +658,10 @@ static int reorder_for_cache_locality(CMLGraph_t ir) {
         }
     }
 
-    struct IRNode** queue = malloc((size_t)ir->node_count * sizeof(struct IRNode*));
+    struct IRNode** queue = cml_malloc((size_t)ir->node_count * sizeof(struct IRNode*));
     if (!queue) {
-        free(in_degree);
-        free(all_nodes);
+        cml_free(in_degree);
+        cml_free(all_nodes);
         return -1;
     }
 
@@ -673,11 +674,11 @@ static int reorder_for_cache_locality(CMLGraph_t ir) {
         }
     }
 
-    struct IRNode** sorted = malloc((size_t)ir->node_count * sizeof(struct IRNode*));
+    struct IRNode** sorted = cml_malloc((size_t)ir->node_count * sizeof(struct IRNode*));
     if (!sorted) {
-        free(in_degree);
-        free(all_nodes);
-        free(queue);
+        cml_free(in_degree);
+        cml_free(all_nodes);
+        cml_free(queue);
         return -1;
     }
 
@@ -714,17 +715,17 @@ static int reorder_for_cache_locality(CMLGraph_t ir) {
         LOG_WARNING("Topological sort incomplete: %d/%d nodes sorted (possible cycle?)",
                     sorted_count, ir->node_count);
         // Don't reorder if sort failed
-        free(in_degree);
-        free(all_nodes);
-        free(queue);
-        free(sorted);
+        cml_free(in_degree);
+        cml_free(all_nodes);
+        cml_free(queue);
+        cml_free(sorted);
         return -1;
     }
 
-    free(in_degree);
-    free(all_nodes);
-    free(queue);
-    free(sorted);
+    cml_free(in_degree);
+    cml_free(all_nodes);
+    cml_free(queue);
+    cml_free(sorted);
 
     return 0;
 }

--- a/src/ops/ir/pattern_matcher.c
+++ b/src/ops/ir/pattern_matcher.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdatomic.h>
+#include "alloc/cml_allocator.h"
 
 /** Counter for generating unique output names for replacement nodes. */
 static atomic_int g_rewrite_counter = 0;
@@ -15,7 +16,7 @@ static atomic_int g_rewrite_counter = 0;
 /** Generate a unique name prefixed with "_rw" for rewrite-emitted nodes. */
 static char* rewrite_unique_name(void) {
     int id = atomic_fetch_add(&g_rewrite_counter, 1);
-    char* name = malloc(32);
+    char* name = cml_malloc(32);
     if (name) {
         snprintf(name, 32, "_rw%d", id);
     }
@@ -135,8 +136,8 @@ static void replace_output_references(CMLGraph_t ir,
     while (n) {
         for (int i = 0; i < n->num_inputs; i++) {
             if (n->input_names[i] && strcmp(n->input_names[i], old_name) == 0) {
-                free(n->input_names[i]);
-                n->input_names[i] = strdup(new_name);
+                cml_free(n->input_names[i]);
+                n->input_names[i] = cml_strdup(new_name);
             }
         }
         n = n->next;
@@ -224,12 +225,12 @@ static void free_unlinked_node(struct IRNode* node) {
 
     if (node->input_names) {
         for (int i = 0; i < node->num_inputs; i++) {
-            free(node->input_names[i]);
+            cml_free(node->input_names[i]);
         }
-        free(node->input_names);
+        cml_free(node->input_names);
     }
-    free(node->output_name);
-    free(node->users);
+    cml_free(node->output_name);
+    cml_free(node->users);
 
     /* Clear tensor's back-pointer to avoid dangling refs. */
     if (node->output) {
@@ -237,13 +238,13 @@ static void free_unlinked_node(struct IRNode* node) {
         node->output->ir_context = NULL;
     }
 
-    free(node);
+    cml_free(node);
 }
 
 CMLPatternNode* cml_pattern_op(UOpType type, CMLPatternNode** inputs, int num_inputs) {
     if (num_inputs < 0 || num_inputs > CML_PATTERN_MAX_INPUTS) return NULL;
 
-    CMLPatternNode* p = calloc(1, sizeof(CMLPatternNode));
+    CMLPatternNode* p = cml_calloc(1, sizeof(CMLPatternNode));
     if (!p) return NULL;
 
     p->kind = CML_PAT_OP;
@@ -259,7 +260,7 @@ CMLPatternNode* cml_pattern_op(UOpType type, CMLPatternNode** inputs, int num_in
 CMLPatternNode* cml_pattern_capture(const char* name) {
     if (!name) return NULL;
 
-    CMLPatternNode* p = calloc(1, sizeof(CMLPatternNode));
+    CMLPatternNode* p = cml_calloc(1, sizeof(CMLPatternNode));
     if (!p) return NULL;
 
     p->kind = CML_PAT_CAPTURE;
@@ -270,7 +271,7 @@ CMLPatternNode* cml_pattern_capture(const char* name) {
 }
 
 CMLPatternNode* cml_pattern_any(void) {
-    CMLPatternNode* p = calloc(1, sizeof(CMLPatternNode));
+    CMLPatternNode* p = cml_calloc(1, sizeof(CMLPatternNode));
     if (!p) return NULL;
 
     p->kind = CML_PAT_ANY;
@@ -284,11 +285,11 @@ void cml_pattern_free(CMLPatternNode* node) {
     for (int i = 0; i < node->num_inputs; i++) {
         cml_pattern_free(node->inputs[i]);
     }
-    free(node);
+    cml_free(node);
 }
 
 CMLRewriteRegistry* cml_rewrite_registry_create(void) {
-    CMLRewriteRegistry* reg = calloc(1, sizeof(CMLRewriteRegistry));
+    CMLRewriteRegistry* reg = cml_calloc(1, sizeof(CMLRewriteRegistry));
     return reg; /* num_rules is 0 thanks to calloc */
 }
 
@@ -299,7 +300,7 @@ void cml_rewrite_registry_free(CMLRewriteRegistry* reg) {
         cml_pattern_free(reg->rules[i].pattern);
         /* emit function pointer and name string literal are not owned */
     }
-    free(reg);
+    cml_free(reg);
 }
 
 int cml_rewrite_register(CMLRewriteRegistry* reg, CMLPatternNode* pattern,
@@ -447,7 +448,7 @@ static bool is_fill_const(struct IRNode* node, float value) {
 static struct IRNode* make_fill_node(CMLGraph_t ir, float value,
                                      struct IRNode* shape_donor) {
     (void)ir;
-    struct IRNode* node = calloc(1, sizeof(struct IRNode));
+    struct IRNode* node = cml_calloc(1, sizeof(struct IRNode));
     if (!node) return NULL;
 
     node->type = UOP_FILL;
@@ -456,20 +457,20 @@ static struct IRNode* make_fill_node(CMLGraph_t ir, float value,
     node->output_name = rewrite_unique_name();
     node->next = NULL;
 
-    FillParams* fp = malloc(sizeof(FillParams));
-    if (!fp) { free(node->output_name); free(node); return NULL; }
+    FillParams* fp = cml_malloc(sizeof(FillParams));
+    if (!fp) { cml_free(node->output_name); cml_free(node); return NULL; }
 
     fp->value = value;
 
     /* Copy shape from the shape_donor if available. */
     if (shape_donor && shape_donor->output_shape && shape_donor->output_ndim > 0) {
         fp->ndim = shape_donor->output_ndim;
-        fp->shape = malloc((size_t)fp->ndim * sizeof(int));
+        fp->shape = cml_malloc((size_t)fp->ndim * sizeof(int));
         if (fp->shape) {
             memcpy(fp->shape, shape_donor->output_shape,
                    (size_t)fp->ndim * sizeof(int));
         }
-        node->output_shape = malloc((size_t)fp->ndim * sizeof(int));
+        node->output_shape = cml_malloc((size_t)fp->ndim * sizeof(int));
         if (node->output_shape) {
             memcpy(node->output_shape, shape_donor->output_shape,
                    (size_t)fp->ndim * sizeof(int));
@@ -478,10 +479,10 @@ static struct IRNode* make_fill_node(CMLGraph_t ir, float value,
     } else {
         /* Scalar: shape = {1} */
         fp->ndim = 1;
-        fp->shape = malloc(sizeof(int));
+        fp->shape = cml_malloc(sizeof(int));
         if (fp->shape) fp->shape[0] = 1;
         node->output_ndim = 1;
-        node->output_shape = malloc(sizeof(int));
+        node->output_shape = cml_malloc(sizeof(int));
         if (node->output_shape) node->output_shape[0] = 1;
     }
 
@@ -641,18 +642,18 @@ static struct IRNode* emit_mul_two(CMLGraph_t ir, const CMLMatchResult* m) {
     if (!x_name) return NULL;
 
     /* Create ADD(x, x) */
-    struct IRNode* node = calloc(1, sizeof(struct IRNode));
+    struct IRNode* node = cml_calloc(1, sizeof(struct IRNode));
     if (!node) return NULL;
     node->type = UOP_ADD;
     node->num_inputs = 2;
-    node->input_names = malloc(2 * sizeof(char*));
-    if (!node->input_names) { free(node); return NULL; }
-    node->input_names[0] = strdup(x_name);
-    node->input_names[1] = strdup(x_name);
+    node->input_names = cml_malloc(2 * sizeof(char*));
+    if (!node->input_names) { cml_free(node); return NULL; }
+    node->input_names[0] = cml_strdup(x_name);
+    node->input_names[1] = cml_strdup(x_name);
     node->output_name = rewrite_unique_name();
     node->output_ndim = root->output_ndim;
     if (root->output_shape && root->output_ndim > 0) {
-        node->output_shape = malloc((size_t)root->output_ndim * sizeof(int));
+        node->output_shape = cml_malloc((size_t)root->output_ndim * sizeof(int));
         if (node->output_shape)
             memcpy(node->output_shape, root->output_shape,
                    (size_t)root->output_ndim * sizeof(int));
@@ -686,18 +687,18 @@ static struct IRNode* emit_div_const(CMLGraph_t ir, const CMLMatchResult* m) {
     /* Create MUL(x, recip) node */
     insert_node_before(ir, recip_node, root);
 
-    struct IRNode* mul_node = calloc(1, sizeof(struct IRNode));
+    struct IRNode* mul_node = cml_calloc(1, sizeof(struct IRNode));
     if (!mul_node) return NULL;
     mul_node->type = UOP_MUL;
     mul_node->num_inputs = 2;
-    mul_node->input_names = malloc(2 * sizeof(char*));
-    if (!mul_node->input_names) { free(mul_node); return NULL; }
-    mul_node->input_names[0] = strdup(root->input_names[0]);
-    mul_node->input_names[1] = strdup(recip_node->output_name);
+    mul_node->input_names = cml_malloc(2 * sizeof(char*));
+    if (!mul_node->input_names) { cml_free(mul_node); return NULL; }
+    mul_node->input_names[0] = cml_strdup(root->input_names[0]);
+    mul_node->input_names[1] = cml_strdup(recip_node->output_name);
     mul_node->output_name = rewrite_unique_name();
     mul_node->output_ndim = root->output_ndim;
     if (root->output_shape && root->output_ndim > 0) {
-        mul_node->output_shape = malloc((size_t)root->output_ndim * sizeof(int));
+        mul_node->output_shape = cml_malloc((size_t)root->output_ndim * sizeof(int));
         if (mul_node->output_shape)
             memcpy(mul_node->output_shape, root->output_shape,
                    (size_t)root->output_ndim * sizeof(int));
@@ -871,9 +872,9 @@ int cml_rewrite_dce(CMLGraph_t ir) {
     if (count == 0) return 0;
 
     /* Build node array for indexed access + visited flags */
-    struct IRNode** nodes = malloc((size_t)count * sizeof(struct IRNode*));
-    bool* marked = calloc((size_t)count, sizeof(bool));
-    if (!nodes || !marked) { free(nodes); free(marked); return -1; }
+    struct IRNode** nodes = cml_malloc((size_t)count * sizeof(struct IRNode*));
+    bool* marked = cml_calloc((size_t)count, sizeof(bool));
+    if (!nodes || !marked) { cml_free(nodes); cml_free(marked); return -1; }
 
     int idx = 0;
     n = ir->head;
@@ -881,9 +882,9 @@ int cml_rewrite_dce(CMLGraph_t ir) {
 
     /* Mark phase: start from tail + any node with a live tensor reference */
     /* Use a simple worklist approach */
-    int* worklist = malloc((size_t)count * sizeof(int));
+    int* worklist = cml_malloc((size_t)count * sizeof(int));
     int wl_head = 0, wl_tail = 0;
-    if (!worklist) { free(nodes); free(marked); return -1; }
+    if (!worklist) { cml_free(nodes); cml_free(marked); return -1; }
 
     for (int i = 0; i < count; i++) {
         /* Mark output nodes and nodes with live tensor references */
@@ -925,9 +926,9 @@ int cml_rewrite_dce(CMLGraph_t ir) {
         }
     }
 
-    free(worklist);
-    free(nodes);
-    free(marked);
+    cml_free(worklist);
+    cml_free(nodes);
+    cml_free(marked);
 
     if (removed > 0) {
     }

--- a/src/ops/ir/process_replay.c
+++ b/src/ops/ir/process_replay.c
@@ -10,6 +10,7 @@
 #include <time.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "alloc/cml_allocator.h"
 
 #define FNV_OFFSET_BASIS 0xcbf29ce484222325ULL
 #define FNV_PRIME 0x100000001b3ULL
@@ -121,7 +122,7 @@ static int read_kernel_file(const char* path, char** out_source, size_t* out_len
         return -1;
     }
 
-    char* buf = malloc((size_t)total + 1);
+    char* buf = cml_malloc((size_t)total + 1);
     if (!buf) {
         fclose(f);
         return -1;
@@ -133,23 +134,23 @@ static int read_kernel_file(const char* path, char** out_source, size_t* out_len
 
     char* sep = strstr(buf, "---\n");
     if (!sep) {
-        free(buf);
+        cml_free(buf);
         return -1;
     }
 
     char* body = sep + 4;
     size_t body_len = read - (size_t)(body - buf);
 
-    *out_source = malloc(body_len + 1);
+    *out_source = cml_malloc(body_len + 1);
     if (!*out_source) {
-        free(buf);
+        cml_free(buf);
         return -1;
     }
     memcpy(*out_source, body, body_len);
     (*out_source)[body_len] = '\0';
     *out_len = body_len;
 
-    free(buf);
+    cml_free(buf);
     return 0;
 }
 
@@ -189,7 +190,7 @@ int cml_process_replay_compare(const char* output_dir, const char* baseline_dir)
 
         if (read_kernel_file(output_path, &output_src, &output_len) != 0) {
             LOG_ERROR("Process replay: missing output for %s", ent->d_name);
-            free(baseline_src);
+            cml_free(baseline_src);
             mismatches++;
             continue;
         }
@@ -201,8 +202,8 @@ int cml_process_replay_compare(const char* output_dir, const char* baseline_dir)
             mismatches++;
         }
 
-        free(baseline_src);
-        free(output_src);
+        cml_free(baseline_src);
+        cml_free(output_src);
     }
 
     closedir(dir);

--- a/src/ops/ir/rangeify.c
+++ b/src/ops/ir/rangeify.c
@@ -5,9 +5,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include "alloc/cml_allocator.h"
 
 RangeProgram* range_program_create(void) {
-    RangeProgram* prog = calloc(1, sizeof(RangeProgram));
+    RangeProgram* prog = cml_calloc(1, sizeof(RangeProgram));
     if (!prog) return NULL;
     prog->next_id = 0;
     return prog;
@@ -18,14 +19,14 @@ void range_program_free(RangeProgram* prog) {
     RangeNode* cur = prog->head;
     while (cur) {
         RangeNode* next = cur->next;
-        free(cur);
+        cml_free(cur);
         cur = next;
     }
-    free(prog);
+    cml_free(prog);
 }
 
 static RangeNode* alloc_node(RangeProgram* prog, RangeUOpType type) {
-    RangeNode* node = calloc(1, sizeof(RangeNode));
+    RangeNode* node = cml_calloc(1, sizeof(RangeNode));
     if (!node) return NULL;
     node->type = type;
     node->id = prog->next_id++;
@@ -86,7 +87,7 @@ void range_program_print(const RangeProgram* prog) {
 
 static size_t* compute_strides_for_shape(const int* shape, int ndim) {
     if (!shape || ndim <= 0) return NULL;
-    size_t* strides = malloc((size_t)ndim * sizeof(size_t));
+    size_t* strides = cml_malloc((size_t)ndim * sizeof(size_t));
     if (!strides) return NULL;
     strides[ndim - 1] = 1;
     for (int i = ndim - 2; i >= 0; i--)
@@ -155,10 +156,10 @@ static RangeProgram* rangeify_node(struct IRNode* node) {
 
         if (count > 0)
             range_program_add_index(prog, inp_range_ids, inp_effective_strides, count);
-        free(inp_strides);
+        cml_free(inp_strides);
     }
 
-    free(out_strides);
+    cml_free(out_strides);
     return prog;
 }
 

--- a/src/ops/ir/runtime_compiler.c
+++ b/src/ops/ir/runtime_compiler.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <time.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 #define FNV_OFFSET 0xcbf29ce484222325ULL
 #define FNV_PRIME  0x100000001b3ULL
@@ -42,7 +43,7 @@ static uint64_t hash_linear_program(const CMLLinearProgram* prog) {
 }
 
 CMLRuntimeCompiler* cml_runtime_compiler_create(void) {
-    CMLRuntimeCompiler* rc = calloc(1, sizeof(CMLRuntimeCompiler));
+    CMLRuntimeCompiler* rc = cml_calloc(1, sizeof(CMLRuntimeCompiler));
     if (!rc) return NULL;
     rc->preferred_backend = CML_FUSED_BACKEND_C;
     rc->enable_caching = true;
@@ -55,12 +56,12 @@ void cml_runtime_compiler_free(CMLRuntimeCompiler* rc) {
     for (int i = 0; i < CML_COMPILED_CACHE_SIZE; i++) {
         CMLCompiledKernel* k = &rc->cache[i];
         if (k->valid) {
-            free(k->source);
-            free(k->binary);
-            free(k->ops);
+            cml_free(k->source);
+            cml_free(k->binary);
+            cml_free(k->ops);
         }
     }
-    free(rc);
+    cml_free(rc);
 }
 
 static CMLCompiledKernel* cache_lookup(CMLRuntimeCompiler* rc, uint64_t hash) {
@@ -87,9 +88,9 @@ static CMLCompiledKernel* cache_insert(CMLRuntimeCompiler* rc, uint64_t hash) {
         }
     }
     CMLCompiledKernel* k = &rc->cache[hash % CML_COMPILED_CACHE_SIZE];
-    free(k->source);
-    free(k->binary);
-    free(k->ops);
+    cml_free(k->source);
+    cml_free(k->binary);
+    cml_free(k->ops);
     memset(k, 0, sizeof(*k));
     k->hash = hash;
     k->valid = true;
@@ -137,7 +138,7 @@ const CMLCompiledKernel* cml_runtime_compile_program(CMLRuntimeCompiler* rc,
     entry->work_size = work_size;
 
     if (prog->num_ops > 0) {
-        entry->ops = malloc((size_t)prog->num_ops * sizeof(CMLLinearOp));
+        entry->ops = cml_malloc((size_t)prog->num_ops * sizeof(CMLLinearOp));
         if (entry->ops) {
             memcpy(entry->ops, prog->ops, (size_t)prog->num_ops * sizeof(CMLLinearOp));
             entry->num_ops = prog->num_ops;
@@ -381,9 +382,9 @@ void cml_runtime_compiler_clear_cache(CMLRuntimeCompiler* rc) {
     for (int i = 0; i < CML_COMPILED_CACHE_SIZE; i++) {
         CMLCompiledKernel* k = &rc->cache[i];
         if (k->valid) {
-            free(k->source);
-            free(k->binary);
-            free(k->ops);
+            cml_free(k->source);
+            cml_free(k->binary);
+            cml_free(k->ops);
             memset(k, 0, sizeof(*k));
         }
     }

--- a/src/ops/ir/schedule.c
+++ b/src/ops/ir/schedule.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include "alloc/cml_allocator.h"
 
 bool cml_schedule_is_elementwise(UOpType type) {
     switch (type) {
@@ -120,12 +121,12 @@ CMLScheduleOptions cml_schedule_default_options(void) {
 }
 
 static CMLScheduleItem* sched_item_create(CMLScheduleItemType type) {
-    CMLScheduleItem* item = calloc(1, sizeof(CMLScheduleItem));
+    CMLScheduleItem* item = cml_calloc(1, sizeof(CMLScheduleItem));
     if (!item) return NULL;
     item->type        = type;
     item->op_capacity = 8;
-    item->ops         = calloc((size_t)item->op_capacity, sizeof(struct IRNode*));
-    if (!item->ops) { free(item); return NULL; }
+    item->ops         = cml_calloc((size_t)item->op_capacity, sizeof(struct IRNode*));
+    if (!item->ops) { cml_free(item); return NULL; }
     item->num_ops     = 0;
     item->inputs      = NULL;
     item->num_inputs  = 0;
@@ -140,7 +141,7 @@ static int sched_item_add_op(CMLScheduleItem* item, struct IRNode* node) {
     if (!item || !node) return -1;
     if (item->num_ops >= item->op_capacity) {
         int new_cap = item->op_capacity * 2;
-        struct IRNode** tmp = realloc(item->ops,
+        struct IRNode** tmp = cml_realloc(item->ops,
                                       (size_t)new_cap * sizeof(struct IRNode*));
         if (!tmp) return -1;
         item->ops = tmp;
@@ -152,10 +153,10 @@ static int sched_item_add_op(CMLScheduleItem* item, struct IRNode* node) {
 
 static void sched_item_free(CMLScheduleItem* item) {
     if (!item) return;
-    free(item->ops);
-    free(item->inputs);
-    free(item->outputs);
-    free(item);
+    cml_free(item->ops);
+    cml_free(item->inputs);
+    cml_free(item->outputs);
+    cml_free(item);
 }
 
 static void compute_item_io(CMLScheduleItem* item) {
@@ -163,7 +164,7 @@ static void compute_item_io(CMLScheduleItem* item) {
 
     
     int out_cap = item->num_ops;
-    Tensor** produced = calloc((size_t)out_cap, sizeof(Tensor*));
+    Tensor** produced = cml_calloc((size_t)out_cap, sizeof(Tensor*));
     int num_produced = 0;
     if (!produced) return;
 
@@ -176,9 +177,9 @@ static void compute_item_io(CMLScheduleItem* item) {
 
     
     int in_cap = 8;
-    Tensor** ext_in = calloc((size_t)in_cap, sizeof(Tensor*));
+    Tensor** ext_in = cml_calloc((size_t)in_cap, sizeof(Tensor*));
     int num_ext = 0;
-    if (!ext_in) { free(produced); return; }
+    if (!ext_in) { cml_free(produced); return; }
 
     for (int i = 0; i < item->num_ops; i++) {
         struct IRNode* nd = item->ops[i];
@@ -200,8 +201,8 @@ static void compute_item_io(CMLScheduleItem* item) {
             if (dup) continue;
             if (num_ext >= in_cap) {
                 in_cap *= 2;
-                Tensor** tmp = realloc(ext_in, (size_t)in_cap * sizeof(Tensor*));
-                if (!tmp) { free(produced); free(ext_in); return; }
+                Tensor** tmp = cml_realloc(ext_in, (size_t)in_cap * sizeof(Tensor*));
+                if (!tmp) { cml_free(produced); cml_free(ext_in); return; }
                 ext_in = tmp;
             }
             ext_in[num_ext++] = t;
@@ -317,8 +318,8 @@ static void estimate_item_cost(CMLScheduleItem* item) {
 static void build_dependencies(CMLSchedule* sched) {
     if (!sched || sched->num_items == 0) return;
 
-    sched->dependencies = calloc((size_t)sched->num_items, sizeof(int*));
-    sched->dep_counts   = calloc((size_t)sched->num_items, sizeof(int));
+    sched->dependencies = cml_calloc((size_t)sched->num_items, sizeof(int*));
+    sched->dep_counts   = cml_calloc((size_t)sched->num_items, sizeof(int));
     if (!sched->dependencies || !sched->dep_counts) return;
 
     for (int i = 0; i < sched->num_items; i++) {
@@ -326,7 +327,7 @@ static void build_dependencies(CMLSchedule* sched) {
         if (!consumer) continue;
 
         int dep_cap  = 4;
-        int* deps    = calloc((size_t)dep_cap, sizeof(int));
+        int* deps    = cml_calloc((size_t)dep_cap, sizeof(int));
         int dep_cnt  = 0;
         if (!deps) continue;
 
@@ -345,7 +346,7 @@ static void build_dependencies(CMLSchedule* sched) {
             if (found) {
                 if (dep_cnt >= dep_cap) {
                     dep_cap *= 2;
-                    int* tmp = realloc(deps, (size_t)dep_cap * sizeof(int));
+                    int* tmp = cml_realloc(deps, (size_t)dep_cap * sizeof(int));
                     if (!tmp) break;
                     deps = tmp;
                 }
@@ -365,7 +366,7 @@ CMLSchedule* cml_schedule_create(CMLGraph_t graph, const CMLScheduleOptions* opt
         opts = &default_opts;
     }
 
-    CMLSchedule* sched = calloc(1, sizeof(CMLSchedule));
+    CMLSchedule* sched = cml_calloc(1, sizeof(CMLSchedule));
     if (!sched) return NULL;
 
     
@@ -385,8 +386,8 @@ CMLSchedule* cml_schedule_create(CMLGraph_t graph, const CMLScheduleOptions* opt
 
     
     int cap = graph->node_count < 16 ? 16 : graph->node_count;
-    sched->items = calloc((size_t)cap, sizeof(CMLScheduleItem*));
-    if (!sched->items) { free(sched); return NULL; }
+    sched->items = cml_calloc((size_t)cap, sizeof(CMLScheduleItem*));
+    if (!sched->items) { cml_free(sched); return NULL; }
     sched->item_capacity = cap;
     sched->num_items     = 0;
 
@@ -414,7 +415,7 @@ CMLSchedule* cml_schedule_create(CMLGraph_t graph, const CMLScheduleOptions* opt
                     
                     if (sched->num_items >= sched->item_capacity) {
                         int nc = sched->item_capacity * 2;
-                        CMLScheduleItem** tmp = realloc(
+                        CMLScheduleItem** tmp = cml_realloc(
                             sched->items, (size_t)nc * sizeof(CMLScheduleItem*));
                         if (tmp) { sched->items = tmp; sched->item_capacity = nc; }
                     }
@@ -440,7 +441,7 @@ CMLSchedule* cml_schedule_create(CMLGraph_t graph, const CMLScheduleOptions* opt
                 
                 if (sched->num_items >= sched->item_capacity) {
                     int nc = sched->item_capacity * 2;
-                    CMLScheduleItem** tmp = realloc(
+                    CMLScheduleItem** tmp = cml_realloc(
                         sched->items, (size_t)nc * sizeof(CMLScheduleItem*));
                     if (tmp) { sched->items = tmp; sched->item_capacity = nc; }
                 }
@@ -470,7 +471,7 @@ CMLSchedule* cml_schedule_create(CMLGraph_t graph, const CMLScheduleOptions* opt
                         cur = NULL;
                         if (sched->num_items >= sched->item_capacity) {
                             int nc = sched->item_capacity * 2;
-                            CMLScheduleItem** tmp = realloc(
+                            CMLScheduleItem** tmp = cml_realloc(
                                 sched->items,
                                 (size_t)nc * sizeof(CMLScheduleItem*));
                             if (tmp) {
@@ -484,7 +485,7 @@ CMLSchedule* cml_schedule_create(CMLGraph_t graph, const CMLScheduleOptions* opt
                     
                     if (sched->num_items >= sched->item_capacity) {
                         int nc = sched->item_capacity * 2;
-                        CMLScheduleItem** tmp = realloc(
+                        CMLScheduleItem** tmp = cml_realloc(
                             sched->items,
                             (size_t)nc * sizeof(CMLScheduleItem*));
                         if (tmp) {
@@ -501,7 +502,7 @@ CMLSchedule* cml_schedule_create(CMLGraph_t graph, const CMLScheduleOptions* opt
                         sched_item_add_op(red, node);
                         if (sched->num_items >= sched->item_capacity) {
                             int nc = sched->item_capacity * 2;
-                            CMLScheduleItem** tmp = realloc(
+                            CMLScheduleItem** tmp = cml_realloc(
                                 sched->items,
                                 (size_t)nc * sizeof(CMLScheduleItem*));
                             if (tmp) {
@@ -519,7 +520,7 @@ CMLSchedule* cml_schedule_create(CMLGraph_t graph, const CMLScheduleOptions* opt
                     sched_item_add_op(red, node);
                     if (sched->num_items >= sched->item_capacity) {
                         int nc = sched->item_capacity * 2;
-                        CMLScheduleItem** tmp = realloc(
+                        CMLScheduleItem** tmp = cml_realloc(
                             sched->items,
                             (size_t)nc * sizeof(CMLScheduleItem*));
                         if (tmp) {
@@ -538,7 +539,7 @@ CMLSchedule* cml_schedule_create(CMLGraph_t graph, const CMLScheduleOptions* opt
             if (cur) {
                 if (sched->num_items >= sched->item_capacity) {
                     int nc = sched->item_capacity * 2;
-                    CMLScheduleItem** tmp = realloc(
+                    CMLScheduleItem** tmp = cml_realloc(
                         sched->items,
                         (size_t)nc * sizeof(CMLScheduleItem*));
                     if (tmp) { sched->items = tmp; sched->item_capacity = nc; }
@@ -554,7 +555,7 @@ CMLSchedule* cml_schedule_create(CMLGraph_t graph, const CMLScheduleOptions* opt
         if (cur) {
             if (sched->num_items >= sched->item_capacity) {
                 int nc = sched->item_capacity * 2;
-                CMLScheduleItem** tmp = realloc(
+                CMLScheduleItem** tmp = cml_realloc(
                     sched->items,
                     (size_t)nc * sizeof(CMLScheduleItem*));
                 if (tmp) { sched->items = tmp; sched->item_capacity = nc; }
@@ -568,7 +569,7 @@ CMLSchedule* cml_schedule_create(CMLGraph_t graph, const CMLScheduleOptions* opt
                 sched_item_add_op(cust, node);
                 if (sched->num_items >= sched->item_capacity) {
                     int nc = sched->item_capacity * 2;
-                    CMLScheduleItem** tmp = realloc(
+                    CMLScheduleItem** tmp = cml_realloc(
                         sched->items,
                         (size_t)nc * sizeof(CMLScheduleItem*));
                     if (tmp) { sched->items = tmp; sched->item_capacity = nc; }
@@ -583,7 +584,7 @@ CMLSchedule* cml_schedule_create(CMLGraph_t graph, const CMLScheduleOptions* opt
     if (cur) {
         if (sched->num_items >= sched->item_capacity) {
             int nc = sched->item_capacity * 2;
-            CMLScheduleItem** tmp = realloc(
+            CMLScheduleItem** tmp = cml_realloc(
                 sched->items, (size_t)nc * sizeof(CMLScheduleItem*));
             if (tmp) { sched->items = tmp; sched->item_capacity = nc; }
         }
@@ -696,7 +697,7 @@ char* cml_schedule_to_string(const CMLSchedule* sched) {
         }
     }
 
-    char* buf = malloc(buf_size);
+    char* buf = cml_malloc(buf_size);
     if (!buf) return NULL;
 
     int off = 0;
@@ -739,14 +740,14 @@ void cml_schedule_free(CMLSchedule* sched) {
     for (int i = 0; i < sched->num_items; i++) {
         sched_item_free(sched->items[i]);
     }
-    free(sched->items);
+    cml_free(sched->items);
 
     if (sched->dependencies) {
         for (int i = 0; i < sched->num_items; i++) {
-            free(sched->dependencies[i]);
+            cml_free(sched->dependencies[i]);
         }
-        free(sched->dependencies);
+        cml_free(sched->dependencies);
     }
-    free(sched->dep_counts);
-    free(sched);
+    cml_free(sched->dep_counts);
+    cml_free(sched);
 }

--- a/src/ops/ir/schedule_allreduce.c
+++ b/src/ops/ir/schedule_allreduce.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 static AllReduceAlgo choose_algo(size_t bytes, int ndevices) {
     
@@ -24,7 +25,7 @@ static int build_ring_steps(ScheduleAllReduce* ar) {
 
     
     int num_steps = 2 * (n - 1);
-    ar->steps = calloc((size_t)num_steps, sizeof(AllReduceStep));
+    ar->steps = cml_calloc((size_t)num_steps, sizeof(AllReduceStep));
     if (!ar->steps) return -1;
 
     int s = 0;
@@ -63,7 +64,7 @@ static int build_ring_steps(ScheduleAllReduce* ar) {
 static int build_flat_steps(ScheduleAllReduce* ar) {
     int n = ar->num_devices;
     int ns = 2 * (n - 1);
-    ar->steps = calloc((size_t)ns, sizeof(AllReduceStep));
+    ar->steps = cml_calloc((size_t)ns, sizeof(AllReduceStep));
     if (!ar->steps) return -1;
     int s = 0;
     for (int rank = 1; rank < n; ++rank) {
@@ -98,7 +99,7 @@ static int build_recursive_halving_steps(ScheduleAllReduce* ar) {
     while (tmp > 1) { rounds++; tmp >>= 1; }
 
     int ns = rounds * (n / 2) * 2;
-    ar->steps = calloc((size_t)(ns + 1), sizeof(AllReduceStep));
+    ar->steps = cml_calloc((size_t)(ns + 1), sizeof(AllReduceStep));
     if (!ar->steps) return -1;
 
     int s = 0;
@@ -142,7 +143,7 @@ ScheduleAllReduce* schedule_allreduce_build(Tensor* t,
                                              int num_devices) {
     if (!t || !device_ids || num_devices <= 0) return NULL;
 
-    ScheduleAllReduce* ar = calloc(1, sizeof(ScheduleAllReduce));
+    ScheduleAllReduce* ar = cml_calloc(1, sizeof(ScheduleAllReduce));
     if (!ar) return NULL;
 
     ar->input       = t;
@@ -151,7 +152,7 @@ ScheduleAllReduce* schedule_allreduce_build(Tensor* t,
     ar->num_devices = num_devices;
     ar->buffer_bytes = t->numel * cml_dtype_size(t->dtype);
 
-    ar->device_ids  = malloc((size_t)num_devices * sizeof(int));
+    ar->device_ids  = cml_malloc((size_t)num_devices * sizeof(int));
     if (!ar->device_ids) { schedule_allreduce_free(ar); return NULL; }
     memcpy(ar->device_ids, device_ids, (size_t)num_devices * sizeof(int));
 
@@ -173,10 +174,10 @@ ScheduleAllReduce* schedule_allreduce_build(Tensor* t,
 
 void schedule_allreduce_free(ScheduleAllReduce* ar) {
     if (!ar) return;
-    free(ar->device_ids);
-    free(ar->steps);
-    free(ar->overlap_kernels);
-    free(ar);
+    cml_free(ar->device_ids);
+    cml_free(ar->steps);
+    cml_free(ar->overlap_kernels);
+    cml_free(ar);
 }
 
 int schedule_allreduce_run(ScheduleAllReduce* ar) {

--- a/src/ops/ir/schedule_indexing.c
+++ b/src/ops/ir/schedule_indexing.c
@@ -3,10 +3,11 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include "alloc/cml_allocator.h"
 
 IndexMap* index_map_create(SymExpr* flat_index, SymExpr* valid, int num_vars) {
     if (!flat_index) return NULL;
-    IndexMap* im = calloc(1, sizeof(IndexMap));
+    IndexMap* im = cml_calloc(1, sizeof(IndexMap));
     if (!im) return NULL;
     sym_expr_retain(flat_index);
     im->flat_index = flat_index;
@@ -22,7 +23,7 @@ void index_map_free(IndexMap* im) {
     if (!im) return;
     sym_expr_release(im->flat_index);
     if (im->valid) sym_expr_release(im->valid);
-    free(im);
+    cml_free(im);
 }
 
 IndexMap* index_map_copy(const IndexMap* im) {
@@ -32,7 +33,7 @@ IndexMap* index_map_copy(const IndexMap* im) {
 
 LoopVar* loop_vars_create(const int* shape, int n) {
     if (!shape || n <= 0) return NULL;
-    LoopVar* vars = malloc((size_t)n * sizeof(LoopVar));
+    LoopVar* vars = cml_malloc((size_t)n * sizeof(LoopVar));
     if (!vars) return NULL;
     for (int i = 0; i < n; ++i) {
         char name[16];
@@ -42,7 +43,7 @@ LoopVar* loop_vars_create(const int* shape, int n) {
         vars[i].end   = shape[i];
         if (!vars[i].expr) {
             for (int j = 0; j < i; ++j) sym_expr_release(vars[j].expr);
-            free(vars);
+            cml_free(vars);
             return NULL;
         }
     }
@@ -53,7 +54,7 @@ void loop_vars_free(LoopVar* vars, int n) {
     if (!vars) return;
     for (int i = 0; i < n; ++i)
         sym_expr_release(vars[i].expr);
-    free(vars);
+    cml_free(vars);
 }
 
 static SymExpr* view_flat_index(const STView* v, const LoopVar* vars, int nvars) {

--- a/src/ops/ir/schedule_multi.c
+++ b/src/ops/ir/schedule_multi.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include "alloc/cml_allocator.h"
 
 static bool tensor_on_device(const Tensor* t, int device_id) __attribute__((unused));
 static bool tensor_on_device(const Tensor* t, int device_id) {
@@ -20,7 +21,7 @@ static int device_for_tensor(const Tensor* t, const int* device_ids, int n) {
 static CrossDeviceOp* xfer_create(XferDirection dir, int src, int dst, Tensor* t) __attribute__((unused));
 static CrossDeviceOp* xfer_create(XferDirection dir,
                                   int src, int dst, Tensor* t) {
-    CrossDeviceOp* op = calloc(1, sizeof(CrossDeviceOp));
+    CrossDeviceOp* op = cml_calloc(1, sizeof(CrossDeviceOp));
     if (!op) return NULL;
     op->direction    = dir;
     op->src_device_id = src;
@@ -42,30 +43,30 @@ MultiDeviceSchedule* multi_schedule_build(CMLSchedule* sched,
                                           int num_devices) {
     if (!sched || !device_ids || num_devices <= 0) return NULL;
 
-    MultiDeviceSchedule* ms = calloc(1, sizeof(MultiDeviceSchedule));
+    MultiDeviceSchedule* ms = cml_calloc(1, sizeof(MultiDeviceSchedule));
     if (!ms) return NULL;
 
     ms->num_devices    = num_devices;
-    ms->device_ids     = malloc((size_t)num_devices * sizeof(int));
-    ms->device_schedules = calloc((size_t)num_devices, sizeof(CMLSchedule*));
+    ms->device_ids     = cml_malloc((size_t)num_devices * sizeof(int));
+    ms->device_schedules = cml_calloc((size_t)num_devices, sizeof(CMLSchedule*));
     if (!ms->device_ids || !ms->device_schedules) goto fail;
     memcpy(ms->device_ids, device_ids, (size_t)num_devices * sizeof(int));
 
     for (int d = 0; d < num_devices; ++d) {
-        ms->device_schedules[d] = calloc(1, sizeof(CMLSchedule));
+        ms->device_schedules[d] = cml_calloc(1, sizeof(CMLSchedule));
         if (!ms->device_schedules[d]) goto fail;
-        ms->device_schedules[d]->items = malloc(
+        ms->device_schedules[d]->items = cml_malloc(
             (size_t)sched->num_items * sizeof(CMLScheduleItem*));
         if (!ms->device_schedules[d]->items) goto fail;
         ms->device_schedules[d]->item_capacity = sched->num_items;
     }
 
     int max_xfer = sched->num_items * 2;
-    ms->xfer_ops = calloc((size_t)max_xfer, sizeof(CrossDeviceOp));
+    ms->xfer_ops = cml_calloc((size_t)max_xfer, sizeof(CrossDeviceOp));
     if (!ms->xfer_ops) goto fail;
 
     int max_steps = sched->num_items * 3;
-    ms->steps = malloc((size_t)max_steps * sizeof(ms->steps[0]));
+    ms->steps = cml_malloc((size_t)max_steps * sizeof(ms->steps[0]));
     if (!ms->steps) goto fail;
 
     for (int i = 0; i < sched->num_items; ++i) {
@@ -121,16 +122,16 @@ void multi_schedule_free(MultiDeviceSchedule* ms) {
     if (ms->device_schedules) {
         for (int d = 0; d < ms->num_devices; ++d) {
             if (ms->device_schedules[d]) {
-                free(ms->device_schedules[d]->items);
-                free(ms->device_schedules[d]);
+                cml_free(ms->device_schedules[d]->items);
+                cml_free(ms->device_schedules[d]);
             }
         }
-        free(ms->device_schedules);
+        cml_free(ms->device_schedules);
     }
-    free(ms->device_ids);
-    free(ms->xfer_ops);
-    free(ms->steps);
-    free(ms);
+    cml_free(ms->device_ids);
+    cml_free(ms->xfer_ops);
+    cml_free(ms->steps);
+    cml_free(ms);
 }
 
 int multi_schedule_run(MultiDeviceSchedule* ms) {

--- a/src/ops/ir/spec.c
+++ b/src/ops/ir/spec.c
@@ -5,14 +5,15 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include "alloc/cml_allocator.h"
 
 static CMLSpecResult* spec_result_create(void) {
-    CMLSpecResult* r = calloc(1, sizeof(CMLSpecResult));
+    CMLSpecResult* r = cml_calloc(1, sizeof(CMLSpecResult));
     if (!r) return NULL;
     r->valid = true;
     r->capacity = 8;
-    r->errors = calloc((size_t)r->capacity, sizeof(CMLSpecError));
-    if (!r->errors) { free(r); return NULL; }
+    r->errors = cml_calloc((size_t)r->capacity, sizeof(CMLSpecError));
+    if (!r->errors) { cml_free(r); return NULL; }
     return r;
 }
 
@@ -22,7 +23,7 @@ static void spec_add_error(CMLSpecResult* r, int node_id,
     r->valid = false;
     if (r->num_errors >= r->capacity) {
         int nc = r->capacity * 2;
-        CMLSpecError* tmp = realloc(r->errors, (size_t)nc * sizeof(CMLSpecError));
+        CMLSpecError* tmp = cml_realloc(r->errors, (size_t)nc * sizeof(CMLSpecError));
         if (!tmp) return;
         r->errors = tmp;
         r->capacity = nc;
@@ -104,7 +105,7 @@ static void validate_tensor_level(CMLGraph_t graph, CMLSpecResult* result) {
     struct IRNode* node = graph->head;
     int idx = 0;
     int visited_cap = graph->node_count > 0 ? graph->node_count : 16;
-    struct IRNode** visited = calloc((size_t)visited_cap, sizeof(struct IRNode*));
+    struct IRNode** visited = cml_calloc((size_t)visited_cap, sizeof(struct IRNode*));
     int num_visited = 0;
 
     while (node) {
@@ -188,7 +189,7 @@ done_cycle:
         idx++;
     }
 
-    free(visited);
+    cml_free(visited);
 }
 
 static void validate_kernel_level(CMLGraph_t graph, CMLSpecResult* result) {
@@ -268,11 +269,11 @@ static void validate_linear_level(CMLGraph_t graph, CMLSpecResult* result) {
         LinearProgram* prog = linearize_group(grp);
         if (!prog) continue;
 
-        bool* has_store = calloc((size_t)(prog->next_vreg + 1), sizeof(bool));
-        bool* has_load_reg = calloc((size_t)(prog->next_vreg + 1), sizeof(bool));
+        bool* has_store = cml_calloc((size_t)(prog->next_vreg + 1), sizeof(bool));
+        bool* has_load_reg = cml_calloc((size_t)(prog->next_vreg + 1), sizeof(bool));
         if (!has_store || !has_load_reg) {
-            free(has_store);
-            free(has_load_reg);
+            cml_free(has_store);
+            cml_free(has_load_reg);
             linear_program_free(prog);
             continue;
         }
@@ -322,8 +323,8 @@ static void validate_linear_level(CMLGraph_t graph, CMLSpecResult* result) {
                 "mismatched LOOP/ENDLOOP nesting", CML_SPEC_LINEAR);
         }
 
-        free(has_store);
-        free(has_load_reg);
+        cml_free(has_store);
+        cml_free(has_load_reg);
         linear_program_free(prog);
     }
 
@@ -403,8 +404,8 @@ CMLSpecResult* cml_spec_validate(CMLGraph_t graph, CMLSpecLevel level) {
 
 void cml_spec_result_free(CMLSpecResult* result) {
     if (!result) return;
-    free(result->errors);
-    free(result);
+    cml_free(result->errors);
+    cml_free(result);
 }
 
 void cml_spec_result_print(const CMLSpecResult* result) {

--- a/src/ops/ir/tc_opt.c
+++ b/src/ops/ir/tc_opt.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdatomic.h>
+#include "alloc/cml_allocator.h"
 
 static CMLTCConfig g_tc_config = {
     .min_m = CML_TC_DEFAULT_MIN_DIM,
@@ -23,7 +24,7 @@ static atomic_int g_tc_counter = 0;
 
 static char* tc_unique_name(void) {
     int id = atomic_fetch_add(&g_tc_counter, 1);
-    char* name = malloc(32);
+    char* name = cml_malloc(32);
     if (name)
         snprintf(name, 32, "_tc%d", id);
     return name;
@@ -105,17 +106,17 @@ static void extract_matmul_dims(struct IRNode* node, int* m, int* n, int* k) {
 
 static struct IRNode* create_pad_node(struct IRNode* src_node, const char* src_name,
                                       int* padded_shape, int ndim) {
-    struct IRNode* pad = calloc(1, sizeof(struct IRNode));
+    struct IRNode* pad = cml_calloc(1, sizeof(struct IRNode));
     if (!pad) return NULL;
 
     pad->type = UOP_PAD;
     pad->num_inputs = 1;
-    pad->input_names = malloc(sizeof(char*));
-    if (!pad->input_names) { free(pad); return NULL; }
-    pad->input_names[0] = strdup(src_name);
+    pad->input_names = cml_malloc(sizeof(char*));
+    if (!pad->input_names) { cml_free(pad); return NULL; }
+    pad->input_names[0] = cml_strdup(src_name);
     pad->output_name = tc_unique_name();
     pad->output_ndim = ndim;
-    pad->output_shape = malloc((size_t)ndim * sizeof(int));
+    pad->output_shape = cml_malloc((size_t)ndim * sizeof(int));
     if (pad->output_shape)
         memcpy(pad->output_shape, padded_shape, (size_t)ndim * sizeof(int));
 
@@ -126,24 +127,24 @@ static struct IRNode* create_pad_node(struct IRNode* src_node, const char* src_n
 static struct IRNode* create_wmma_node(const char* a_name, const char* b_name,
                                        int m, int n, int k,
                                        int* output_shape, int output_ndim) {
-    struct IRNode* wmma = calloc(1, sizeof(struct IRNode));
+    struct IRNode* wmma = cml_calloc(1, sizeof(struct IRNode));
     if (!wmma) return NULL;
 
     wmma->type = UOP_MATMUL;
     wmma->is_fused = true;
     wmma->fusion_type = FUSION_FMA;
     wmma->num_inputs = 2;
-    wmma->input_names = malloc(2 * sizeof(char*));
-    if (!wmma->input_names) { free(wmma); return NULL; }
-    wmma->input_names[0] = strdup(a_name);
-    wmma->input_names[1] = strdup(b_name);
+    wmma->input_names = cml_malloc(2 * sizeof(char*));
+    if (!wmma->input_names) { cml_free(wmma); return NULL; }
+    wmma->input_names[0] = cml_strdup(a_name);
+    wmma->input_names[1] = cml_strdup(b_name);
     wmma->output_name = tc_unique_name();
     wmma->output_ndim = output_ndim;
-    wmma->output_shape = malloc((size_t)output_ndim * sizeof(int));
+    wmma->output_shape = cml_malloc((size_t)output_ndim * sizeof(int));
     if (wmma->output_shape)
         memcpy(wmma->output_shape, output_shape, (size_t)output_ndim * sizeof(int));
 
-    WMMAConfig* cfg = calloc(1, sizeof(WMMAConfig));
+    WMMAConfig* cfg = cml_calloc(1, sizeof(WMMAConfig));
     if (cfg) {
         cml_wmma_select_config(m, n, k, cfg);
         wmma->params = cfg;
@@ -169,8 +170,8 @@ static void replace_refs(CMLGraph_t ir, const char* old_name, const char* new_na
     while (n) {
         for (int i = 0; i < n->num_inputs; i++) {
             if (n->input_names[i] && strcmp(n->input_names[i], old_name) == 0) {
-                free(n->input_names[i]);
-                n->input_names[i] = strdup(new_name);
+                cml_free(n->input_names[i]);
+                n->input_names[i] = cml_strdup(new_name);
             }
         }
         n = n->next;
@@ -236,18 +237,18 @@ static void free_node(struct IRNode* node) {
     if (!node) return;
     if (node->input_names) {
         for (int i = 0; i < node->num_inputs; i++)
-            free(node->input_names[i]);
-        free(node->input_names);
+            cml_free(node->input_names[i]);
+        cml_free(node->input_names);
     }
-    free(node->output_name);
-    free(node->output_shape);
-    free(node->params);
-    free(node->users);
+    cml_free(node->output_name);
+    cml_free(node->output_shape);
+    cml_free(node->params);
+    cml_free(node->users);
     if (node->output) {
         node->output->ir_node = NULL;
         node->output->ir_context = NULL;
     }
-    free(node);
+    cml_free(node);
 }
 
 static int rewrite_matmul_to_wmma(CMLGraph_t ir, struct IRNode* node) {
@@ -277,13 +278,13 @@ static int rewrite_matmul_to_wmma(CMLGraph_t ir, struct IRNode* node) {
         int ndim_b = node->input_ndims[1];
 
         if (pm != m || pk != k) {
-            int* padded_a = malloc((size_t)ndim_a * sizeof(int));
+            int* padded_a = cml_malloc((size_t)ndim_a * sizeof(int));
             if (padded_a) {
                 memcpy(padded_a, node->input_shapes[0], (size_t)ndim_a * sizeof(int));
                 padded_a[ndim_a - 2] = pm;
                 padded_a[ndim_a - 1] = pk;
                 struct IRNode* pad_a = create_pad_node(NULL, a_name, padded_a, ndim_a);
-                free(padded_a);
+                cml_free(padded_a);
                 if (pad_a) {
                     insert_before(ir, pad_a, node);
                     final_a = pad_a->output_name;
@@ -292,13 +293,13 @@ static int rewrite_matmul_to_wmma(CMLGraph_t ir, struct IRNode* node) {
         }
 
         if (pk != k || pn != n) {
-            int* padded_b = malloc((size_t)ndim_b * sizeof(int));
+            int* padded_b = cml_malloc((size_t)ndim_b * sizeof(int));
             if (padded_b) {
                 memcpy(padded_b, node->input_shapes[1], (size_t)ndim_b * sizeof(int));
                 padded_b[ndim_b - 2] = pk;
                 padded_b[ndim_b - 1] = pn;
                 struct IRNode* pad_b = create_pad_node(NULL, b_name, padded_b, ndim_b);
-                free(padded_b);
+                cml_free(padded_b);
                 if (pad_b) {
                     insert_before(ir, pad_b, node);
                     final_b = pad_b->output_name;
@@ -308,7 +309,7 @@ static int rewrite_matmul_to_wmma(CMLGraph_t ir, struct IRNode* node) {
     }
 
     int out_ndim = node->output_ndim > 0 ? node->output_ndim : 2;
-    int* out_shape = malloc((size_t)out_ndim * sizeof(int));
+    int* out_shape = cml_malloc((size_t)out_ndim * sizeof(int));
     if (!out_shape) return 0;
 
     if (node->output_shape && node->output_ndim > 0) {
@@ -322,22 +323,22 @@ static int rewrite_matmul_to_wmma(CMLGraph_t ir, struct IRNode* node) {
 
     struct IRNode* wmma = create_wmma_node(final_a, final_b, pm, pn, pk,
                                            out_shape, out_ndim);
-    free(out_shape);
+    cml_free(out_shape);
     if (!wmma) return 0;
 
     insert_before(ir, wmma, node);
 
     if (needs_pad && node->output_shape) {
-        int* slice_shape = malloc((size_t)out_ndim * sizeof(int));
+        int* slice_shape = cml_malloc((size_t)out_ndim * sizeof(int));
         if (slice_shape) {
             memcpy(slice_shape, node->output_shape, (size_t)out_ndim * sizeof(int));
-            struct IRNode* slice = calloc(1, sizeof(struct IRNode));
+            struct IRNode* slice = cml_calloc(1, sizeof(struct IRNode));
             if (slice) {
                 slice->type = UOP_SHRINK;
                 slice->num_inputs = 1;
-                slice->input_names = malloc(sizeof(char*));
+                slice->input_names = cml_malloc(sizeof(char*));
                 if (slice->input_names) {
-                    slice->input_names[0] = strdup(wmma->output_name);
+                    slice->input_names[0] = cml_strdup(wmma->output_name);
                     slice->output_name = tc_unique_name();
                     slice->output_ndim = out_ndim;
                     slice->output_shape = slice_shape;
@@ -350,11 +351,11 @@ static int rewrite_matmul_to_wmma(CMLGraph_t ir, struct IRNode* node) {
                         node->output->ir_context = ir;
                     }
                 } else {
-                    free(slice_shape);
-                    free(slice);
+                    cml_free(slice_shape);
+                    cml_free(slice);
                 }
             } else {
-                free(slice_shape);
+                cml_free(slice_shape);
             }
         }
     } else {
@@ -417,7 +418,7 @@ static int rewrite_fused_matmul(CMLGraph_t ir, struct IRNode* reduce_node,
     int pk = round_up(k, 16);
 
     int out_ndim = reduce_node->output_ndim > 0 ? reduce_node->output_ndim : 2;
-    int* out_shape = malloc((size_t)out_ndim * sizeof(int));
+    int* out_shape = cml_malloc((size_t)out_ndim * sizeof(int));
     if (!out_shape) return 0;
 
     if (reduce_node->output_shape && reduce_node->output_ndim > 0)
@@ -430,7 +431,7 @@ static int rewrite_fused_matmul(CMLGraph_t ir, struct IRNode* reduce_node,
     struct IRNode* wmma = create_wmma_node(
         src_a->output_name, src_b->output_name,
         pm, pn, pk, out_shape, out_ndim);
-    free(out_shape);
+    cml_free(out_shape);
     if (!wmma) return 0;
 
     insert_before(ir, wmma, reduce_node);

--- a/src/ops/ir/tiny_jit.c
+++ b/src/ops/ir/tiny_jit.c
@@ -6,6 +6,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 #define FNV_OFFSET_BASIS 0xcbf29ce484222325ULL
 #define FNV_PRIME        0x100000001b3ULL
@@ -61,7 +62,7 @@ static bool shape_matches(const CMLJitEntry *entry, const int *sig, int sig_len)
 
 CMLTinyJit *cml_tinyjit_create(void)
 {
-    CMLTinyJit *jit = (CMLTinyJit *)calloc(1, sizeof(CMLTinyJit));
+    CMLTinyJit *jit = (CMLTinyJit *)cml_calloc(1, sizeof(CMLTinyJit));
     return jit;
 }
 
@@ -73,7 +74,7 @@ void cml_tinyjit_free(CMLTinyJit *jit)
             cml_trace_free(jit->entries[i].trace);
         }
     }
-    free(jit);
+    cml_free(jit);
 }
 
 int cml_tinyjit_execute(CMLTinyJit *jit, CMLGraph_t ir)

--- a/src/ops/ir/trace.c
+++ b/src/ops/ir/trace.c
@@ -4,6 +4,7 @@
 #include "core/logging.h"
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 static _Thread_local CMLTrace* g_active_trace = NULL;
 
@@ -20,14 +21,14 @@ void cml_trace_set_active(CMLTrace* trace) {
 
 CMLTrace *cml_trace_create(void)
 {
-    CMLTrace *trace = (CMLTrace *)calloc(1, sizeof(CMLTrace));
+    CMLTrace *trace = (CMLTrace *)cml_calloc(1, sizeof(CMLTrace));
     return trace; /* NULL on allocation failure */
 }
 
 void cml_trace_free(CMLTrace *trace)
 {
     if (!trace) return;
-    free(trace);
+    cml_free(trace);
 }
 
 int cml_trace_begin(CMLTrace *trace, uint64_t graph_hash)
@@ -168,7 +169,7 @@ int cml_trace_replay(CMLTrace *trace, void **tensor_ptrs, int num_tensors)
 
 CMLTraceCache *cml_trace_cache_create(void)
 {
-    CMLTraceCache *cache = (CMLTraceCache *)calloc(1, sizeof(CMLTraceCache));
+    CMLTraceCache *cache = (CMLTraceCache *)cml_calloc(1, sizeof(CMLTraceCache));
     return cache;
 }
 
@@ -181,7 +182,7 @@ void cml_trace_cache_free(CMLTraceCache *cache)
             cml_trace_free(cache->entries[i].trace);
         }
     }
-    free(cache);
+    cml_free(cache);
 }
 
 CMLTrace *cml_trace_cache_lookup(CMLTraceCache *cache, uint64_t graph_hash)

--- a/src/ops/ir/tree_automaton.c
+++ b/src/ops/ir/tree_automaton.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdatomic.h>
+#include "alloc/cml_allocator.h"
 
 #define AUTOMATON_INITIAL_TABLE_CAP 256
 #define AUTOMATON_MAX_ARITY CML_PATTERN_MAX_INPUTS
@@ -102,7 +103,7 @@ static void transition_grow(CMLAutomaton* aut) {
     CMLTransition* old = aut->transitions;
 
     int new_cap = old_cap < 16 ? 16 : old_cap * 2;
-    aut->transitions = calloc((size_t)new_cap, sizeof(CMLTransition));
+    aut->transitions = cml_calloc((size_t)new_cap, sizeof(CMLTransition));
     aut->table_capacity = new_cap;
     aut->num_transitions = 0;
 
@@ -110,14 +111,14 @@ static void transition_grow(CMLAutomaton* aut) {
         if (old[i].occupied)
             transition_insert(aut, old[i].key, old[i].result_state);
     }
-    free(old);
+    cml_free(old);
 }
 
 static int automaton_add_state(CMLAutomaton* aut) {
     if (aut->num_states >= aut->states_capacity) {
         int new_cap = aut->states_capacity * 2;
         if (new_cap < 16) new_cap = 16;
-        CMLAutomatonState* ns = realloc(aut->states, (size_t)new_cap * sizeof(CMLAutomatonState));
+        CMLAutomatonState* ns = cml_realloc(aut->states, (size_t)new_cap * sizeof(CMLAutomatonState));
         if (!ns) return -1;
         aut->states = ns;
         aut->states_capacity = new_cap;
@@ -140,7 +141,7 @@ static void state_add_rule(CMLAutomaton* aut, int state_id, int rule_idx) {
             return;
     }
 
-    s->matched_rules = realloc(s->matched_rules,
+    s->matched_rules = cml_realloc(s->matched_rules,
                                 (size_t)(s->num_matched + 1) * sizeof(int));
     s->matched_rules[s->num_matched] = rule_idx;
     s->num_matched++;
@@ -257,7 +258,7 @@ static void expand_wildcard_transitions(CMLAutomaton* aut,
 CMLAutomaton* cml_automaton_compile(CMLRewriteRegistry* registry) {
     if (!registry || registry->num_rules == 0) return NULL;
 
-    CMLAutomaton* aut = calloc(1, sizeof(CMLAutomaton));
+    CMLAutomaton* aut = cml_calloc(1, sizeof(CMLAutomaton));
     if (!aut) return NULL;
 
     aut->registry = registry;
@@ -275,7 +276,7 @@ CMLAutomaton* cml_automaton_compile(CMLRewriteRegistry* registry) {
 
     /* Allocate pending wildcard records for expansion pass */
     int pending_cap = registry->num_rules * AUTOMATON_MAX_ARITY;
-    PendingWildcard* pending = calloc((size_t)pending_cap, sizeof(PendingWildcard));
+    PendingWildcard* pending = cml_calloc((size_t)pending_cap, sizeof(PendingWildcard));
     int num_pending = 0;
 
     for (int r = 0; r < registry->num_rules; r++) {
@@ -302,7 +303,7 @@ CMLAutomaton* cml_automaton_compile(CMLRewriteRegistry* registry) {
     }
 
     expand_wildcard_transitions(aut, pending, num_pending);
-    free(pending);
+    cml_free(pending);
 
     return aut;
 }
@@ -310,10 +311,10 @@ CMLAutomaton* cml_automaton_compile(CMLRewriteRegistry* registry) {
 void cml_automaton_free(CMLAutomaton* automaton) {
     if (!automaton) return;
     for (int i = 0; i < automaton->num_states; i++)
-        free(automaton->states[i].matched_rules);
-    free(automaton->states);
-    free(automaton->transitions);
-    free(automaton);
+        cml_free(automaton->states[i].matched_rules);
+    cml_free(automaton->states);
+    cml_free(automaton->transitions);
+    cml_free(automaton);
 }
 
 static struct IRNode* find_node_by_output(CMLGraph_t ir, const char* name) {
@@ -366,7 +367,7 @@ static atomic_int g_rewrite_counter = 0;
 
 static char* rewrite_unique_name(void) {
     int id = atomic_fetch_add(&g_rewrite_counter, 1);
-    char* name = malloc(32);
+    char* name = cml_malloc(32);
     if (name)
         snprintf(name, 32, "_rw%d", id);
     return name;
@@ -380,8 +381,8 @@ static void replace_output_references(CMLGraph_t ir,
     while (n) {
         for (int i = 0; i < n->num_inputs; i++) {
             if (n->input_names[i] && strcmp(n->input_names[i], old_name) == 0) {
-                free(n->input_names[i]);
-                n->input_names[i] = strdup(new_name);
+                cml_free(n->input_names[i]);
+                n->input_names[i] = cml_strdup(new_name);
             }
         }
         n = n->next;
@@ -451,18 +452,18 @@ static void free_unlinked_node(struct IRNode* node) {
 
     if (node->input_names) {
         for (int i = 0; i < node->num_inputs; i++)
-            free(node->input_names[i]);
-        free(node->input_names);
+            cml_free(node->input_names[i]);
+        cml_free(node->input_names);
     }
-    free(node->output_name);
-    free(node->users);
+    cml_free(node->output_name);
+    cml_free(node->users);
 
     if (node->output) {
         node->output->ir_node = NULL;
         node->output->ir_context = NULL;
     }
 
-    free(node);
+    cml_free(node);
 }
 
 static bool match_node_recursive(CMLGraph_t ir, const CMLPatternNode* pattern,
@@ -513,18 +514,18 @@ int cml_automaton_rewrite(CMLAutomaton* automaton, struct CMLGraph* graph) {
     for (int iter = 0; iter < max_iter; iter++) {
         /* Phase 1: topological order (children before parents) */
         int cap = graph->node_count > 0 ? graph->node_count : 16;
-        struct IRNode** topo = malloc((size_t)cap * sizeof(struct IRNode*));
-        int* node_states = calloc((size_t)cap, sizeof(int));
-        if (!topo || !node_states) { free(topo); free(node_states); return -1; }
+        struct IRNode** topo = cml_malloc((size_t)cap * sizeof(struct IRNode*));
+        int* node_states = cml_calloc((size_t)cap, sizeof(int));
+        if (!topo || !node_states) { cml_free(topo); cml_free(node_states); return -1; }
 
         int topo_count = 0;
         struct IRNode* n = graph->head;
         while (n) {
             if (topo_count >= cap) {
                 cap *= 2;
-                topo = realloc(topo, (size_t)cap * sizeof(struct IRNode*));
-                node_states = realloc(node_states, (size_t)cap * sizeof(int));
-                if (!topo || !node_states) { free(topo); free(node_states); return -1; }
+                topo = cml_realloc(topo, (size_t)cap * sizeof(struct IRNode*));
+                node_states = cml_realloc(node_states, (size_t)cap * sizeof(int));
+                if (!topo || !node_states) { cml_free(topo); cml_free(node_states); return -1; }
             }
             topo[topo_count] = n;
             node_states[topo_count] = AUTOMATON_DEAD_STATE;
@@ -622,8 +623,8 @@ int cml_automaton_rewrite(CMLAutomaton* automaton, struct CMLGraph* graph) {
             }
         }
 
-        free(topo);
-        free(node_states);
+        cml_free(topo);
+        cml_free(node_states);
 
         total_rewrites += rewrites_this_pass;
         if (rewrites_this_pass == 0)

--- a/src/ops/ir/validate.c
+++ b/src/ops/ir/validate.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdarg.h>
+#include "alloc/cml_allocator.h"
 
 CMLValidateOpts cml_validate_default_opts(void) {
     CMLValidateOpts o;
@@ -33,7 +34,7 @@ static void push_diag(CMLValidateDiag* diags, int max_diags, int* count,
 static struct IRNode** collect_nodes(CMLGraph_t ir, int* out_count) {
     *out_count = 0;
     if (!ir || ir->node_count == 0) return NULL;
-    struct IRNode** arr = malloc((size_t)ir->node_count * sizeof(struct IRNode*));
+    struct IRNode** arr = cml_malloc((size_t)ir->node_count * sizeof(struct IRNode*));
     if (!arr) return NULL;
     int n = 0;
     struct IRNode* cur = ir->head;
@@ -127,7 +128,7 @@ CMLValidateCode cml_validate_graph(CMLGraph_t ir,
 
     if (num_nodes == 0) {
         RECORD(CML_VALID_EMPTY_GRAPH, -1, "IR graph is empty");
-        free(nodes);
+        cml_free(nodes);
         goto done;
     }
 
@@ -136,7 +137,7 @@ CMLValidateCode cml_validate_graph(CMLGraph_t ir,
             RECORD(CML_VALID_NULL_NODE, i, "Node slot %d is NULL", i);
         }
     }
-    if (first != CML_VALID_OK) { free(nodes); goto done; }
+    if (first != CML_VALID_OK) { cml_free(nodes); goto done; }
 
     for (int i = 0; i < num_nodes; ++i) {
         struct IRNode* n = nodes[i];
@@ -158,13 +159,13 @@ CMLValidateCode cml_validate_graph(CMLGraph_t ir,
     }
 
     if (opts->check_cycles) {
-        uint8_t* color = calloc((size_t)num_nodes, 1);
+        uint8_t* color = cml_calloc((size_t)num_nodes, 1);
         if (color) {
             for (int i = 0; i < num_nodes; ++i)
                 if (color[i] == 0)
                     dfs_has_cycle(nodes, num_nodes, color, i,
                                   diags, max_diag_count, &ndiags);
-            free(color);
+            cml_free(color);
         }
     }
 
@@ -194,7 +195,7 @@ CMLValidateCode cml_validate_graph(CMLGraph_t ir,
         }
     }
 
-    free(nodes);
+    cml_free(nodes);
 
 done:
     if (num_diags_out) *num_diags_out = ndiags;

--- a/src/ops/ir/viz_server.c
+++ b/src/ops/ir/viz_server.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include "alloc/cml_allocator.h"
 
 #ifdef _WIN32
 #  include <winsock2.h>
@@ -148,7 +149,7 @@ char* viz_graph_to_json(CMLGraph_t ir) {
     if (!ir) return NULL;
 
     int n = ir->node_count;
-    struct IRNode** nodes = malloc((size_t)(n + 1) * sizeof(struct IRNode*));
+    struct IRNode** nodes = cml_malloc((size_t)(n + 1) * sizeof(struct IRNode*));
     if (!nodes) return NULL;
     int cnt = 0;
     for (struct IRNode* cur = ir->head; cur && cnt < n; cur = cur->next)
@@ -156,8 +157,8 @@ char* viz_graph_to_json(CMLGraph_t ir) {
     n = cnt;
 
     size_t cap = (size_t)(n * 256) + 2048;
-    char* buf = malloc(cap);
-    if (!buf) { free(nodes); return NULL; }
+    char* buf = cml_malloc(cap);
+    if (!buf) { cml_free(nodes); return NULL; }
     size_t pos = 0;
 
 #define A(...) do { int _r = snprintf(buf+pos, cap-pos, __VA_ARGS__); \
@@ -203,7 +204,7 @@ char* viz_graph_to_json(CMLGraph_t ir) {
     }
     A("]}");
 #undef A
-    free(nodes);
+    cml_free(nodes);
     return buf;
 }
 
@@ -212,12 +213,12 @@ int viz_export_html(CMLGraph_t ir, const char* path) {
     char* json = viz_graph_to_json(ir);
     if (!json) return -1;
     FILE* f = fopen(path, "w");
-    if (!f) { free(json); return -1; }
+    if (!f) { cml_free(json); return -1; }
     fputs(VIZ_HTML_PRE, f);
     fputs(json, f);
     fputs(VIZ_HTML_POST, f);
     fclose(f);
-    free(json);
+    cml_free(json);
     LOG_INFO("Exported IR graph to %s", path);
     return 0;
 }
@@ -265,7 +266,7 @@ VizServer* viz_server_start(CMLGraph_t ir, int port) {
         port = ntohs(b.sin_port);
     }
 
-    VizServer* srv = calloc(1, sizeof(VizServer));
+    VizServer* srv = cml_calloc(1, sizeof(VizServer));
     if (!srv) { sock_close(fd); return NULL; }
     srv->listen_fd  = fd;
     srv->port       = port;
@@ -278,7 +279,7 @@ VizServer* viz_server_start(CMLGraph_t ir, int port) {
 void viz_server_update(VizServer* srv, CMLGraph_t ir) {
     if (!srv) return;
     srv->ir = ir;
-    free(srv->json_cache);
+    cml_free(srv->json_cache);
     srv->json_cache = ir ? viz_graph_to_json(ir) : NULL;
 }
 
@@ -317,8 +318,8 @@ int viz_server_poll(VizServer* srv) {
 void viz_server_stop(VizServer* srv) {
     if (!srv) return;
     sock_close(srv->listen_fd);
-    free(srv->json_cache);
-    free(srv);
+    cml_free(srv->json_cache);
+    cml_free(srv);
 #ifdef _WIN32
     WSACleanup();
 #endif

--- a/src/ops/ir/z3_verify.c
+++ b/src/ops/ir/z3_verify.c
@@ -4,6 +4,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 #ifdef CML_HAS_Z3
 
@@ -162,7 +163,7 @@ bool cml_z3_available(void) {
 }
 
 CMLZ3Verifier* cml_z3_verifier_create(int timeout_ms) {
-    CMLZ3Verifier* v = calloc(1, sizeof(CMLZ3Verifier));
+    CMLZ3Verifier* v = cml_calloc(1, sizeof(CMLZ3Verifier));
     if (!v) return NULL;
     v->timeout_ms = timeout_ms;
 
@@ -198,7 +199,7 @@ void cml_z3_verifier_free(CMLZ3Verifier* v) {
             z3.del_context(v->z3_context);
         }
     }
-    free(v);
+    cml_free(v);
 }
 
 static Z3_ast z3_build_node_expr(Z3_context ctx, struct IRNode* node,
@@ -433,12 +434,12 @@ void cml_z3_verifier_stats(const CMLZ3Verifier* v,
 bool cml_z3_available(void) { return false; }
 
 CMLZ3Verifier* cml_z3_verifier_create(int timeout_ms) {
-    CMLZ3Verifier* v = calloc(1, sizeof(CMLZ3Verifier));
+    CMLZ3Verifier* v = cml_calloc(1, sizeof(CMLZ3Verifier));
     if (v) v->timeout_ms = timeout_ms;
     return v;
 }
 
-void cml_z3_verifier_free(CMLZ3Verifier* v) { free(v); }
+void cml_z3_verifier_free(CMLZ3Verifier* v) { cml_free(v); }
 
 CMLVerifyResult cml_z3_verify_equivalence(CMLZ3Verifier* v,
                                            CMLGraph_t original,

--- a/src/ops/simd_math.c
+++ b/src/ops/simd_math.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdbool.h>
 #include <stdlib.h>
+#include "alloc/cml_allocator.h"
 
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
 #define CML_X86 1
@@ -646,6 +647,7 @@ static void simd_div_f32_avx512(const float* a, const float* b, float* out, size
 
 #ifdef CML_HAS_AVX_COMPILE
 
+__attribute__((target("avx2")))
 static inline __m256 exp_poly_avx(__m256 x) {
     // Clamp input to prevent overflow/underflow
     // exp(88.7) ~ 3.4e38 (max float), exp(-87.3) ~ 1e-38 (min normal float)
@@ -691,6 +693,7 @@ static inline __m256 exp_poly_avx(__m256 x) {
     return _mm256_mul_ps(result, scale);
 }
 
+__attribute__((target("avx2")))
 static inline __m256 log_poly_avx(__m256 x) {
     __m256i xi        = _mm256_castps_si256(x);
     __m256i exp_mask  = _mm256_set1_epi32(0x7F800000);
@@ -2261,6 +2264,7 @@ void simd_max_broadcast_f32(const float* a, size_t a_n, const float* b, size_t b
 }
 
 #include "backend/threadpool.h"
+#include "alloc/cml_allocator.h"
 
 static size_t g_parallel_threshold = 10000; // Min elements for parallel execution
 
@@ -2388,7 +2392,7 @@ float simd_sum_f32_parallel(const float* data, size_t n) {
     if (num_threads == 0)
         num_threads = 1;
 
-    float* partial_sums = calloc(num_threads, sizeof(float));
+    float* partial_sums = cml_calloc(num_threads, sizeof(float));
     if (!partial_sums) {
         return simd_sum_float(data, n);
     }
@@ -2401,7 +2405,7 @@ float simd_sum_f32_parallel(const float* data, size_t n) {
     for (size_t i = 0; i < num_threads; i++) {
         total += partial_sums[i];
     }
-    free(partial_sums);
+    cml_free(partial_sums);
 
     return total;
 }

--- a/src/ops/simd_views.c
+++ b/src/ops/simd_views.c
@@ -1,6 +1,7 @@
 #include "ops/simd_views.h"
 #include <string.h>
 #include <stdlib.h>
+#include "alloc/cml_allocator.h"
 
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
   #define CML_X86 1
@@ -20,6 +21,7 @@
 #elif defined(__aarch64__) || defined(__arm__)
   #define CML_ARM 1
   #include <arm_neon.h>
+#include "alloc/cml_allocator.h"
   #define CML_HAS_NEON 1
 #endif
 
@@ -299,11 +301,11 @@ void simd_broadcast_copy_f32(const float* src, size_t src_n, float* dst, size_t 
 void simd_permute_nd_f32(const float* src, float* dst, const int* shape,
                          const size_t* strides, const int* perm, int ndim, size_t numel) {
     /* Compute destination strides from permuted shape */
-    int* dst_shape = (int*)malloc(ndim * sizeof(int));
-    size_t* dst_strides = (size_t*)malloc(ndim * sizeof(size_t));
+    int* dst_shape = (int*)cml_malloc(ndim * sizeof(int));
+    size_t* dst_strides = (size_t*)cml_malloc(ndim * sizeof(size_t));
     if (!dst_shape || !dst_strides) {
-        free(dst_shape);
-        free(dst_strides);
+        cml_free(dst_shape);
+        cml_free(dst_strides);
         /* Fallback: plain copy */
         memcpy(dst, src, numel * sizeof(float));
         return;
@@ -317,10 +319,10 @@ void simd_permute_nd_f32(const float* src, float* dst, const int* shape,
         dst_strides[i] = dst_strides[i + 1] * dst_shape[i + 1];
 
     /* Map each source element to destination via stride calculation */
-    int* coords = (int*)calloc(ndim, sizeof(int));
+    int* coords = (int*)cml_calloc(ndim, sizeof(int));
     if (!coords) {
-        free(dst_shape);
-        free(dst_strides);
+        cml_free(dst_shape);
+        cml_free(dst_strides);
         memcpy(dst, src, numel * sizeof(float));
         return;
     }
@@ -347,7 +349,7 @@ void simd_permute_nd_f32(const float* src, float* dst, const int* shape,
         }
     }
 
-    free(coords);
-    free(dst_shape);
-    free(dst_strides);
+    cml_free(coords);
+    cml_free(dst_shape);
+    cml_free(dst_strides);
 }

--- a/src/ops/uops.c
+++ b/src/ops/uops.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <math.h>
 #include <stdio.h>
+#include "alloc/cml_allocator.h"
 
 static Tensor* uop_binary(Tensor* a, Tensor* b, UOpType type) {
     if (!a || !b) {
@@ -57,13 +58,13 @@ Tensor* uop_max(Tensor* a, Tensor* b) {
 
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) {
-        free(out_shape);
+        cml_free(out_shape);
         return NULL;
     }
 
     Tensor* inputs[] = {a, b};
     if (cml_ir_add_uop(ir, UOP_MAX, inputs, 2, NULL) != 0) {
-        free(out_shape);
+        cml_free(out_shape);
         return NULL;
     }
 
@@ -98,13 +99,13 @@ Tensor* uop_cmplt(Tensor* a, Tensor* b) {
 
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) {
-        free(out_shape);
+        cml_free(out_shape);
         return NULL;
     }
 
     Tensor* inputs[] = {a, b};
     if (cml_ir_add_uop(ir, UOP_CMPLT, inputs, 2, NULL) != 0) {
-        free(out_shape);
+        cml_free(out_shape);
         return NULL;
     }
 
@@ -171,15 +172,15 @@ static Tensor* uop_reduce(Tensor* a, ReduceParams* params, UOpType type) {
     if (!ir)
         return NULL;
 
-    ReduceParams* new_params = malloc(sizeof(ReduceParams));
+    ReduceParams* new_params = cml_malloc(sizeof(ReduceParams));
     if (!new_params)
         return NULL;
     new_params->keepdim  = params ? params->keepdim : false;
     new_params->num_dims = params ? params->num_dims : 0;
     if (params && params->dims && params->num_dims > 0) {
-        new_params->dims = malloc((size_t)params->num_dims * sizeof(int));
+        new_params->dims = cml_malloc((size_t)params->num_dims * sizeof(int));
         if (!new_params->dims) {
-            free(new_params);
+            cml_free(new_params);
             return NULL;
         }
         memcpy(new_params->dims, params->dims, (size_t)params->num_dims * sizeof(int));
@@ -190,8 +191,8 @@ static Tensor* uop_reduce(Tensor* a, ReduceParams* params, UOpType type) {
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, type, inputs, 1, new_params) != 0) {
-        free(new_params->dims);
-        free(new_params);
+        cml_free(new_params->dims);
+        cml_free(new_params);
         return NULL;
     }
 
@@ -205,7 +206,7 @@ static Tensor* uop_reduce(Tensor* a, ReduceParams* params, UOpType type) {
 
     if (dim < 0 || dim >= a->ndim) {
         out_ndim  = 1;
-        out_shape = malloc(sizeof(int));
+        out_shape = cml_malloc(sizeof(int));
         if (!out_shape)
             return NULL;
         out_shape[0] = 1;
@@ -213,7 +214,7 @@ static Tensor* uop_reduce(Tensor* a, ReduceParams* params, UOpType type) {
         out_ndim = keepdim ? a->ndim : (a->ndim - 1);
         if (out_ndim == 0)
             out_ndim = 1;
-        out_shape = malloc((size_t)out_ndim * sizeof(int));
+        out_shape = cml_malloc((size_t)out_ndim * sizeof(int));
         if (!out_shape)
             return NULL;
 
@@ -254,10 +255,10 @@ Tensor* uop_reshape(Tensor* a, ReshapeParams* params) {
     if (result) {
         CMLGraph_t ir = cml_ir_get_or_create_context();
         if (ir) {
-                    ReshapeParams* new_params = malloc(sizeof(ReshapeParams));
+                    ReshapeParams* new_params = cml_malloc(sizeof(ReshapeParams));
             if (new_params) {
                 new_params->new_ndim  = params->new_ndim;
-                new_params->new_shape = malloc((size_t)params->new_ndim * sizeof(int));
+                new_params->new_shape = cml_malloc((size_t)params->new_ndim * sizeof(int));
                 if (new_params->new_shape) {
                     memcpy(new_params->new_shape, params->new_shape,
                            (size_t)params->new_ndim * sizeof(int));
@@ -275,11 +276,11 @@ Tensor* uop_reshape(Tensor* a, ReshapeParams* params) {
                         result->ir_context = ir;
                         node->output       = result;
                     } else {
-                        free(new_params->new_shape);
-                        free(new_params);
+                        cml_free(new_params->new_shape);
+                        cml_free(new_params);
                     }
                 } else {
-                    free(new_params);
+                    cml_free(new_params);
                 }
             }
         }
@@ -304,24 +305,24 @@ Tensor* uop_permute(Tensor* a, PermuteParams* params) {
         return NULL;
     }
 
-    bool* used = calloc((size_t)actual_ndim, sizeof(bool));
+    bool* used = cml_calloc((size_t)actual_ndim, sizeof(bool));
     if (!used)
         return NULL;
 
     for (int i = 0; i < params->num_dims; i++) {
         if (params->perm[i] < 0 || params->perm[i] >= actual_ndim) {
-            free(used);
+            cml_free(used);
             LOG_ERROR("Permute: invalid dimension %d in permutation", params->perm[i]);
             return NULL;
         }
         if (used[params->perm[i]]) {
-            free(used);
+            cml_free(used);
             LOG_ERROR("Permute: duplicate dimension %d in permutation", params->perm[i]);
             return NULL;
         }
         used[params->perm[i]] = true;
     }
-    free(used);
+    cml_free(used);
 
     int* a_shape = a->shape;
     if (a->ir_node && a->ir_node->output_shape && a->ir_node->output_ndim > 0) {
@@ -332,28 +333,28 @@ Tensor* uop_permute(Tensor* a, PermuteParams* params) {
     if (!ir)
         return NULL;
 
-    PermuteParams* new_params = malloc(sizeof(PermuteParams));
+    PermuteParams* new_params = cml_malloc(sizeof(PermuteParams));
     if (!new_params)
         return NULL;
 
     new_params->num_dims = params->num_dims;
-    new_params->perm     = malloc((size_t)params->num_dims * sizeof(int));
+    new_params->perm     = cml_malloc((size_t)params->num_dims * sizeof(int));
     if (!new_params->perm) {
-        free(new_params);
+        cml_free(new_params);
         return NULL;
     }
     memcpy(new_params->perm, params->perm, (size_t)params->num_dims * sizeof(int));
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, UOP_PERMUTE, inputs, 1, new_params) != 0) {
-        free(new_params->perm);
-        free(new_params);
+        cml_free(new_params->perm);
+        cml_free(new_params);
         return NULL;
     }
 
     struct IRNode* node = cml_ir_get_tail(ir);
 
-    int* out_shape = malloc((size_t)actual_ndim * sizeof(int));
+    int* out_shape = cml_malloc((size_t)actual_ndim * sizeof(int));
     if (!out_shape)
         return NULL;
 
@@ -383,7 +384,7 @@ Tensor* uop_expand(Tensor* a, ExpandParams* params) {
         return NULL;
     }
 
-    int* broadcast_shape = malloc((size_t)params->new_ndim * sizeof(int));
+    int* broadcast_shape = cml_malloc((size_t)params->new_ndim * sizeof(int));
     if (!broadcast_shape)
         return NULL;
 
@@ -399,23 +400,23 @@ Tensor* uop_expand(Tensor* a, ExpandParams* params) {
     for (int i = 0; i < params->new_ndim; i++) {
         int orig_dim = i >= prepend ? a->shape[i - prepend] : 1;
         if (orig_dim != params->new_shape[i] && orig_dim != 1 && params->new_shape[i] != 1) {
-            free(broadcast_shape);
+            cml_free(broadcast_shape);
             LOG_ERROR("Expand: cannot broadcast dimension %d: %d -> %d", i, orig_dim,
                       params->new_shape[i]);
             return NULL;
         }
     }
 
-    size_t* new_strides = malloc((size_t)params->new_ndim * sizeof(size_t));
+    size_t* new_strides = cml_malloc((size_t)params->new_ndim * sizeof(size_t));
     if (!new_strides) {
-        free(broadcast_shape);
+        cml_free(broadcast_shape);
         return NULL;
     }
 
     size_t* orig_strides = a->strides ? a->strides : compute_contiguous_strides(a->shape, a->ndim);
     if (!orig_strides) {
-        free(broadcast_shape);
-        free(new_strides);
+        cml_free(broadcast_shape);
+        cml_free(new_strides);
         return NULL;
     }
 
@@ -435,22 +436,22 @@ Tensor* uop_expand(Tensor* a, ExpandParams* params) {
     }
 
     if (!a->strides) {
-        free(orig_strides);
+        cml_free(orig_strides);
     }
 
     Tensor* result =
         tensor_as_strided(a, params->new_shape, params->new_ndim, new_strides, a->storage_offset);
 
-    free(broadcast_shape);
-    free(new_strides);
+    cml_free(broadcast_shape);
+    cml_free(new_strides);
 
     if (result) {
         CMLGraph_t ir = cml_ir_get_or_create_context();
         if (ir) {
-            ExpandParams* new_params = malloc(sizeof(ExpandParams));
+            ExpandParams* new_params = cml_malloc(sizeof(ExpandParams));
             if (new_params) {
                 new_params->new_ndim  = params->new_ndim;
-                new_params->new_shape = malloc((size_t)params->new_ndim * sizeof(int));
+                new_params->new_shape = cml_malloc((size_t)params->new_ndim * sizeof(int));
                 if (new_params->new_shape) {
                     memcpy(new_params->new_shape, params->new_shape,
                            (size_t)params->new_ndim * sizeof(int));
@@ -468,11 +469,11 @@ Tensor* uop_expand(Tensor* a, ExpandParams* params) {
                         result->ir_context = ir;
                         node->output       = result;
                     } else {
-                        free(new_params->new_shape);
-                        free(new_params);
+                        cml_free(new_params->new_shape);
+                        cml_free(new_params);
                     }
                 } else {
-                    free(new_params);
+                    cml_free(new_params);
                 }
             }
         }
@@ -498,10 +499,10 @@ Tensor* uop_stride(Tensor* a, StrideParams* params) {
     if (result) {
         CMLGraph_t ir = cml_ir_get_or_create_context();
         if (ir) {
-            StrideParams* new_params = malloc(sizeof(StrideParams));
+            StrideParams* new_params = cml_malloc(sizeof(StrideParams));
             if (new_params) {
                 new_params->num_dims    = params->num_dims;
-                new_params->new_strides = malloc((size_t)params->num_dims * sizeof(size_t));
+                new_params->new_strides = cml_malloc((size_t)params->num_dims * sizeof(size_t));
                 if (new_params->new_strides) {
                     memcpy(new_params->new_strides, params->new_strides,
                            (size_t)params->num_dims * sizeof(size_t));
@@ -519,11 +520,11 @@ Tensor* uop_stride(Tensor* a, StrideParams* params) {
                         result->ir_context = ir;
                         node->output       = result;
                     } else {
-                        free(new_params->new_strides);
-                        free(new_params);
+                        cml_free(new_params->new_strides);
+                        cml_free(new_params);
                     }
                 } else {
-                    free(new_params);
+                    cml_free(new_params);
                 }
             }
         }
@@ -543,7 +544,7 @@ Tensor* uop_slice(Tensor* a, SliceParams* params) {
         return NULL;
     }
 
-    int* new_shape = malloc((size_t)a->ndim * sizeof(int));
+    int* new_shape = cml_malloc((size_t)a->ndim * sizeof(int));
     if (!new_shape)
         return NULL;
 
@@ -553,7 +554,7 @@ Tensor* uop_slice(Tensor* a, SliceParams* params) {
     bool free_strides = !a->strides;
 
     if (!strides) {
-        free(new_shape);
+        cml_free(new_shape);
         return NULL;
     }
 
@@ -584,11 +585,11 @@ Tensor* uop_slice(Tensor* a, SliceParams* params) {
         storage_offset += (size_t)start * strides[i];
     }
 
-    size_t* new_strides = malloc((size_t)a->ndim * sizeof(size_t));
+    size_t* new_strides = cml_malloc((size_t)a->ndim * sizeof(size_t));
     if (!new_strides) {
-        free(new_shape);
+        cml_free(new_shape);
         if (free_strides)
-            free(strides);
+            cml_free(strides);
         return NULL;
     }
 
@@ -599,20 +600,20 @@ Tensor* uop_slice(Tensor* a, SliceParams* params) {
 
     Tensor* result = tensor_as_strided(a, new_shape, a->ndim, new_strides, storage_offset);
 
-    free(new_shape);
-    free(new_strides);
+    cml_free(new_shape);
+    cml_free(new_strides);
     if (free_strides)
-        free(strides);
+        cml_free(strides);
 
     if (result) {
         CMLGraph_t ir = cml_ir_get_or_create_context();
         if (ir) {
-            SliceParams* new_params = malloc(sizeof(SliceParams));
+            SliceParams* new_params = cml_malloc(sizeof(SliceParams));
             if (new_params) {
                 new_params->num_dims = params->num_dims;
-                new_params->start    = malloc((size_t)params->num_dims * sizeof(int));
-                new_params->end      = malloc((size_t)params->num_dims * sizeof(int));
-                new_params->step     = malloc((size_t)params->num_dims * sizeof(int));
+                new_params->start    = cml_malloc((size_t)params->num_dims * sizeof(int));
+                new_params->end      = cml_malloc((size_t)params->num_dims * sizeof(int));
+                new_params->step     = cml_malloc((size_t)params->num_dims * sizeof(int));
 
                 if (new_params->start && new_params->end && new_params->step) {
                     memcpy(new_params->start, params->start,
@@ -639,19 +640,19 @@ Tensor* uop_slice(Tensor* a, SliceParams* params) {
                         result->ir_context = ir;
                         node->output       = result;
                     } else {
-                        free(new_params->start);
-                        free(new_params->end);
-                        free(new_params->step);
-                        free(new_params);
+                        cml_free(new_params->start);
+                        cml_free(new_params->end);
+                        cml_free(new_params->step);
+                        cml_free(new_params);
                     }
                 } else {
                     if (new_params->start)
-                        free(new_params->start);
+                        cml_free(new_params->start);
                     if (new_params->end)
-                        free(new_params->end);
+                        cml_free(new_params->end);
                     if (new_params->step)
-                        free(new_params->step);
-                    free(new_params);
+                        cml_free(new_params->step);
+                    cml_free(new_params);
                 }
             }
         }
@@ -693,7 +694,7 @@ Tensor* uop_linear(Tensor* input, Tensor* weight, Tensor* bias) {
     struct IRNode* node = cml_ir_get_tail(ir);
     /* Output preserves all leading dims: [..., M, K] -> [..., M, N] */
     node->output_ndim   = input->ndim;
-    node->output_shape  = malloc((size_t)input->ndim * sizeof(int));
+    node->output_shape  = cml_malloc((size_t)input->ndim * sizeof(int));
     for (int i = 0; i < input->ndim - 1; i++)
         node->output_shape[i] = input->shape[i];
     node->output_shape[input->ndim - 1] = N;
@@ -725,14 +726,14 @@ static void conv2d_params_free_local(Conv2DParams* p) {
     if (!p)
         return;
     if (p->kernel_size)
-        free(p->kernel_size);
+        cml_free(p->kernel_size);
     if (p->stride)
-        free(p->stride);
+        cml_free(p->stride);
     if (p->padding)
-        free(p->padding);
+        cml_free(p->padding);
     if (p->dilation)
-        free(p->dilation);
-    free(p);
+        cml_free(p->dilation);
+    cml_free(p);
 }
 
 static Tensor* uop_pool2d(Tensor* input, Pool2DParams* params, UOpType type) {
@@ -780,7 +781,7 @@ static Tensor* uop_pool2d(Tensor* input, Pool2DParams* params, UOpType type) {
         return NULL;
     }
 
-    Pool2DParams* params_copy = malloc(sizeof(Pool2DParams));
+    Pool2DParams* params_copy = cml_malloc(sizeof(Pool2DParams));
     if (!params_copy)
         return NULL;
     memcpy(params_copy, params, sizeof(Pool2DParams));
@@ -791,13 +792,13 @@ static Tensor* uop_pool2d(Tensor* input, Pool2DParams* params, UOpType type) {
 
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) {
-        free(params_copy);
+        cml_free(params_copy);
         return NULL;
     }
 
     Tensor* inputs[] = {input};
     if (cml_ir_add_uop(ir, type, inputs, 1, params_copy) != 0) {
-        free(params_copy);
+        cml_free(params_copy);
         return NULL;
     }
 
@@ -863,7 +864,7 @@ static Tensor* uop_conv3d_like(Tensor* input, Tensor* weight, Tensor* bias,
     if (out_depth <= 0 || out_height <= 0 || out_width <= 0)
         return NULL;
 
-    Conv3DParams* params_copy = calloc(1, sizeof(Conv3DParams));
+    Conv3DParams* params_copy = cml_calloc(1, sizeof(Conv3DParams));
     if (!params_copy)
         return NULL;
     if (params)
@@ -878,14 +879,14 @@ static Tensor* uop_conv3d_like(Tensor* input, Tensor* weight, Tensor* bias,
 
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) {
-        free(params_copy);
+        cml_free(params_copy);
         return NULL;
     }
 
     Tensor* inputs[3] = {input, weight, bias};
     int num_inputs = bias ? 3 : 2;
     if (cml_ir_add_uop(ir, UOP_CONV3D, inputs, num_inputs, params_copy) != 0) {
-        free(params_copy);
+        cml_free(params_copy);
         return NULL;
     }
 
@@ -925,7 +926,7 @@ static Tensor* uop_conv_transpose2d_like(Tensor* input, Tensor* weight, Tensor* 
     if (out_height <= 0 || out_width <= 0)
         return NULL;
 
-    ConvTranspose2DParams* params_copy = malloc(sizeof(ConvTranspose2DParams));
+    ConvTranspose2DParams* params_copy = cml_malloc(sizeof(ConvTranspose2DParams));
     if (!params_copy)
         return NULL;
     memcpy(params_copy, params, sizeof(ConvTranspose2DParams));
@@ -934,13 +935,13 @@ static Tensor* uop_conv_transpose2d_like(Tensor* input, Tensor* weight, Tensor* 
 
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) {
-        free(params_copy);
+        cml_free(params_copy);
         return NULL;
     }
     Tensor* inputs[3] = {input, weight, bias};
     int num_inputs = bias ? 3 : 2;
     if (cml_ir_add_uop(ir, UOP_CONV_TRANSPOSE2D, inputs, num_inputs, params_copy) != 0) {
-        free(params_copy);
+        cml_free(params_copy);
         return NULL;
     }
 
@@ -984,7 +985,7 @@ static Tensor* uop_conv_transpose3d_like(Tensor* input, Tensor* weight, Tensor* 
     if (out_depth <= 0 || out_height <= 0 || out_width <= 0)
         return NULL;
 
-    ConvTranspose3DParams* params_copy = malloc(sizeof(ConvTranspose3DParams));
+    ConvTranspose3DParams* params_copy = cml_malloc(sizeof(ConvTranspose3DParams));
     if (!params_copy)
         return NULL;
     memcpy(params_copy, params, sizeof(ConvTranspose3DParams));
@@ -994,13 +995,13 @@ static Tensor* uop_conv_transpose3d_like(Tensor* input, Tensor* weight, Tensor* 
 
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) {
-        free(params_copy);
+        cml_free(params_copy);
         return NULL;
     }
     Tensor* inputs[3] = {input, weight, bias};
     int num_inputs = bias ? 3 : 2;
     if (cml_ir_add_uop(ir, UOP_CONV_TRANSPOSE3D, inputs, num_inputs, params_copy) != 0) {
-        free(params_copy);
+        cml_free(params_copy);
         return NULL;
     }
 
@@ -1080,17 +1081,17 @@ Tensor* uop_conv2d(Tensor* input, Tensor* weight, Tensor* bias, Conv2DParams* pa
         }
     }
 
-    Conv2DParams* params_copy = calloc(1, sizeof(Conv2DParams));
+    Conv2DParams* params_copy = cml_calloc(1, sizeof(Conv2DParams));
     if (!params_copy) {
         error_stack_push(CM_OPERATION_FAILED, "uop_conv2d: params alloc failed", __FILE__, __LINE__,
                          __func__);
         return NULL;
     }
 
-    params_copy->kernel_size = malloc(2 * sizeof(int));
-    params_copy->stride      = malloc(2 * sizeof(int));
-    params_copy->padding     = malloc(2 * sizeof(int));
-    params_copy->dilation    = malloc(2 * sizeof(int));
+    params_copy->kernel_size = cml_malloc(2 * sizeof(int));
+    params_copy->stride      = cml_malloc(2 * sizeof(int));
+    params_copy->padding     = cml_malloc(2 * sizeof(int));
+    params_copy->dilation    = cml_malloc(2 * sizeof(int));
     if (!params_copy->kernel_size || !params_copy->stride || !params_copy->padding ||
         !params_copy->dilation) {
         conv2d_params_free_local(params_copy);
@@ -1170,7 +1171,7 @@ Tensor* uop_fill(int* shape, int ndim, float value) {
     if (!ir)
         return NULL;
 
-    FillParams* params = malloc(sizeof(FillParams));
+    FillParams* params = cml_malloc(sizeof(FillParams));
     if (!params)
         return NULL;
 
@@ -1178,16 +1179,16 @@ Tensor* uop_fill(int* shape, int ndim, float value) {
     params->ndim   = ndim;
     params->dtype  = DTYPE_FLOAT32;
     params->device = DEVICE_CPU;
-    params->shape  = malloc((size_t)ndim * sizeof(int));
+    params->shape  = cml_malloc((size_t)ndim * sizeof(int));
     if (!params->shape) {
-        free(params);
+        cml_free(params);
         return NULL;
     }
     memcpy(params->shape, shape, (size_t)ndim * sizeof(int));
 
     if (cml_ir_add_uop(ir, UOP_FILL, NULL, 0, params) != 0) {
-        free(params->shape);
-        free(params);
+        cml_free(params->shape);
+        cml_free(params);
         return NULL;
     }
 
@@ -1215,7 +1216,7 @@ Tensor* uop_fill_ex(int* shape, int ndim, float value, DType dtype, DeviceType d
     if (!ir)
         return NULL;
 
-    FillParams* params = malloc(sizeof(FillParams));
+    FillParams* params = cml_malloc(sizeof(FillParams));
     if (!params)
         return NULL;
 
@@ -1223,16 +1224,16 @@ Tensor* uop_fill_ex(int* shape, int ndim, float value, DType dtype, DeviceType d
     params->ndim   = ndim;
     params->dtype  = dtype;
     params->device = device;
-    params->shape  = malloc((size_t)ndim * sizeof(int));
+    params->shape  = cml_malloc((size_t)ndim * sizeof(int));
     if (!params->shape) {
-        free(params);
+        cml_free(params);
         return NULL;
     }
     memcpy(params->shape, shape, (size_t)ndim * sizeof(int));
 
     if (cml_ir_add_uop(ir, UOP_FILL, NULL, 0, params) != 0) {
-        free(params->shape);
-        free(params);
+        cml_free(params->shape);
+        cml_free(params);
         return NULL;
     }
 
@@ -1260,13 +1261,13 @@ Tensor* uop_const(const void* data, size_t data_size, int* shape, int ndim,
     if (!ir)
         return NULL;
 
-    ConstParams* params = malloc(sizeof(ConstParams));
+    ConstParams* params = cml_malloc(sizeof(ConstParams));
     if (!params)
         return NULL;
 
-    params->data = malloc(data_size);
+    params->data = cml_malloc(data_size);
     if (!params->data) {
-        free(params);
+        cml_free(params);
         return NULL;
     }
     memcpy(params->data, data, data_size);
@@ -1274,18 +1275,18 @@ Tensor* uop_const(const void* data, size_t data_size, int* shape, int ndim,
     params->dtype     = dtype;
     params->device    = device;
     params->ndim      = ndim;
-    params->shape     = malloc((size_t)ndim * sizeof(int));
+    params->shape     = cml_malloc((size_t)ndim * sizeof(int));
     if (!params->shape) {
-        free(params->data);
-        free(params);
+        cml_free(params->data);
+        cml_free(params);
         return NULL;
     }
     memcpy(params->shape, shape, (size_t)ndim * sizeof(int));
 
     if (cml_ir_add_uop(ir, UOP_CONST, NULL, 0, params) != 0) {
-        free(params->shape);
-        free(params->data);
-        free(params);
+        cml_free(params->shape);
+        cml_free(params->data);
+        cml_free(params);
         return NULL;
     }
 
@@ -1312,14 +1313,14 @@ Tensor* uop_rand_uniform(int* shape, int ndim, DType dtype, DeviceType device) {
     if (!ir)
         return NULL;
 
-    RandParams* params = malloc(sizeof(RandParams));
+    RandParams* params = cml_malloc(sizeof(RandParams));
     if (!params)
         return NULL;
     params->dtype  = dtype;
     params->device = device;
 
     if (cml_ir_add_uop(ir, UOP_RAND_UNIFORM, NULL, 0, params) != 0) {
-        free(params);
+        cml_free(params);
         return NULL;
     }
 
@@ -1346,14 +1347,14 @@ Tensor* uop_rand_normal(int* shape, int ndim, DType dtype, DeviceType device) {
     if (!ir)
         return NULL;
 
-    RandParams* params = malloc(sizeof(RandParams));
+    RandParams* params = cml_malloc(sizeof(RandParams));
     if (!params)
         return NULL;
     params->dtype  = dtype;
     params->device = device;
 
     if (cml_ir_add_uop(ir, UOP_RAND_NORMAL, NULL, 0, params) != 0) {
-        free(params);
+        cml_free(params);
         return NULL;
     }
 
@@ -1386,7 +1387,7 @@ Tensor* uop_arange_op(float start, float end, float step, DType dtype, DeviceTyp
     if (!ir)
         return NULL;
 
-    ArangeParams* params = malloc(sizeof(ArangeParams));
+    ArangeParams* params = cml_malloc(sizeof(ArangeParams));
     if (!params)
         return NULL;
     params->start  = start;
@@ -1396,7 +1397,7 @@ Tensor* uop_arange_op(float start, float end, float step, DType dtype, DeviceTyp
     params->device = device;
 
     if (cml_ir_add_uop(ir, UOP_ARANGE_OP, NULL, 0, params) != 0) {
-        free(params);
+        cml_free(params);
         return NULL;
     }
 
@@ -1404,7 +1405,7 @@ Tensor* uop_arange_op(float start, float end, float step, DType dtype, DeviceTyp
     if (!node)
         return NULL;
 
-    int* out_shape = malloc(sizeof(int));
+    int* out_shape = cml_malloc(sizeof(int));
     if (!out_shape)
         return NULL;
     out_shape[0]        = n;
@@ -1427,7 +1428,7 @@ Tensor* uop_eye_op(int n, DType dtype, DeviceType device) {
     if (!ir)
         return NULL;
 
-    EyeParams* params = malloc(sizeof(EyeParams));
+    EyeParams* params = cml_malloc(sizeof(EyeParams));
     if (!params)
         return NULL;
     params->n      = n;
@@ -1435,7 +1436,7 @@ Tensor* uop_eye_op(int n, DType dtype, DeviceType device) {
     params->device = device;
 
     if (cml_ir_add_uop(ir, UOP_EYE_OP, NULL, 0, params) != 0) {
-        free(params);
+        cml_free(params);
         return NULL;
     }
 
@@ -1443,7 +1444,7 @@ Tensor* uop_eye_op(int n, DType dtype, DeviceType device) {
     if (!node)
         return NULL;
 
-    int* out_shape = malloc(2 * sizeof(int));
+    int* out_shape = cml_malloc(2 * sizeof(int));
     if (!out_shape)
         return NULL;
     out_shape[0]        = n;
@@ -1472,7 +1473,7 @@ Tensor* uop_rand_int(int low, int high, int* shape, int ndim,
     if (!ir)
         return NULL;
 
-    RandIntParams* params = malloc(sizeof(RandIntParams));
+    RandIntParams* params = cml_malloc(sizeof(RandIntParams));
     if (!params)
         return NULL;
     params->low    = low;
@@ -1481,7 +1482,7 @@ Tensor* uop_rand_int(int low, int high, int* shape, int ndim,
     params->device = device;
 
     if (cml_ir_add_uop(ir, UOP_RAND_INT, NULL, 0, params) != 0) {
-        free(params);
+        cml_free(params);
         return NULL;
     }
 
@@ -1524,7 +1525,7 @@ Tensor* uop_gather(Tensor* input, Tensor* indices, int dim) {
         LOG_ERROR("uop_gather: invalid output rank");
         return NULL;
     }
-    int* out_shape = malloc((size_t)out_ndim * sizeof(int));
+    int* out_shape = cml_malloc((size_t)out_ndim * sizeof(int));
     if (!out_shape)
         return NULL;
     memcpy(out_shape, indices->shape, (size_t)indices->ndim * sizeof(int));
@@ -1536,27 +1537,27 @@ Tensor* uop_gather(Tensor* input, Tensor* indices, int dim) {
 
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) {
-        free(out_shape);
+        cml_free(out_shape);
         return NULL;
     }
 
-    GatherParams* params = malloc(sizeof(GatherParams));
+    GatherParams* params = cml_malloc(sizeof(GatherParams));
     if (!params) {
-        free(out_shape);
+        cml_free(out_shape);
         return NULL;
     }
     params->dim = gather_dim;
 
     Tensor* inputs[] = {input, indices};
     if (cml_ir_add_uop(ir, UOP_GATHER, inputs, 2, params) != 0) {
-        free(params);
-        free(out_shape);
+        cml_free(params);
+        cml_free(out_shape);
         return NULL;
     }
 
     struct IRNode* node = cml_ir_get_tail(ir);
     if (!node) {
-        free(out_shape);
+        cml_free(out_shape);
         return NULL;
     }
 
@@ -1639,7 +1640,7 @@ Tensor* uop_sigmoid(Tensor* x) {
     if (!node)
         return NULL;
 
-    node->output_shape = (int*)malloc(x->ndim * sizeof(int));
+    node->output_shape = (int*)cml_malloc(x->ndim * sizeof(int));
     if (!node->output_shape)
         return NULL;
     memcpy(node->output_shape, x->shape, x->ndim * sizeof(int));
@@ -1671,7 +1672,7 @@ Tensor* uop_tanh(Tensor* x) {
     if (!node)
         return NULL;
 
-    node->output_shape = (int*)malloc(x->ndim * sizeof(int));
+    node->output_shape = (int*)cml_malloc(x->ndim * sizeof(int));
     if (!node->output_shape)
         return NULL;
     memcpy(node->output_shape, x->shape, x->ndim * sizeof(int));
@@ -1833,14 +1834,14 @@ Tensor* uop_clamp(Tensor* a, float min_val, float max_val) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    ClampParams* params = malloc(sizeof(ClampParams));
+    ClampParams* params = cml_malloc(sizeof(ClampParams));
     if (!params) return NULL;
     params->min_val = min_val;
     params->max_val = max_val;
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, UOP_CLAMP, inputs, 1, params) != 0) {
-        free(params);
+        cml_free(params);
         return NULL;
     }
     struct IRNode* node = cml_ir_get_tail(ir);
@@ -1862,13 +1863,13 @@ Tensor* uop_argmax(Tensor* a, ReduceParams* params) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    ReduceParams* new_params = malloc(sizeof(ReduceParams));
+    ReduceParams* new_params = cml_malloc(sizeof(ReduceParams));
     if (!new_params) return NULL;
     new_params->keepdim = params ? params->keepdim : false;
     new_params->num_dims = params ? params->num_dims : 0;
     if (params && params->dims && params->num_dims > 0) {
-        new_params->dims = malloc((size_t)params->num_dims * sizeof(int));
-        if (!new_params->dims) { free(new_params); return NULL; }
+        new_params->dims = cml_malloc((size_t)params->num_dims * sizeof(int));
+        if (!new_params->dims) { cml_free(new_params); return NULL; }
         memcpy(new_params->dims, params->dims, (size_t)params->num_dims * sizeof(int));
     } else {
         new_params->dims = NULL;
@@ -1876,8 +1877,8 @@ Tensor* uop_argmax(Tensor* a, ReduceParams* params) {
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, UOP_ARGMAX, inputs, 1, new_params) != 0) {
-        if (new_params->dims) free(new_params->dims);
-        free(new_params);
+        if (new_params->dims) cml_free(new_params->dims);
+        cml_free(new_params);
         return NULL;
     }
 
@@ -1889,13 +1890,13 @@ Tensor* uop_argmax(Tensor* a, ReduceParams* params) {
 
     if (dim < 0 || dim >= a->ndim) {
         out_ndim = 1;
-        out_shape = malloc(sizeof(int));
+        out_shape = cml_malloc(sizeof(int));
         if (!out_shape) return NULL;
         out_shape[0] = 1;
     } else {
         out_ndim = keepdim ? a->ndim : (a->ndim - 1);
         if (out_ndim == 0) out_ndim = 1;
-        out_shape = malloc((size_t)out_ndim * sizeof(int));
+        out_shape = cml_malloc((size_t)out_ndim * sizeof(int));
         if (!out_shape) return NULL;
         int out_idx = 0;
         if (keepdim) {
@@ -1918,13 +1919,13 @@ Tensor* uop_argmin(Tensor* a, ReduceParams* params) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    ReduceParams* new_params = malloc(sizeof(ReduceParams));
+    ReduceParams* new_params = cml_malloc(sizeof(ReduceParams));
     if (!new_params) return NULL;
     new_params->keepdim = params ? params->keepdim : false;
     new_params->num_dims = params ? params->num_dims : 0;
     if (params && params->dims && params->num_dims > 0) {
-        new_params->dims = malloc((size_t)params->num_dims * sizeof(int));
-        if (!new_params->dims) { free(new_params); return NULL; }
+        new_params->dims = cml_malloc((size_t)params->num_dims * sizeof(int));
+        if (!new_params->dims) { cml_free(new_params); return NULL; }
         memcpy(new_params->dims, params->dims, (size_t)params->num_dims * sizeof(int));
     } else {
         new_params->dims = NULL;
@@ -1932,8 +1933,8 @@ Tensor* uop_argmin(Tensor* a, ReduceParams* params) {
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, UOP_ARGMIN, inputs, 1, new_params) != 0) {
-        if (new_params->dims) free(new_params->dims);
-        free(new_params);
+        if (new_params->dims) cml_free(new_params->dims);
+        cml_free(new_params);
         return NULL;
     }
 
@@ -1945,13 +1946,13 @@ Tensor* uop_argmin(Tensor* a, ReduceParams* params) {
 
     if (dim < 0 || dim >= a->ndim) {
         out_ndim = 1;
-        out_shape = malloc(sizeof(int));
+        out_shape = cml_malloc(sizeof(int));
         if (!out_shape) return NULL;
         out_shape[0] = 1;
     } else {
         out_ndim = keepdim ? a->ndim : (a->ndim - 1);
         if (out_ndim == 0) out_ndim = 1;
-        out_shape = malloc((size_t)out_ndim * sizeof(int));
+        out_shape = cml_malloc((size_t)out_ndim * sizeof(int));
         if (!out_shape) return NULL;
         int out_idx = 0;
         if (keepdim) {
@@ -1974,13 +1975,13 @@ Tensor* uop_cumsum(Tensor* a, int dim) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    CumsumParams* params = malloc(sizeof(CumsumParams));
+    CumsumParams* params = cml_malloc(sizeof(CumsumParams));
     if (!params) return NULL;
     params->dim = dim < 0 ? a->ndim + dim : dim;
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, UOP_CUMSUM, inputs, 1, params) != 0) {
-        free(params);
+        cml_free(params);
         return NULL;
     }
 
@@ -1999,13 +2000,13 @@ Tensor* uop_triu(Tensor* a, int diagonal) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    TriParams* params = malloc(sizeof(TriParams));
+    TriParams* params = cml_malloc(sizeof(TriParams));
     if (!params) return NULL;
     params->diagonal = diagonal;
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, UOP_TRIU, inputs, 1, params) != 0) {
-        free(params);
+        cml_free(params);
         return NULL;
     }
 
@@ -2024,13 +2025,13 @@ Tensor* uop_tril(Tensor* a, int diagonal) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    TriParams* params = malloc(sizeof(TriParams));
+    TriParams* params = cml_malloc(sizeof(TriParams));
     if (!params) return NULL;
     params->diagonal = diagonal;
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, UOP_TRIL, inputs, 1, params) != 0) {
-        free(params);
+        cml_free(params);
         return NULL;
     }
 
@@ -2049,24 +2050,24 @@ Tensor* uop_pad(Tensor* a, int* pad_widths, int num_dims, float value) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    PadParams* params = malloc(sizeof(PadParams));
+    PadParams* params = cml_malloc(sizeof(PadParams));
     if (!params) return NULL;
     params->num_dims = num_dims;
     params->value = value;
     params->mode = PAD_CONSTANT;
-    params->pad_widths = malloc((size_t)(num_dims * 2) * sizeof(int));
-    if (!params->pad_widths) { free(params); return NULL; }
+    params->pad_widths = cml_malloc((size_t)(num_dims * 2) * sizeof(int));
+    if (!params->pad_widths) { cml_free(params); return NULL; }
     memcpy(params->pad_widths, pad_widths, (size_t)(num_dims * 2) * sizeof(int));
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, UOP_PAD, inputs, 1, params) != 0) {
-        free(params->pad_widths);
-        free(params);
+        cml_free(params->pad_widths);
+        cml_free(params);
         return NULL;
     }
 
     struct IRNode* node = cml_ir_get_tail(ir);
-    int* out_shape = malloc((size_t)a->ndim * sizeof(int));
+    int* out_shape = cml_malloc((size_t)a->ndim * sizeof(int));
     if (!out_shape) return NULL;
     for (int i = 0; i < a->ndim; i++)
         out_shape[i] = a->shape[i] + pad_widths[i * 2] + pad_widths[i * 2 + 1];
@@ -2084,14 +2085,14 @@ Tensor* uop_sort(Tensor* a, int dim, bool descending) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    SortParams* params = malloc(sizeof(SortParams));
+    SortParams* params = cml_malloc(sizeof(SortParams));
     if (!params) return NULL;
     params->dim = dim < 0 ? a->ndim + dim : dim;
     params->descending = descending;
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, UOP_SORT, inputs, 1, params) != 0) {
-        free(params); return NULL;
+        cml_free(params); return NULL;
     }
 
     struct IRNode* node = cml_ir_get_tail(ir);
@@ -2105,14 +2106,14 @@ Tensor* uop_argsort(Tensor* a, int dim, bool descending) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    SortParams* params = malloc(sizeof(SortParams));
+    SortParams* params = cml_malloc(sizeof(SortParams));
     if (!params) return NULL;
     params->dim = dim < 0 ? a->ndim + dim : dim;
     params->descending = descending;
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, UOP_ARGSORT, inputs, 1, params) != 0) {
-        free(params); return NULL;
+        cml_free(params); return NULL;
     }
 
     struct IRNode* node = cml_ir_get_tail(ir);
@@ -2128,7 +2129,7 @@ Tensor* uop_topk(Tensor* a, int k, int dim, bool largest, Tensor** indices_out) 
 
     int resolved_dim = dim < 0 ? a->ndim + dim : dim;
 
-    TopkParams* params = malloc(sizeof(TopkParams));
+    TopkParams* params = cml_malloc(sizeof(TopkParams));
     if (!params) return NULL;
     params->k = k;
     params->dim = resolved_dim;
@@ -2136,7 +2137,7 @@ Tensor* uop_topk(Tensor* a, int k, int dim, bool largest, Tensor** indices_out) 
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, UOP_TOPK, inputs, 1, params) != 0) {
-        free(params); return NULL;
+        cml_free(params); return NULL;
     }
 
     struct IRNode* node = cml_ir_get_tail(ir);
@@ -2157,7 +2158,7 @@ Tensor* uop_topk(Tensor* a, int k, int dim, bool largest, Tensor** indices_out) 
     Tensor* values = tensor_from_ir_node(node, ir);
 
     if (indices_out) {
-        SortParams* sort_params = malloc(sizeof(SortParams));
+        SortParams* sort_params = cml_malloc(sizeof(SortParams));
         if (sort_params) {
             sort_params->dim = resolved_dim;
             sort_params->descending = largest;
@@ -2176,7 +2177,7 @@ Tensor* uop_topk(Tensor* a, int k, int dim, bool largest, Tensor** indices_out) 
                 }
                 *indices_out = tensor_from_ir_node(idx_node, ir);
             } else {
-                free(sort_params);
+                cml_free(sort_params);
                 *indices_out = NULL;
             }
         } else {
@@ -2192,13 +2193,13 @@ Tensor* uop_cumprod(Tensor* a, int dim) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    CumsumParams* params = malloc(sizeof(CumsumParams));
+    CumsumParams* params = cml_malloc(sizeof(CumsumParams));
     if (!params) return NULL;
     params->dim = dim < 0 ? a->ndim + dim : dim;
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, UOP_CUMPROD, inputs, 1, params) != 0) {
-        free(params); return NULL;
+        cml_free(params); return NULL;
     }
 
     struct IRNode* node = cml_ir_get_tail(ir);
@@ -2303,13 +2304,13 @@ Tensor* uop_masked_fill(Tensor* a, Tensor* mask, float value) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    MaskedFillParams* params = malloc(sizeof(MaskedFillParams));
+    MaskedFillParams* params = cml_malloc(sizeof(MaskedFillParams));
     if (!params) return NULL;
     params->value = value;
 
     Tensor* inputs[] = {a, mask};
     if (cml_ir_add_uop(ir, UOP_MASKED_FILL, inputs, 2, params) != 0) {
-        free(params); return NULL;
+        cml_free(params); return NULL;
     }
 
     struct IRNode* node = cml_ir_get_tail(ir);
@@ -2430,13 +2431,13 @@ Tensor* uop_any(Tensor* a, ReduceParams* params) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    ReduceParams* new_params = malloc(sizeof(ReduceParams));
+    ReduceParams* new_params = cml_malloc(sizeof(ReduceParams));
     if (!new_params) return NULL;
     new_params->keepdim = params ? params->keepdim : false;
     new_params->num_dims = params ? params->num_dims : 0;
     if (params && params->dims && params->num_dims > 0) {
-        new_params->dims = malloc((size_t)params->num_dims * sizeof(int));
-        if (!new_params->dims) { free(new_params); return NULL; }
+        new_params->dims = cml_malloc((size_t)params->num_dims * sizeof(int));
+        if (!new_params->dims) { cml_free(new_params); return NULL; }
         memcpy(new_params->dims, params->dims, (size_t)params->num_dims * sizeof(int));
     } else {
         new_params->dims = NULL;
@@ -2444,8 +2445,8 @@ Tensor* uop_any(Tensor* a, ReduceParams* params) {
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, UOP_ANY, inputs, 1, new_params) != 0) {
-        if (new_params->dims) free(new_params->dims);
-        free(new_params);
+        if (new_params->dims) cml_free(new_params->dims);
+        cml_free(new_params);
         return NULL;
     }
 
@@ -2457,13 +2458,13 @@ Tensor* uop_any(Tensor* a, ReduceParams* params) {
 
     if (dim < 0 || dim >= a->ndim) {
         out_ndim = 1;
-        out_shape = malloc(sizeof(int));
+        out_shape = cml_malloc(sizeof(int));
         if (!out_shape) return NULL;
         out_shape[0] = 1;
     } else {
         out_ndim = keepdim ? a->ndim : (a->ndim - 1);
         if (out_ndim == 0) out_ndim = 1;
-        out_shape = malloc((size_t)out_ndim * sizeof(int));
+        out_shape = cml_malloc((size_t)out_ndim * sizeof(int));
         if (!out_shape) return NULL;
         int out_idx = 0;
         if (keepdim) {
@@ -2486,13 +2487,13 @@ Tensor* uop_all(Tensor* a, ReduceParams* params) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    ReduceParams* new_params = malloc(sizeof(ReduceParams));
+    ReduceParams* new_params = cml_malloc(sizeof(ReduceParams));
     if (!new_params) return NULL;
     new_params->keepdim = params ? params->keepdim : false;
     new_params->num_dims = params ? params->num_dims : 0;
     if (params && params->dims && params->num_dims > 0) {
-        new_params->dims = malloc((size_t)params->num_dims * sizeof(int));
-        if (!new_params->dims) { free(new_params); return NULL; }
+        new_params->dims = cml_malloc((size_t)params->num_dims * sizeof(int));
+        if (!new_params->dims) { cml_free(new_params); return NULL; }
         memcpy(new_params->dims, params->dims, (size_t)params->num_dims * sizeof(int));
     } else {
         new_params->dims = NULL;
@@ -2500,8 +2501,8 @@ Tensor* uop_all(Tensor* a, ReduceParams* params) {
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, UOP_ALL, inputs, 1, new_params) != 0) {
-        if (new_params->dims) free(new_params->dims);
-        free(new_params);
+        if (new_params->dims) cml_free(new_params->dims);
+        cml_free(new_params);
         return NULL;
     }
 
@@ -2513,13 +2514,13 @@ Tensor* uop_all(Tensor* a, ReduceParams* params) {
 
     if (dim < 0 || dim >= a->ndim) {
         out_ndim = 1;
-        out_shape = malloc(sizeof(int));
+        out_shape = cml_malloc(sizeof(int));
         if (!out_shape) return NULL;
         out_shape[0] = 1;
     } else {
         out_ndim = keepdim ? a->ndim : (a->ndim - 1);
         if (out_ndim == 0) out_ndim = 1;
-        out_shape = malloc((size_t)out_ndim * sizeof(int));
+        out_shape = cml_malloc((size_t)out_ndim * sizeof(int));
         if (!out_shape) return NULL;
         int out_idx = 0;
         if (keepdim) {
@@ -2546,13 +2547,13 @@ Tensor* uop_cummax(Tensor* a, int dim) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    CumsumParams* params = malloc(sizeof(CumsumParams));
+    CumsumParams* params = cml_malloc(sizeof(CumsumParams));
     if (!params) return NULL;
     params->dim = dim < 0 ? a->ndim + dim : dim;
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, UOP_CUMMAX, inputs, 1, params) != 0) {
-        free(params); return NULL;
+        cml_free(params); return NULL;
     }
 
     struct IRNode* node = cml_ir_get_tail(ir);
@@ -2566,13 +2567,13 @@ Tensor* uop_cummin(Tensor* a, int dim) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    CumsumParams* params = malloc(sizeof(CumsumParams));
+    CumsumParams* params = cml_malloc(sizeof(CumsumParams));
     if (!params) return NULL;
     params->dim = dim < 0 ? a->ndim + dim : dim;
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, UOP_CUMMIN, inputs, 1, params) != 0) {
-        free(params); return NULL;
+        cml_free(params); return NULL;
     }
 
     struct IRNode* node = cml_ir_get_tail(ir);
@@ -2597,13 +2598,13 @@ Tensor* uop_cat(Tensor** tensors, int num_tensors, int dim) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    CatParams* params = malloc(sizeof(CatParams));
+    CatParams* params = cml_malloc(sizeof(CatParams));
     if (!params) return NULL;
     params->dim = dim;
     params->num_tensors = num_tensors;
 
     if (cml_ir_add_uop(ir, UOP_CAT, tensors, num_tensors, params) != 0) {
-        free(params); return NULL;
+        cml_free(params); return NULL;
     }
 
     struct IRNode* node = cml_ir_get_tail(ir);
@@ -2633,18 +2634,18 @@ Tensor* uop_stack(Tensor** tensors, int num_tensors, int dim) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    StackParams* params = malloc(sizeof(StackParams));
+    StackParams* params = cml_malloc(sizeof(StackParams));
     if (!params) return NULL;
     params->dim = dim;
     params->num_tensors = num_tensors;
 
     if (cml_ir_add_uop(ir, UOP_STACK, tensors, num_tensors, params) != 0) {
-        free(params); return NULL;
+        cml_free(params); return NULL;
     }
 
     struct IRNode* node = cml_ir_get_tail(ir);
     int out_ndim = ndim + 1;
-    int* out_shape = malloc((size_t)out_ndim * sizeof(int));
+    int* out_shape = cml_malloc((size_t)out_ndim * sizeof(int));
     if (!out_shape) return NULL;
     int si = 0;
     for (int d = 0; d < out_ndim; d++) {
@@ -2663,13 +2664,13 @@ Tensor* uop_scatter(Tensor* a, int dim, Tensor* index, Tensor* src) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    ScatterParams* params = malloc(sizeof(ScatterParams));
+    ScatterParams* params = cml_malloc(sizeof(ScatterParams));
     if (!params) return NULL;
     params->dim = dim;
 
     Tensor* inputs[] = {a, index, src};
     if (cml_ir_add_uop(ir, UOP_SCATTER, inputs, 3, params) != 0) {
-        free(params); return NULL;
+        cml_free(params); return NULL;
     }
 
     struct IRNode* node = cml_ir_get_tail(ir);
@@ -2685,14 +2686,14 @@ Tensor* uop_roll(Tensor* a, int shift, int dim) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    RollParams* params = malloc(sizeof(RollParams));
+    RollParams* params = cml_malloc(sizeof(RollParams));
     if (!params) return NULL;
     params->shift = shift;
     params->dim = dim;
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, UOP_ROLL, inputs, 1, params) != 0) {
-        free(params); return NULL;
+        cml_free(params); return NULL;
     }
 
     struct IRNode* node = cml_ir_get_tail(ir);
@@ -2714,19 +2715,19 @@ Tensor* uop_flatten(Tensor* a, int start_dim, int end_dim) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    FlattenParams* params = malloc(sizeof(FlattenParams));
+    FlattenParams* params = cml_malloc(sizeof(FlattenParams));
     if (!params) return NULL;
     params->start_dim = start_dim;
     params->end_dim = end_dim;
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, UOP_FLATTEN, inputs, 1, params) != 0) {
-        free(params); return NULL;
+        cml_free(params); return NULL;
     }
 
     struct IRNode* node = cml_ir_get_tail(ir);
     int out_ndim = a->ndim - (end_dim - start_dim);
-    int* out_shape = malloc((size_t)out_ndim * sizeof(int));
+    int* out_shape = cml_malloc((size_t)out_ndim * sizeof(int));
     if (!out_shape) return NULL;
     int oi = 0;
     for (int i = 0; i < a->ndim; i++) {
@@ -2760,22 +2761,22 @@ Tensor* uop_unflatten(Tensor* a, int dim, int* sizes, int num_sizes) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    UnflattenParams* params = malloc(sizeof(UnflattenParams));
+    UnflattenParams* params = cml_malloc(sizeof(UnflattenParams));
     if (!params) return NULL;
     params->dim = dim;
     params->num_sizes = num_sizes;
-    params->sizes = malloc((size_t)num_sizes * sizeof(int));
-    if (!params->sizes) { free(params); return NULL; }
+    params->sizes = cml_malloc((size_t)num_sizes * sizeof(int));
+    if (!params->sizes) { cml_free(params); return NULL; }
     memcpy(params->sizes, sizes, (size_t)num_sizes * sizeof(int));
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, UOP_UNFLATTEN, inputs, 1, params) != 0) {
-        free(params->sizes); free(params); return NULL;
+        cml_free(params->sizes); cml_free(params); return NULL;
     }
 
     struct IRNode* node = cml_ir_get_tail(ir);
     int out_ndim = a->ndim - 1 + num_sizes;
-    int* out_shape = malloc((size_t)out_ndim * sizeof(int));
+    int* out_shape = cml_malloc((size_t)out_ndim * sizeof(int));
     if (!out_shape) return NULL;
     int oi = 0;
     for (int i = 0; i < a->ndim; i++) {
@@ -2800,13 +2801,13 @@ Tensor* uop_diag(Tensor* a, int offset) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    DiagParams* params = malloc(sizeof(DiagParams));
+    DiagParams* params = cml_malloc(sizeof(DiagParams));
     if (!params) return NULL;
     params->offset = offset;
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, UOP_DIAG, inputs, 1, params) != 0) {
-        free(params); return NULL;
+        cml_free(params); return NULL;
     }
 
     struct IRNode* node = cml_ir_get_tail(ir);
@@ -2827,7 +2828,7 @@ Tensor* uop_diag(Tensor* a, int offset) {
         node->output_shape = tensor_shape_copy(out_shape, 1);
         node->output_ndim = 1;
     } else {
-        free(params); return NULL;
+        cml_free(params); return NULL;
     }
     return tensor_from_ir_node(node, ir);
 }
@@ -2838,18 +2839,18 @@ Tensor* uop_one_hot(Tensor* a, int num_classes) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    OneHotParams* params = malloc(sizeof(OneHotParams));
+    OneHotParams* params = cml_malloc(sizeof(OneHotParams));
     if (!params) return NULL;
     params->num_classes = num_classes;
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, UOP_ONE_HOT, inputs, 1, params) != 0) {
-        free(params); return NULL;
+        cml_free(params); return NULL;
     }
 
     struct IRNode* node = cml_ir_get_tail(ir);
     int out_ndim = a->ndim + 1;
-    int* out_shape = malloc((size_t)out_ndim * sizeof(int));
+    int* out_shape = cml_malloc((size_t)out_ndim * sizeof(int));
     if (!out_shape) return NULL;
     for (int i = 0; i < a->ndim; i++) out_shape[i] = a->shape[i];
     out_shape[a->ndim] = num_classes;
@@ -2891,20 +2892,20 @@ Tensor* uop_tile(Tensor* a, int* repeats, int num_dims) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    TileParams* params = malloc(sizeof(TileParams));
+    TileParams* params = cml_malloc(sizeof(TileParams));
     if (!params) return NULL;
     params->num_dims = num_dims;
-    params->repeats = malloc((size_t)num_dims * sizeof(int));
-    if (!params->repeats) { free(params); return NULL; }
+    params->repeats = cml_malloc((size_t)num_dims * sizeof(int));
+    if (!params->repeats) { cml_free(params); return NULL; }
     memcpy(params->repeats, repeats, (size_t)num_dims * sizeof(int));
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, UOP_TILE, inputs, 1, params) != 0) {
-        free(params->repeats); free(params); return NULL;
+        cml_free(params->repeats); cml_free(params); return NULL;
     }
 
     struct IRNode* node = cml_ir_get_tail(ir);
-    int* out_shape = malloc((size_t)num_dims * sizeof(int));
+    int* out_shape = cml_malloc((size_t)num_dims * sizeof(int));
     if (!out_shape) return NULL;
     for (int i = 0; i < num_dims; i++)
         out_shape[i] = a->shape[i] * repeats[i];
@@ -2925,14 +2926,14 @@ Tensor* uop_repeat_interleave(Tensor* a, int repeats, int dim) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    RepeatInterleaveParams* params = malloc(sizeof(RepeatInterleaveParams));
+    RepeatInterleaveParams* params = cml_malloc(sizeof(RepeatInterleaveParams));
     if (!params) return NULL;
     params->repeats = repeats;
     params->dim = dim;
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, UOP_REPEAT_INTERLEAVE, inputs, 1, params) != 0) {
-        free(params); return NULL;
+        cml_free(params); return NULL;
     }
 
     struct IRNode* node = cml_ir_get_tail(ir);
@@ -2974,15 +2975,15 @@ Tensor* uop_shrink(Tensor* a, int* starts, int* ends, int num_dims) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    ShrinkParams* params = malloc(sizeof(ShrinkParams));
+    ShrinkParams* params = cml_malloc(sizeof(ShrinkParams));
     if (!params) return NULL;
     params->num_dims = num_dims;
-    params->starts = malloc((size_t)num_dims * sizeof(int));
-    params->ends = malloc((size_t)num_dims * sizeof(int));
+    params->starts = cml_malloc((size_t)num_dims * sizeof(int));
+    params->ends = cml_malloc((size_t)num_dims * sizeof(int));
     if (!params->starts || !params->ends) {
-        if (params->starts) free(params->starts);
-        if (params->ends) free(params->ends);
-        free(params);
+        if (params->starts) cml_free(params->starts);
+        if (params->ends) cml_free(params->ends);
+        cml_free(params);
         return NULL;
     }
     memcpy(params->starts, starts, (size_t)num_dims * sizeof(int));
@@ -2990,11 +2991,11 @@ Tensor* uop_shrink(Tensor* a, int* starts, int* ends, int num_dims) {
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, UOP_SHRINK, inputs, 1, params) != 0) {
-        free(params->starts); free(params->ends); free(params); return NULL;
+        cml_free(params->starts); cml_free(params->ends); cml_free(params); return NULL;
     }
 
     struct IRNode* node = cml_ir_get_tail(ir);
-    int* out_shape = malloc((size_t)num_dims * sizeof(int));
+    int* out_shape = cml_malloc((size_t)num_dims * sizeof(int));
     if (!out_shape) return NULL;
     for (int i = 0; i < num_dims; i++)
         out_shape[i] = ends[i] - starts[i];
@@ -3012,13 +3013,13 @@ Tensor* uop_logcumsumexp(Tensor* a, int dim) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    CumsumParams* params = malloc(sizeof(CumsumParams));
+    CumsumParams* params = cml_malloc(sizeof(CumsumParams));
     if (!params) return NULL;
     params->dim = dim < 0 ? a->ndim + dim : dim;
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, UOP_LOGCUMSUMEXP, inputs, 1, params) != 0) {
-        free(params); return NULL;
+        cml_free(params); return NULL;
     }
 
     struct IRNode* node = cml_ir_get_tail(ir);
@@ -3061,14 +3062,14 @@ Tensor* uop_celu(Tensor* x, float alpha) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    ClampParams* params = malloc(sizeof(ClampParams));
+    ClampParams* params = cml_malloc(sizeof(ClampParams));
     if (!params) return NULL;
     params->min_val = alpha; 
     params->max_val = 0.0f;  
 
     Tensor* inputs[] = {x};
     if (cml_ir_add_uop(ir, UOP_CELU, inputs, 1, params) != 0) {
-        free(params); return NULL;
+        cml_free(params); return NULL;
     }
 
     struct IRNode* node = cml_ir_get_tail(ir);
@@ -3152,14 +3153,14 @@ Tensor* uop_unfold(Tensor* a, int kernel_size, int stride) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    UnfoldParams* params = malloc(sizeof(UnfoldParams));
+    UnfoldParams* params = cml_malloc(sizeof(UnfoldParams));
     if (!params) return NULL;
     params->kernel_size = kernel_size;
     params->stride = stride > 0 ? stride : 1;
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, UOP_UNFOLD, inputs, 1, params) != 0) {
-        free(params);
+        cml_free(params);
         return NULL;
     }
 
@@ -3175,7 +3176,7 @@ Tensor* uop_unfold(Tensor* a, int kernel_size, int stride) {
     }
 
     int out_ndim = a->ndim + 1;
-    node->output_shape = malloc((size_t)out_ndim * sizeof(int));
+    node->output_shape = cml_malloc((size_t)out_ndim * sizeof(int));
     for (int i = 0; i < a->ndim - 1; i++) {
         node->output_shape[i] = a->shape[i];
     }
@@ -3203,14 +3204,14 @@ Tensor* uop_elu(Tensor* x, float alpha) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    ClampParams* params = malloc(sizeof(ClampParams));
+    ClampParams* params = cml_malloc(sizeof(ClampParams));
     if (!params) return NULL;
     params->min_val = alpha;
     params->max_val = 0.0f; 
 
     Tensor* inputs[] = {x};
     if (cml_ir_add_uop(ir, UOP_ELU, inputs, 1, params) != 0) {
-        free(params);
+        cml_free(params);
         return NULL;
     }
 
@@ -3308,7 +3309,7 @@ Tensor* uop_masked_select(Tensor* a, Tensor* mask) {
 
     struct IRNode* node = cml_ir_get_tail(ir);
     
-    node->output_shape = malloc(sizeof(int));
+    node->output_shape = cml_malloc(sizeof(int));
     if (!node->output_shape) return NULL;
     node->output_shape[0] = (int)a->numel; 
     node->output_ndim = 1;
@@ -3324,7 +3325,7 @@ Tensor** uop_split(Tensor* a, int split_size, int dim, int* num_splits) {
     int n_splits = (dim_size + split_size - 1) / split_size;
     *num_splits = n_splits;
 
-    Tensor** results = malloc((size_t)n_splits * sizeof(Tensor*));
+    Tensor** results = cml_malloc((size_t)n_splits * sizeof(Tensor*));
     if (!results) return NULL;
 
     for (int i = 0; i < n_splits; i++) {
@@ -3333,12 +3334,12 @@ Tensor** uop_split(Tensor* a, int split_size, int dim, int* num_splits) {
         if (end > dim_size) end = dim_size;
 
         
-        int* starts = calloc((size_t)a->ndim, sizeof(int));
-        int* ends = malloc((size_t)a->ndim * sizeof(int));
-        int* steps = malloc((size_t)a->ndim * sizeof(int));
+        int* starts = cml_calloc((size_t)a->ndim, sizeof(int));
+        int* ends = cml_malloc((size_t)a->ndim * sizeof(int));
+        int* steps = cml_malloc((size_t)a->ndim * sizeof(int));
         if (!starts || !ends || !steps) {
-            free(starts); free(ends); free(steps);
-            free(results);
+            cml_free(starts); cml_free(ends); cml_free(steps);
+            cml_free(results);
             return NULL;
         }
         for (int d = 0; d < a->ndim; d++) {
@@ -3347,8 +3348,8 @@ Tensor** uop_split(Tensor* a, int split_size, int dim, int* num_splits) {
             steps[d] = 1;
         }
 
-        SliceParams* sp = malloc(sizeof(SliceParams));
-        if (!sp) { free(starts); free(ends); free(steps); free(results); return NULL; }
+        SliceParams* sp = cml_malloc(sizeof(SliceParams));
+        if (!sp) { cml_free(starts); cml_free(ends); cml_free(steps); cml_free(results); return NULL; }
         sp->start = starts;
         sp->end = ends;
         sp->step = steps;
@@ -3375,33 +3376,33 @@ Tensor** uop_meshgrid(Tensor** tensors, int num_tensors, int* num_outputs) {
     *num_outputs = num_tensors;
 
     
-    int* out_shape = malloc((size_t)num_tensors * sizeof(int));
+    int* out_shape = cml_malloc((size_t)num_tensors * sizeof(int));
     if (!out_shape) return NULL;
     for (int i = 0; i < num_tensors; i++) {
-        if (!tensors[i]) { free(out_shape); return NULL; }
+        if (!tensors[i]) { cml_free(out_shape); return NULL; }
         out_shape[i] = (int)tensors[i]->numel;
     }
 
-    Tensor** results = malloc((size_t)num_tensors * sizeof(Tensor*));
-    if (!results) { free(out_shape); return NULL; }
+    Tensor** results = cml_malloc((size_t)num_tensors * sizeof(Tensor*));
+    if (!results) { cml_free(out_shape); return NULL; }
 
     for (int i = 0; i < num_tensors; i++) {
         
-        int* reshape = malloc((size_t)num_tensors * sizeof(int));
-        if (!reshape) { free(out_shape); free(results); return NULL; }
+        int* reshape = cml_malloc((size_t)num_tensors * sizeof(int));
+        if (!reshape) { cml_free(out_shape); cml_free(results); return NULL; }
         for (int j = 0; j < num_tensors; j++) {
             reshape[j] = (i == j) ? out_shape[j] : 1;
         }
         Tensor* reshaped = uop_reshape(tensors[i], &(ReshapeParams){.new_shape = reshape, .new_ndim = num_tensors});
-        free(reshape);
-        if (!reshaped) { free(out_shape); free(results); return NULL; }
+        cml_free(reshape);
+        if (!reshaped) { cml_free(out_shape); cml_free(results); return NULL; }
 
         
         ExpandParams ep = {.new_shape = out_shape, .new_ndim = num_tensors};
         results[i] = uop_expand(reshaped, &ep);
     }
 
-    free(out_shape);
+    cml_free(out_shape);
     return results;
 }
 
@@ -3414,13 +3415,13 @@ Tensor* uop_diagonal(Tensor* a, int offset, int dim1, int dim2) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    DiagParams* params = malloc(sizeof(DiagParams));
+    DiagParams* params = cml_malloc(sizeof(DiagParams));
     if (!params) return NULL;
     params->offset = offset;
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, UOP_DIAGONAL, inputs, 1, params) != 0) {
-        free(params);
+        cml_free(params);
         return NULL;
     }
 
@@ -3439,7 +3440,7 @@ Tensor* uop_diagonal(Tensor* a, int offset, int dim1, int dim2) {
 
     
     int out_ndim = a->ndim - 1;
-    int* out_shape = malloc((size_t)out_ndim * sizeof(int));
+    int* out_shape = cml_malloc((size_t)out_ndim * sizeof(int));
     if (!out_shape) return NULL;
     int oi = 0;
     for (int d = 0; d < a->ndim; d++) {
@@ -3461,22 +3462,22 @@ Tensor* uop_pad_reflect(Tensor* a, int* pad_widths, int num_dims) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    PadParams* params = malloc(sizeof(PadParams));
+    PadParams* params = cml_malloc(sizeof(PadParams));
     if (!params) return NULL;
     params->num_dims = num_dims;
     params->value = 0.0f;
     params->mode = PAD_REFLECT;
-    params->pad_widths = malloc((size_t)(num_dims * 2) * sizeof(int));
-    if (!params->pad_widths) { free(params); return NULL; }
+    params->pad_widths = cml_malloc((size_t)(num_dims * 2) * sizeof(int));
+    if (!params->pad_widths) { cml_free(params); return NULL; }
     memcpy(params->pad_widths, pad_widths, (size_t)(num_dims * 2) * sizeof(int));
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, UOP_PAD, inputs, 1, params) != 0) {
-        free(params->pad_widths); free(params); return NULL;
+        cml_free(params->pad_widths); cml_free(params); return NULL;
     }
 
     struct IRNode* node = cml_ir_get_tail(ir);
-    int* out_shape = malloc((size_t)a->ndim * sizeof(int));
+    int* out_shape = cml_malloc((size_t)a->ndim * sizeof(int));
     if (!out_shape) return NULL;
     for (int i = 0; i < a->ndim; i++) {
         out_shape[i] = a->shape[i] + pad_widths[i * 2] + pad_widths[i * 2 + 1];
@@ -3495,22 +3496,22 @@ Tensor* uop_pad_replicate(Tensor* a, int* pad_widths, int num_dims) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    PadParams* params = malloc(sizeof(PadParams));
+    PadParams* params = cml_malloc(sizeof(PadParams));
     if (!params) return NULL;
     params->num_dims = num_dims;
     params->value = 0.0f;
     params->mode = PAD_REPLICATE;
-    params->pad_widths = malloc((size_t)(num_dims * 2) * sizeof(int));
-    if (!params->pad_widths) { free(params); return NULL; }
+    params->pad_widths = cml_malloc((size_t)(num_dims * 2) * sizeof(int));
+    if (!params->pad_widths) { cml_free(params); return NULL; }
     memcpy(params->pad_widths, pad_widths, (size_t)(num_dims * 2) * sizeof(int));
 
     Tensor* inputs[] = {a};
     if (cml_ir_add_uop(ir, UOP_PAD, inputs, 1, params) != 0) {
-        free(params->pad_widths); free(params); return NULL;
+        cml_free(params->pad_widths); cml_free(params); return NULL;
     }
 
     struct IRNode* node = cml_ir_get_tail(ir);
-    int* out_shape = malloc((size_t)a->ndim * sizeof(int));
+    int* out_shape = cml_malloc((size_t)a->ndim * sizeof(int));
     if (!out_shape) return NULL;
     for (int i = 0; i < a->ndim; i++) {
         out_shape[i] = a->shape[i] + pad_widths[i * 2] + pad_widths[i * 2 + 1];
@@ -3534,7 +3535,7 @@ Tensor* uop_scaled_dot_product_attention(Tensor* q, Tensor* k, Tensor* v, Tensor
 
     
     PermuteParams perm_params = {0};
-    int* perm = malloc((size_t)k->ndim * sizeof(int));
+    int* perm = cml_malloc((size_t)k->ndim * sizeof(int));
     if (!perm) return NULL;
     for (int i = 0; i < k->ndim - 2; i++) perm[i] = i;
     perm[k->ndim - 2] = k->ndim - 1;
@@ -3543,7 +3544,7 @@ Tensor* uop_scaled_dot_product_attention(Tensor* q, Tensor* k, Tensor* v, Tensor
     perm_params.num_dims = k->ndim;
 
     Tensor* kt = uop_permute(k, &perm_params);
-    free(perm);
+    cml_free(perm);
     if (!kt) return NULL;
 
     
@@ -3900,19 +3901,19 @@ Tensor* uop_alloc(int* shape, int ndim, DType dtype, DeviceType device) {
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    AllocParams* params = malloc(sizeof(AllocParams));
+    AllocParams* params = cml_malloc(sizeof(AllocParams));
     if (!params) return NULL;
 
     params->ndim   = ndim;
     params->dtype  = dtype;
     params->device = device;
-    params->shape  = malloc((size_t)ndim * sizeof(int));
-    if (!params->shape) { free(params); return NULL; }
+    params->shape  = cml_malloc((size_t)ndim * sizeof(int));
+    if (!params->shape) { cml_free(params); return NULL; }
     memcpy(params->shape, shape, (size_t)ndim * sizeof(int));
 
     if (cml_ir_add_uop(ir, UOP_ALLOC, NULL, 0, params) != 0) {
-        free(params->shape);
-        free(params);
+        cml_free(params->shape);
+        cml_free(params);
         return NULL;
     }
 
@@ -3937,7 +3938,7 @@ Tensor* uop_sgd_step(Tensor* param, Tensor* grad, Tensor* momentum_buf,
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    SgdStepParams* cp = malloc(sizeof(SgdStepParams));
+    SgdStepParams* cp = cml_malloc(sizeof(SgdStepParams));
     if (!cp) return NULL;
     *cp = *p;
 
@@ -3951,7 +3952,7 @@ Tensor* uop_sgd_step(Tensor* param, Tensor* grad, Tensor* momentum_buf,
     }
 
     if (cml_ir_add_uop(ir, UOP_SGD_STEP, inputs, n_inputs, cp) != 0) {
-        free(cp);
+        cml_free(cp);
         return NULL;
     }
 
@@ -3975,7 +3976,7 @@ Tensor* uop_adam_step(Tensor* param, Tensor* grad, Tensor* exp_avg,
     CMLGraph_t ir = cml_ir_get_or_create_context();
     if (!ir) return NULL;
 
-    AdamStepParams* cp = malloc(sizeof(AdamStepParams));
+    AdamStepParams* cp = cml_malloc(sizeof(AdamStepParams));
     if (!cp) return NULL;
     *cp = *p;
 
@@ -3991,7 +3992,7 @@ Tensor* uop_adam_step(Tensor* param, Tensor* grad, Tensor* exp_avg,
     }
 
     if (cml_ir_add_uop(ir, UOP_ADAM_STEP, inputs, n_inputs, cp) != 0) {
-        free(cp);
+        cml_free(cp);
         return NULL;
     }
 

--- a/src/ops/winograd.c
+++ b/src/ops/winograd.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 /* Static transform matrices for F(2x2, 3x3)
  * tile_size = 4, output_tile = 2, kernel = 3 */
@@ -240,7 +241,7 @@ int winograd_conv2d(const float *input, const float *weight, const float *bias,
     int out_channels_per_group = out_channels / groups;
 
     size_t U_size = (size_t)out_channels * in_channels_per_group * ts * ts;
-    float *U = (float *)malloc(U_size * sizeof(float));
+    float *U = (float *)cml_malloc(U_size * sizeof(float));
     if (!U) return -1;
 
     {
@@ -304,19 +305,19 @@ int winograd_conv2d(const float *input, const float *weight, const float *bias,
     size_t ts2  = (size_t)ts * ts;
     size_t ot2  = (size_t)out_tile * out_tile;
 
-    float *tile_buf = (float *)malloc(ts2 * sizeof(float));
-    float *V_buf    = (float *)malloc(ts2 * sizeof(float));
-    float *Y_buf    = (float *)malloc(ot2 * sizeof(float));
-    float *tmp1     = (float *)malloc(ts2 * sizeof(float));
-    float *acc_buf  = (float *)malloc(ts2 * sizeof(float));
+    float *tile_buf = (float *)cml_malloc(ts2 * sizeof(float));
+    float *V_buf    = (float *)cml_malloc(ts2 * sizeof(float));
+    float *Y_buf    = (float *)cml_malloc(ot2 * sizeof(float));
+    float *tmp1     = (float *)cml_malloc(ts2 * sizeof(float));
+    float *acc_buf  = (float *)cml_malloc(ts2 * sizeof(float));
 
     if (!tile_buf || !V_buf || !Y_buf || !tmp1 || !acc_buf) {
-        free(U);
-        free(tile_buf);
-        free(V_buf);
-        free(Y_buf);
-        free(tmp1);
-        free(acc_buf);
+        cml_free(U);
+        cml_free(tile_buf);
+        cml_free(V_buf);
+        cml_free(Y_buf);
+        cml_free(tmp1);
+        cml_free(acc_buf);
         return -1;
     }
 
@@ -386,12 +387,12 @@ int winograd_conv2d(const float *input, const float *weight, const float *bias,
         }
     }
 
-    free(U);
-    free(tile_buf);
-    free(V_buf);
-    free(Y_buf);
-    free(tmp1);
-    free(acc_buf);
+    cml_free(U);
+    cml_free(tile_buf);
+    cml_free(V_buf);
+    cml_free(Y_buf);
+    cml_free(tmp1);
+    cml_free(acc_buf);
 
     return 0;
 }

--- a/src/optim.c
+++ b/src/optim.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 int optimizer_init(Optimizer* optimizer, const char* name, StepFn step, ZeroGradFn zero_grad) {
     if (!optimizer || !name || !step || !zero_grad)
@@ -36,7 +37,7 @@ int optimizer_init(Optimizer* optimizer, const char* name, StepFn step, ZeroGrad
 }
 
 Optimizer* optimizer_create(const char* name, StepFn step, ZeroGradFn zero_grad) {
-    Optimizer* optimizer = malloc(sizeof(Optimizer));
+    Optimizer* optimizer = cml_malloc(sizeof(Optimizer));
     if (!optimizer) {
         error_stack_push(CM_MEMORY_ALLOCATION_ERROR, "Failed to allocate memory for Optimizer",
                          __FILE__, __LINE__, __func__);
@@ -46,7 +47,7 @@ Optimizer* optimizer_create(const char* name, StepFn step, ZeroGradFn zero_grad)
     if (optimizer_init(optimizer, name, step, zero_grad) != 0) {
         error_stack_push(CM_OPERATION_FAILED, "Failed to initialize Optimizer", __FILE__, __LINE__,
                          __func__);
-        free(optimizer);
+        cml_free(optimizer);
         return NULL;
     }
 
@@ -92,13 +93,13 @@ typedef struct MuonState {
 typedef void (*StateInitFn)(void* state, Tensor* tensor, TensorConfig* config);
 
 static void* optimizer_alloc_state(ParameterGroup* group, size_t state_size, StateInitFn init_fn) {
-    void** states = malloc((size_t)group->num_parameters * sizeof(void*));
+    void** states = cml_malloc((size_t)group->num_parameters * sizeof(void*));
     if (!states) return NULL;
     memset(states, 0, (size_t)group->num_parameters * sizeof(void*));
     for (int i = 0; i < group->num_parameters; i++) {
         Parameter* param = group->parameters[i];
         if (!param || !param->tensor) continue;
-        void* state = calloc(1, state_size);
+        void* state = cml_calloc(1, state_size);
         if (!state) continue;
         TensorConfig config = {.dtype = param->tensor->dtype, .device = param->tensor->device,
                                .has_dtype = true, .has_device = true};
@@ -173,7 +174,7 @@ void optimizer_free(Optimizer* optimizer) {
         for (int i = 0; i < optimizer->num_param_groups; i++) {
             ParameterGroup* group = &optimizer->param_groups[i];
             if (group->parameters) {
-                free(group->parameters);
+                cml_free(group->parameters);
             }
             if (group->state) {
                 if (strcmp(optimizer->name, "SGD") == 0) {
@@ -183,10 +184,10 @@ void optimizer_free(Optimizer* optimizer) {
                             if (states[j]->momentum_buffer) {
                                 tensor_free(states[j]->momentum_buffer);
                             }
-                            free(states[j]);
+                            cml_free(states[j]);
                         }
                     }
-                    free(states);
+                    cml_free(states);
                 } else if (strcmp(optimizer->name, "Adam") == 0) {
                     AdamState** states = (AdamState**)group->state;
                     for (int j = 0; j < group->num_parameters; j++) {
@@ -197,30 +198,30 @@ void optimizer_free(Optimizer* optimizer) {
                                 tensor_free(states[j]->exp_avg_sq);
                             if (states[j]->max_exp_avg_sq)
                                 tensor_free(states[j]->max_exp_avg_sq);
-                            free(states[j]);
+                            cml_free(states[j]);
                         }
                     }
-                    free(states);
+                    cml_free(states);
                 } else if (strcmp(optimizer->name, "RMSprop") == 0) {
                     RMSpropState** states = (RMSpropState**)group->state;
                     for (int j = 0; j < group->num_parameters; j++) {
                         if (states[j]) {
                             if (states[j]->square_avg)
                                 tensor_free(states[j]->square_avg);
-                            free(states[j]);
+                            cml_free(states[j]);
                         }
                     }
-                    free(states);
+                    cml_free(states);
                 } else if (strcmp(optimizer->name, "Adagrad") == 0) {
                     AdagradState** states = (AdagradState**)group->state;
                     for (int j = 0; j < group->num_parameters; j++) {
                         if (states[j]) {
                             if (states[j]->sum_sq_grad)
                                 tensor_free(states[j]->sum_sq_grad);
-                            free(states[j]);
+                            cml_free(states[j]);
                         }
                     }
-                    free(states);
+                    cml_free(states);
                 } else if (strcmp(optimizer->name, "AdamW") == 0) {
                     AdamState** states = (AdamState**)group->state;
                     for (int j = 0; j < group->num_parameters; j++) {
@@ -231,10 +232,10 @@ void optimizer_free(Optimizer* optimizer) {
                                 tensor_free(states[j]->exp_avg_sq);
                             if (states[j]->max_exp_avg_sq)
                                 tensor_free(states[j]->max_exp_avg_sq);
-                            free(states[j]);
+                            cml_free(states[j]);
                         }
                     }
-                    free(states);
+                    cml_free(states);
                 } else if (strcmp(optimizer->name, "AdaDelta") == 0) {
                     AdaDeltaState** states = (AdaDeltaState**)group->state;
                     for (int j = 0; j < group->num_parameters; j++) {
@@ -243,10 +244,10 @@ void optimizer_free(Optimizer* optimizer) {
                                 tensor_free(states[j]->acc_grad);
                             if (states[j]->acc_update)
                                 tensor_free(states[j]->acc_update);
-                            free(states[j]);
+                            cml_free(states[j]);
                         }
                     }
-                    free(states);
+                    cml_free(states);
                 } else if (strcmp(optimizer->name, "LAMB") == 0) {
                     LAMBState** states = (LAMBState**)group->state;
                     for (int j = 0; j < group->num_parameters; j++) {
@@ -255,30 +256,30 @@ void optimizer_free(Optimizer* optimizer) {
                                 tensor_free(states[j]->exp_avg);
                             if (states[j]->exp_avg_sq)
                                 tensor_free(states[j]->exp_avg_sq);
-                            free(states[j]);
+                            cml_free(states[j]);
                         }
                     }
-                    free(states);
+                    cml_free(states);
                 } else if (strcmp(optimizer->name, "Muon") == 0) {
                     MuonState** states = (MuonState**)group->state;
                     for (int j = 0; j < group->num_parameters; j++) {
                         if (states[j]) {
                             if (states[j]->momentum_buffer)
                                 tensor_free(states[j]->momentum_buffer);
-                            free(states[j]);
+                            cml_free(states[j]);
                         }
                     }
-                    free(states);
+                    cml_free(states);
                 } else if (strcmp(optimizer->name, "LARS") == 0) {
                     LARSState** states = (LARSState**)group->state;
                     for (int j = 0; j < group->num_parameters; j++) {
                         if (states[j]) {
                             if (states[j]->momentum_buffer)
                                 tensor_free(states[j]->momentum_buffer);
-                            free(states[j]);
+                            cml_free(states[j]);
                         }
                     }
-                    free(states);
+                    cml_free(states);
                 } else if (strcmp(optimizer->name, "Nadam") == 0 ||
                            strcmp(optimizer->name, "AdaMax") == 0) {
                     AdamState** states = (AdamState**)group->state;
@@ -290,20 +291,20 @@ void optimizer_free(Optimizer* optimizer) {
                                 tensor_free(states[j]->exp_avg_sq);
                             if (states[j]->max_exp_avg_sq)
                                 tensor_free(states[j]->max_exp_avg_sq);
-                            free(states[j]);
+                            cml_free(states[j]);
                         }
                     }
-                    free(states);
+                    cml_free(states);
                 } else {
                     // Generic state cleanup
-                    free(group->state);
+                    cml_free(group->state);
                 }
             }
         }
-        free(optimizer->param_groups);
+        cml_free(optimizer->param_groups);
     }
 
-    free(optimizer);
+    cml_free(optimizer);
 }
 
 int optimizer_add_param_group(Optimizer* optimizer, Parameter** parameters, int num_parameters,
@@ -317,7 +318,7 @@ int optimizer_add_param_group(Optimizer* optimizer, Parameter** parameters, int 
         int new_capacity =
             optimizer->param_groups_capacity == 0 ? 4 : optimizer->param_groups_capacity * 2;
         ParameterGroup* new_groups =
-            realloc(optimizer->param_groups, (size_t)new_capacity * sizeof(ParameterGroup));
+            cml_realloc(optimizer->param_groups, (size_t)new_capacity * sizeof(ParameterGroup));
         if (!new_groups) {
             LOG_ERROR("Failed to allocate memory for parameter groups");
             return -1;
@@ -328,7 +329,7 @@ int optimizer_add_param_group(Optimizer* optimizer, Parameter** parameters, int 
 
     ParameterGroup* group = &optimizer->param_groups[optimizer->num_param_groups];
 
-    group->parameters = malloc((size_t)num_parameters * sizeof(Parameter*));
+    group->parameters = cml_malloc((size_t)num_parameters * sizeof(Parameter*));
     if (!group->parameters) {
         LOG_ERROR("Failed to allocate memory for parameter group parameters");
         return -1;
@@ -1114,7 +1115,7 @@ Optimizer* optim_adam_for_model(Module* model, float lr, float weight_decay, flo
     }
 
     Optimizer* optimizer = optim_adam(params, num_params, lr, weight_decay, beta1, beta2, eps);
-    free(params);
+    cml_free(params);
 
     if (optimizer) {
         extern void cml_track_optimizer(Optimizer*);
@@ -1400,7 +1401,7 @@ static void muon_step(Optimizer* optimizer) {
             for (size_t j = 0; j < numel; j++)
                 momentum_data[j] = momentum_val * momentum_data[j] + grad_data[j];
 
-            float* update = malloc(numel * sizeof(float));
+            float* update = cml_malloc(numel * sizeof(float));
             if (!update) continue;
 
             if (nesterov) {
@@ -1415,7 +1416,7 @@ static void muon_step(Optimizer* optimizer) {
             for (size_t j = 0; j < numel; j++)
                 param_data[j] -= lr * update[j];
 
-            free(update);
+            cml_free(update);
         }
 
         group->step_count++;
@@ -1592,7 +1593,7 @@ Optimizer* optim_sgd_for_model(Module* model, float lr, float momentum, float we
     }
 
     Optimizer* optimizer = optim_sgd(params, num_params, lr, momentum, weight_decay);
-    free(params);
+    cml_free(params);
 
     return optimizer;
 }

--- a/src/optim/lr_scheduler.c
+++ b/src/optim/lr_scheduler.c
@@ -2,6 +2,7 @@
 #include "core/logging.h"
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 LRScheduler* lr_scheduler_cosine_annealing(Optimizer* optimizer, int T_max, float eta_min) {
     return lr_scheduler_cosine(optimizer, T_max, eta_min);
@@ -14,7 +15,7 @@ LRScheduler* lr_scheduler_multi_step(Optimizer* optimizer, int* milestones, int 
         return NULL;
     }
 
-    LRScheduler* scheduler = malloc(sizeof(LRScheduler));
+    LRScheduler* scheduler = cml_malloc(sizeof(LRScheduler));
     if (!scheduler) return NULL;
 
     memset(scheduler, 0, sizeof(LRScheduler));
@@ -25,9 +26,9 @@ LRScheduler* lr_scheduler_multi_step(Optimizer* optimizer, int* milestones, int 
     scheduler->num_milestones = num_milestones;
     scheduler->last_epoch     = 0;
 
-    scheduler->milestones = malloc(sizeof(int) * (size_t)num_milestones);
+    scheduler->milestones = cml_malloc(sizeof(int) * (size_t)num_milestones);
     if (!scheduler->milestones) {
-        free(scheduler);
+        cml_free(scheduler);
         return NULL;
     }
     memcpy(scheduler->milestones, milestones, sizeof(int) * (size_t)num_milestones);
@@ -57,7 +58,7 @@ LRScheduler* lr_scheduler_one_cycle(Optimizer* optimizer, float max_lr, int tota
         return NULL;
     }
 
-    LRScheduler* scheduler = malloc(sizeof(LRScheduler));
+    LRScheduler* scheduler = cml_malloc(sizeof(LRScheduler));
     if (!scheduler) return NULL;
 
     memset(scheduler, 0, sizeof(LRScheduler));

--- a/src/symbolic/symbolic.c
+++ b/src/symbolic/symbolic.c
@@ -3,12 +3,13 @@
 #include <string.h>
 #include <stdio.h>
 #include <limits.h>
+#include "alloc/cml_allocator.h"
 
 static int g_var_id_counter = 0;
 
 
 static SymExpr* sym_alloc(SymExprType type) {
-    SymExpr* e = (SymExpr*)calloc(1, sizeof(SymExpr));
+    SymExpr* e = (SymExpr*)cml_calloc(1, sizeof(SymExpr));
     if (!e) return NULL;
     e->type = type;
     e->ref_count = 1;
@@ -316,7 +317,7 @@ void sym_expr_release(SymExpr* e) {
         sym_expr_release(e->binop.left);
         sym_expr_release(e->binop.right);
     }
-    free(e);
+    cml_free(e);
 }
 
 
@@ -378,10 +379,10 @@ void sym_dim_release(SymDim* dim) {
 SymShape* sym_shape_from_concrete(const int* dims, int ndim) {
     if (!dims || ndim <= 0) return NULL;
 
-    SymShape* s = (SymShape*)calloc(1, sizeof(SymShape));
+    SymShape* s = (SymShape*)cml_calloc(1, sizeof(SymShape));
     if (!s) return NULL;
-    s->dims = (SymDim*)calloc((size_t)ndim, sizeof(SymDim));
-    if (!s->dims) { free(s); return NULL; }
+    s->dims = (SymDim*)cml_calloc((size_t)ndim, sizeof(SymDim));
+    if (!s->dims) { cml_free(s); return NULL; }
 
     s->ndim = ndim;
     s->ref_count = 1;
@@ -395,10 +396,10 @@ SymShape* sym_shape_broadcast(const SymShape* a, const SymShape* b) {
     if (!a || !b) return NULL;
 
     int max_ndim = a->ndim > b->ndim ? a->ndim : b->ndim;
-    SymShape* out = (SymShape*)calloc(1, sizeof(SymShape));
+    SymShape* out = (SymShape*)cml_calloc(1, sizeof(SymShape));
     if (!out) return NULL;
-    out->dims = (SymDim*)calloc((size_t)max_ndim, sizeof(SymDim));
-    if (!out->dims) { free(out); return NULL; }
+    out->dims = (SymDim*)cml_calloc((size_t)max_ndim, sizeof(SymDim));
+    if (!out->dims) { cml_free(out); return NULL; }
     out->ndim = max_ndim;
     out->ref_count = 1;
 
@@ -518,6 +519,6 @@ void sym_shape_release(SymShape* shape) {
     for (int i = 0; i < shape->ndim; i++) {
         sym_dim_release(&shape->dims[i]);
     }
-    free(shape->dims);
-    free(shape);
+    cml_free(shape->dims);
+    cml_free(shape);
 }

--- a/src/tensor/image_dtype.c
+++ b/src/tensor/image_dtype.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 int cml_image_dtype_channels(CMLImageFormat format) {
     switch (format) {
@@ -107,7 +108,7 @@ CMLImageTensor* cml_image_tensor_create(Tensor* tensor, CMLImageFormat format) {
     if (!cml_image_dtype_compatible(tensor->shape, tensor->ndim, format))
         return NULL;
 
-    CMLImageTensor* img = (CMLImageTensor*)calloc(1, sizeof(CMLImageTensor));
+    CMLImageTensor* img = (CMLImageTensor*)cml_calloc(1, sizeof(CMLImageTensor));
     if (!img) return NULL;
 
     img->tensor = tensor;
@@ -135,7 +136,7 @@ Tensor* cml_image_tensor_to_regular(CMLImageTensor* img) {
 void cml_image_tensor_free(CMLImageTensor* img) {
     if (!img) return;
     /* Note: does NOT free the underlying tensor */
-    free(img);
+    cml_free(img);
 }
 
 size_t cml_image_tensor_memory(const CMLImageTensor* img) {

--- a/src/tensor/realize.c
+++ b/src/tensor/realize.c
@@ -5,6 +5,7 @@
 #include "tensor/tensor.h"
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 bool tensor_is_realized(const Tensor* t) {
     return t != NULL && t->data != NULL;
@@ -27,7 +28,7 @@ int tensor_realize(Tensor* t) {
      * by cml_graph_cache_reset_global() / cml_ir_reset_global_context(). */
     if (t->data && !t->owns_data) {
         size_t nbytes = t->numel * cml_dtype_size(t->dtype);
-        void* owned = malloc(nbytes);
+        void* owned = cml_malloc(nbytes);
         if (owned) {
             memcpy(owned, t->data, nbytes);
             t->data      = owned;
@@ -62,7 +63,7 @@ int tensor_realize_all(Tensor** tensors, int num_tensors) {
 
 void tensor_unrealize(Tensor* t) {
     if (!t || !t->data) return;
-    if (t->owns_data) free(t->data);
+    if (t->owns_data) cml_free(t->data);
     t->data        = NULL;
     t->is_executed = false;
     t->owns_data   = false;

--- a/src/tensor/shape_tracker.c
+++ b/src/tensor/shape_tracker.c
@@ -4,17 +4,18 @@
 #include <string.h>
 #include <stdio.h>
 #include <assert.h>
+#include "alloc/cml_allocator.h"
 
 static int64_t* dup_i64(const int64_t* src, int n) {
     if (!src) return NULL;
-    int64_t* dst = malloc((size_t)n * sizeof(int64_t));
+    int64_t* dst = cml_malloc((size_t)n * sizeof(int64_t));
     if (dst) memcpy(dst, src, (size_t)n * sizeof(int64_t));
     return dst;
 }
 
 static int* dup_int(const int* src, int n) {
     if (!src) return NULL;
-    int* dst = malloc((size_t)n * sizeof(int));
+    int* dst = cml_malloc((size_t)n * sizeof(int));
     if (dst) memcpy(dst, src, (size_t)n * sizeof(int));
     return dst;
 }
@@ -22,7 +23,7 @@ static int* dup_int(const int* src, int n) {
 STView* st_view_create(const int* shape, const int64_t* strides, int64_t offset,
                        const int64_t* mask_begin, const int64_t* mask_end, int ndim) {
     if (!shape || ndim <= 0) return NULL;
-    STView* v = calloc(1, sizeof(STView));
+    STView* v = cml_calloc(1, sizeof(STView));
     if (!v) return NULL;
     v->ndim   = ndim;
     v->offset = offset;
@@ -49,16 +50,16 @@ STView* st_view_copy(const STView* v) {
 
 void st_view_free(STView* v) {
     if (!v) return;
-    free(v->shape);
-    free(v->strides);
-    free(v->mask_begin);
-    free(v->mask_end);
-    free(v);
+    cml_free(v->shape);
+    cml_free(v->strides);
+    cml_free(v->mask_begin);
+    cml_free(v->mask_end);
+    cml_free(v);
 }
 
 STView* st_view_from_shape(const int* shape, int ndim) {
     if (!shape || ndim <= 0) return NULL;
-    int64_t* strides = malloc((size_t)ndim * sizeof(int64_t));
+    int64_t* strides = cml_malloc((size_t)ndim * sizeof(int64_t));
     if (!strides) return NULL;
     
     int64_t stride = 1;
@@ -67,7 +68,7 @@ STView* st_view_from_shape(const int* shape, int ndim) {
         stride *= shape[i];
     }
     STView* v = st_view_create(shape, strides, 0, NULL, NULL, ndim);
-    free(strides);
+    cml_free(strides);
     return v;
 }
 
@@ -85,14 +86,14 @@ bool st_view_is_contiguous(const STView* v) {
 
 ShapeTracker* shape_tracker_create(const int* shape, int ndim) {
     if (!shape || ndim <= 0) return NULL;
-    ShapeTracker* st = calloc(1, sizeof(ShapeTracker));
+    ShapeTracker* st = cml_calloc(1, sizeof(ShapeTracker));
     if (!st) return NULL;
-    st->views = malloc(ST_INIT_CAPACITY * sizeof(STView*));
-    if (!st->views) { free(st); return NULL; }
+    st->views = cml_malloc(ST_INIT_CAPACITY * sizeof(STView*));
+    if (!st->views) { cml_free(st); return NULL; }
     st->views_capacity = ST_INIT_CAPACITY;
     st->num_views = 0;
     STView* v = st_view_from_shape(shape, ndim);
-    if (!v) { free(st->views); free(st); return NULL; }
+    if (!v) { cml_free(st->views); cml_free(st); return NULL; }
     st->views[0] = v;
     st->num_views = 1;
     return st;
@@ -100,16 +101,16 @@ ShapeTracker* shape_tracker_create(const int* shape, int ndim) {
 
 ShapeTracker* shape_tracker_copy(const ShapeTracker* src) {
     if (!src) return NULL;
-    ShapeTracker* dst = calloc(1, sizeof(ShapeTracker));
+    ShapeTracker* dst = cml_calloc(1, sizeof(ShapeTracker));
     if (!dst) return NULL;
-    dst->views = malloc((size_t)src->num_views * sizeof(STView*));
-    if (!dst->views) { free(dst); return NULL; }
+    dst->views = cml_malloc((size_t)src->num_views * sizeof(STView*));
+    if (!dst->views) { cml_free(dst); return NULL; }
     dst->views_capacity = src->num_views;
     for (int i = 0; i < src->num_views; ++i) {
         dst->views[i] = st_view_copy(src->views[i]);
         if (!dst->views[i]) {
             for (int j = 0; j < i; ++j) st_view_free(dst->views[j]);
-            free(dst->views); free(dst); return NULL;
+            cml_free(dst->views); cml_free(dst); return NULL;
         }
     }
     dst->num_views = src->num_views;
@@ -120,8 +121,8 @@ void shape_tracker_free(ShapeTracker* st) {
     if (!st) return;
     for (int i = 0; i < st->num_views; ++i)
         st_view_free(st->views[i]);
-    free(st->views);
-    free(st);
+    cml_free(st->views);
+    cml_free(st);
 }
 
 static STView* st_top(const ShapeTracker* st) {
@@ -131,7 +132,7 @@ static STView* st_top(const ShapeTracker* st) {
 static int st_push(ShapeTracker* st, STView* v) {
     if (st->num_views >= st->views_capacity) {
         int new_cap = st->views_capacity * 2;
-        STView** tmp = realloc(st->views, (size_t)new_cap * sizeof(STView*));
+        STView** tmp = cml_realloc(st->views, (size_t)new_cap * sizeof(STView*));
         if (!tmp) return -1;
         st->views = tmp;
         st->views_capacity = new_cap;
@@ -171,10 +172,10 @@ int shape_tracker_reshape(ShapeTracker* st, const int* new_shape, int new_ndim) 
 
     
     if (st_view_is_contiguous(top)) {
-        free(top->shape);
-        free(top->strides);
+        cml_free(top->shape);
+        cml_free(top->strides);
         top->shape   = dup_int(new_shape, new_ndim);
-        top->strides = malloc((size_t)new_ndim * sizeof(int64_t));
+        top->strides = cml_malloc((size_t)new_ndim * sizeof(int64_t));
         if (!top->shape || !top->strides) return -1;
         int64_t stride = 1;
         for (int i = new_ndim - 1; i >= 0; --i) {
@@ -197,13 +198,13 @@ int shape_tracker_permute(ShapeTracker* st, const int* perm) {
     if (!top) return -1;
     int ndim = top->ndim;
 
-    int* new_shape     = malloc((size_t)ndim * sizeof(int));
-    int64_t* new_strides = malloc((size_t)ndim * sizeof(int64_t));
-    if (!new_shape || !new_strides) { free(new_shape); free(new_strides); return -1; }
+    int* new_shape     = cml_malloc((size_t)ndim * sizeof(int));
+    int64_t* new_strides = cml_malloc((size_t)ndim * sizeof(int64_t));
+    if (!new_shape || !new_strides) { cml_free(new_shape); cml_free(new_strides); return -1; }
 
     for (int i = 0; i < ndim; ++i) {
         int p = perm[i];
-        if (p < 0 || p >= ndim) { free(new_shape); free(new_strides); return -1; }
+        if (p < 0 || p >= ndim) { cml_free(new_shape); cml_free(new_strides); return -1; }
         new_shape[i]   = top->shape[p];
         new_strides[i] = top->strides[p];
     }
@@ -211,20 +212,20 @@ int shape_tracker_permute(ShapeTracker* st, const int* perm) {
     
     memcpy(top->shape,   new_shape,   (size_t)ndim * sizeof(int));
     memcpy(top->strides, new_strides, (size_t)ndim * sizeof(int64_t));
-    free(new_shape);
-    free(new_strides);
+    cml_free(new_shape);
+    cml_free(new_strides);
 
     if (top->has_mask) {
-        int64_t* nb = malloc((size_t)ndim * sizeof(int64_t));
-        int64_t* ne = malloc((size_t)ndim * sizeof(int64_t));
-        if (!nb || !ne) { free(nb); free(ne); return -1; }
+        int64_t* nb = cml_malloc((size_t)ndim * sizeof(int64_t));
+        int64_t* ne = cml_malloc((size_t)ndim * sizeof(int64_t));
+        if (!nb || !ne) { cml_free(nb); cml_free(ne); return -1; }
         for (int i = 0; i < ndim; ++i) {
             nb[i] = top->mask_begin[perm[i]];
             ne[i] = top->mask_end[perm[i]];
         }
         memcpy(top->mask_begin, nb, (size_t)ndim * sizeof(int64_t));
         memcpy(top->mask_end,   ne, (size_t)ndim * sizeof(int64_t));
-        free(nb); free(ne);
+        cml_free(nb); cml_free(ne);
     }
     return 0;
 }
@@ -235,9 +236,9 @@ int shape_tracker_expand(ShapeTracker* st, const int* new_shape, int new_ndim) {
     if (!top) return -1;
     if (new_ndim < top->ndim) return -1;
 
-    int* ns     = malloc((size_t)new_ndim * sizeof(int));
-    int64_t* ss = malloc((size_t)new_ndim * sizeof(int64_t));
-    if (!ns || !ss) { free(ns); free(ss); return -1; }
+    int* ns     = cml_malloc((size_t)new_ndim * sizeof(int));
+    int64_t* ss = cml_malloc((size_t)new_ndim * sizeof(int64_t));
+    if (!ns || !ss) { cml_free(ns); cml_free(ss); return -1; }
 
     
     int offset = new_ndim - top->ndim;
@@ -251,8 +252,8 @@ int shape_tracker_expand(ShapeTracker* st, const int* new_shape, int new_ndim) {
             ss[i] = (top->shape[old_i] == 1 && new_shape[i] != 1) ? 0 : top->strides[old_i];
         }
     }
-    free(top->shape);   top->shape   = ns;
-    free(top->strides); top->strides = ss;
+    cml_free(top->shape);   top->shape   = ns;
+    cml_free(top->strides); top->strides = ss;
     top->ndim = new_ndim;
     return 0;
 }
@@ -280,8 +281,8 @@ int shape_tracker_pad(ShapeTracker* st, const int64_t* before, const int64_t* af
     int ndim = top->ndim;
 
     if (!top->has_mask) {
-        top->mask_begin = malloc((size_t)ndim * sizeof(int64_t));
-        top->mask_end   = malloc((size_t)ndim * sizeof(int64_t));
+        top->mask_begin = cml_malloc((size_t)ndim * sizeof(int64_t));
+        top->mask_end   = cml_malloc((size_t)ndim * sizeof(int64_t));
         if (!top->mask_begin || !top->mask_end) return -1;
         for (int i = 0; i < ndim; ++i) {
             top->mask_begin[i] = 0;

--- a/src/tensor/shard.c
+++ b/src/tensor/shard.c
@@ -3,27 +3,28 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 static CMLShardedTensor* sharded_tensor_alloc(int num_shards, int ndim, int* shape,
                                                DeviceType* devices, int axis)
 {
-    CMLShardedTensor* st = (CMLShardedTensor*)calloc(1, sizeof(CMLShardedTensor));
+    CMLShardedTensor* st = (CMLShardedTensor*)cml_calloc(1, sizeof(CMLShardedTensor));
     if (!st) return NULL;
 
     st->num_shards = num_shards;
     st->axis = axis;
     st->ndim = ndim;
 
-    st->shape = (int*)malloc((size_t)ndim * sizeof(int));
-    if (!st->shape) { free(st); return NULL; }
+    st->shape = (int*)cml_malloc((size_t)ndim * sizeof(int));
+    if (!st->shape) { cml_free(st); return NULL; }
     memcpy(st->shape, shape, (size_t)ndim * sizeof(int));
 
-    st->devices = (DeviceType*)malloc((size_t)num_shards * sizeof(DeviceType));
-    if (!st->devices) { free(st->shape); free(st); return NULL; }
+    st->devices = (DeviceType*)cml_malloc((size_t)num_shards * sizeof(DeviceType));
+    if (!st->devices) { cml_free(st->shape); cml_free(st); return NULL; }
     memcpy(st->devices, devices, (size_t)num_shards * sizeof(DeviceType));
 
-    st->shards = (Tensor**)calloc((size_t)num_shards, sizeof(Tensor*));
-    if (!st->shards) { free(st->devices); free(st->shape); free(st); return NULL; }
+    st->shards = (Tensor**)cml_calloc((size_t)num_shards, sizeof(Tensor*));
+    if (!st->shards) { cml_free(st->devices); cml_free(st->shape); cml_free(st); return NULL; }
 
     return st;
 }
@@ -42,7 +43,7 @@ CMLShardedTensor* tensor_shard(Tensor* t, DeviceType* devices, int num_devices, 
     }
 
     int dim_size = t->shape[norm_axis];
-    int* sizes = (int*)malloc((size_t)num_devices * sizeof(int));
+    int* sizes = (int*)cml_malloc((size_t)num_devices * sizeof(int));
     if (!sizes) return NULL;
 
     int base = dim_size / num_devices;
@@ -52,7 +53,7 @@ CMLShardedTensor* tensor_shard(Tensor* t, DeviceType* devices, int num_devices, 
     }
 
     CMLShardedTensor* st = tensor_shard_with_sizes(t, devices, num_devices, norm_axis, sizes);
-    free(sizes);
+    cml_free(sizes);
     return st;
 }
 
@@ -103,7 +104,7 @@ CMLShardedTensor* tensor_shard_with_sizes(Tensor* t, DeviceType* devices, int nu
         int shard_axis = sizes[s];
         size_t shard_elems = outer * (size_t)shard_axis * inner;
 
-        float* shard_data = (float*)malloc(shard_elems * sizeof(float));
+        float* shard_data = (float*)cml_malloc(shard_elems * sizeof(float));
         if (!shard_data) {
             LOG_ERROR("tensor_shard_with_sizes: allocation failed for shard %d", s);
             sharded_tensor_free(st);
@@ -116,9 +117,9 @@ CMLShardedTensor* tensor_shard_with_sizes(Tensor* t, DeviceType* devices, int nu
             memcpy(row_dst, row_src, (size_t)shard_axis * inner * sizeof(float));
         }
 
-        int* shard_shape = (int*)malloc((size_t)t->ndim * sizeof(int));
+        int* shard_shape = (int*)cml_malloc((size_t)t->ndim * sizeof(int));
         if (!shard_shape) {
-            free(shard_data);
+            cml_free(shard_data);
             sharded_tensor_free(st);
             return NULL;
         }
@@ -127,8 +128,8 @@ CMLShardedTensor* tensor_shard_with_sizes(Tensor* t, DeviceType* devices, int nu
 
         cfg.device = devices[s];
         st->shards[s] = tensor_from_data(shard_data, shard_shape, t->ndim, &cfg);
-        free(shard_data);
-        free(shard_shape);
+        cml_free(shard_data);
+        cml_free(shard_shape);
 
         if (!st->shards[s]) {
             LOG_ERROR("tensor_shard_with_sizes: failed to create shard %d", s);
@@ -159,7 +160,7 @@ Tensor* tensor_unshard(CMLShardedTensor* st)
     for (int i = axis + 1; i < ndim; i++) inner *= (size_t)st->shape[i];
 
     size_t total_elems = outer * (size_t)st->shape[axis] * inner;
-    float* out_data = (float*)malloc(total_elems * sizeof(float));
+    float* out_data = (float*)cml_malloc(total_elems * sizeof(float));
     if (!out_data) {
         LOG_ERROR("tensor_unshard: allocation failed");
         return NULL;
@@ -174,7 +175,7 @@ Tensor* tensor_unshard(CMLShardedTensor* st)
         const float* sdata = (const float*)tensor_data_ptr(shard);
         if (!sdata) {
             LOG_ERROR("tensor_unshard: failed to get data for shard %d", s);
-            free(out_data);
+            cml_free(out_data);
             return NULL;
         }
 
@@ -191,7 +192,7 @@ Tensor* tensor_unshard(CMLShardedTensor* st)
     TensorConfig cfg = {.dtype = DTYPE_FLOAT32, .device = DEVICE_CPU,
                         .has_dtype = true, .has_device = true};
     Tensor* result = tensor_from_data(out_data, st->shape, ndim, &cfg);
-    free(out_data);
+    cml_free(out_data);
     return result;
 }
 
@@ -202,11 +203,11 @@ void sharded_tensor_free(CMLShardedTensor* st)
         for (int i = 0; i < st->num_shards; i++) {
             if (st->shards[i]) tensor_free(st->shards[i]);
         }
-        free(st->shards);
+        cml_free(st->shards);
     }
-    free(st->shape);
-    free(st->devices);
-    free(st);
+    cml_free(st->shape);
+    cml_free(st->devices);
+    cml_free(st);
 }
 
 CMLShardedTensor* sharded_add(CMLShardedTensor* a, CMLShardedTensor* b)
@@ -243,7 +244,7 @@ CMLShardedTensor* sharded_add(CMLShardedTensor* a, CMLShardedTensor* b)
         }
 
         size_t n = sa->numel;
-        float* out = (float*)malloc(n * sizeof(float));
+        float* out = (float*)cml_malloc(n * sizeof(float));
         if (!out) {
             sharded_tensor_free(result);
             return NULL;
@@ -254,7 +255,7 @@ CMLShardedTensor* sharded_add(CMLShardedTensor* a, CMLShardedTensor* b)
         TensorConfig cfg = {.dtype = DTYPE_FLOAT32, .device = a->devices[s],
                             .has_dtype = true, .has_device = true};
         result->shards[s] = tensor_from_data(out, sa->shape, sa->ndim, &cfg);
-        free(out);
+        cml_free(out);
 
         if (!result->shards[s]) {
             sharded_tensor_free(result);
@@ -276,7 +277,7 @@ CMLShardedTensor* sharded_allreduce_sum(CMLShardedTensor* st)
     tensor_ensure_executed(first);
     size_t numel = first->numel;
 
-    float* sum_data = (float*)calloc(numel, sizeof(float));
+    float* sum_data = (float*)cml_calloc(numel, sizeof(float));
     if (!sum_data) return NULL;
 
     for (int s = 0; s < st->num_shards; s++) {
@@ -284,7 +285,7 @@ CMLShardedTensor* sharded_allreduce_sum(CMLShardedTensor* st)
         tensor_ensure_executed(shard);
         const float* sd = (const float*)tensor_data_ptr(shard);
         if (!sd) {
-            free(sum_data);
+            cml_free(sum_data);
             return NULL;
         }
         for (size_t i = 0; i < numel; i++) sum_data[i] += sd[i];
@@ -292,20 +293,20 @@ CMLShardedTensor* sharded_allreduce_sum(CMLShardedTensor* st)
 
     CMLShardedTensor* result = sharded_tensor_alloc(st->num_shards, first->ndim, first->shape,
                                                      st->devices, st->axis);
-    if (!result) { free(sum_data); return NULL; }
+    if (!result) { cml_free(sum_data); return NULL; }
 
     for (int s = 0; s < st->num_shards; s++) {
         TensorConfig cfg = {.dtype = DTYPE_FLOAT32, .device = st->devices[s],
                             .has_dtype = true, .has_device = true};
         result->shards[s] = tensor_from_data(sum_data, first->shape, first->ndim, &cfg);
         if (!result->shards[s]) {
-            free(sum_data);
+            cml_free(sum_data);
             sharded_tensor_free(result);
             return NULL;
         }
     }
 
-    free(sum_data);
+    cml_free(sum_data);
     return result;
 }
 
@@ -364,7 +365,7 @@ CMLShardedTensor* sharded_matmul(CMLShardedTensor* a, CMLShardedTensor* b)
             }
 
             int local_K = sa->shape[1];
-            float* out = (float*)malloc((size_t)M * N * sizeof(float));
+            float* out = (float*)cml_malloc((size_t)M * N * sizeof(float));
             if (!out) { sharded_tensor_free(partial); return NULL; }
 
             matmul_2d(da, M, local_K, db, N, out);
@@ -372,7 +373,7 @@ CMLShardedTensor* sharded_matmul(CMLShardedTensor* a, CMLShardedTensor* b)
             TensorConfig cfg = {.dtype = DTYPE_FLOAT32, .device = a->devices[s],
                                 .has_dtype = true, .has_device = true};
             partial->shards[s] = tensor_from_data(out, out_shape, 2, &cfg);
-            free(out);
+            cml_free(out);
 
             if (!partial->shards[s]) {
                 sharded_tensor_free(partial);
@@ -406,7 +407,7 @@ CMLShardedTensor* sharded_matmul(CMLShardedTensor* a, CMLShardedTensor* b)
 
             int local_M = sa->shape[0];
             int shard_out_shape[2] = {local_M, N};
-            float* out = (float*)malloc((size_t)local_M * N * sizeof(float));
+            float* out = (float*)cml_malloc((size_t)local_M * N * sizeof(float));
             if (!out) { sharded_tensor_free(result); return NULL; }
 
             matmul_2d(da, local_M, K, db, N, out);
@@ -414,7 +415,7 @@ CMLShardedTensor* sharded_matmul(CMLShardedTensor* a, CMLShardedTensor* b)
             TensorConfig cfg = {.dtype = DTYPE_FLOAT32, .device = a->devices[s],
                                 .has_dtype = true, .has_device = true};
             result->shards[s] = tensor_from_data(out, shard_out_shape, 2, &cfg);
-            free(out);
+            cml_free(out);
 
             if (!result->shards[s]) {
                 sharded_tensor_free(result);

--- a/src/tensor/sparse_tensor.c
+++ b/src/tensor/sparse_tensor.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 SparseCOOData* sparse_coo_tensor(Tensor* indices, Tensor* values,
                                   const int* dense_shape, int dense_ndim) {
@@ -39,7 +40,7 @@ SparseCOOData* sparse_coo_tensor(Tensor* indices, Tensor* values,
         return NULL;
     }
 
-    SparseCOOData* sparse = calloc(1, sizeof(SparseCOOData));
+    SparseCOOData* sparse = cml_calloc(1, sizeof(SparseCOOData));
     if (!sparse) {
         LOG_ERROR("sparse_coo_tensor: failed to allocate SparseCOOData");
         return NULL;
@@ -53,19 +54,19 @@ SparseCOOData* sparse_coo_tensor(Tensor* indices, Tensor* values,
         LOG_ERROR("sparse_coo_tensor: failed to clone indices or values");
         if (sparse->indices) tensor_free(sparse->indices);
         if (sparse->values) tensor_free(sparse->values);
-        free(sparse);
+        cml_free(sparse);
         return NULL;
     }
 
     sparse->nnz        = nnz;
     sparse->dense_ndim = dense_ndim;
 
-    sparse->dense_shape = calloc(dense_ndim, sizeof(int));
+    sparse->dense_shape = cml_calloc(dense_ndim, sizeof(int));
     if (!sparse->dense_shape) {
         LOG_ERROR("sparse_coo_tensor: failed to allocate dense_shape");
         tensor_free(sparse->indices);
         tensor_free(sparse->values);
-        free(sparse);
+        cml_free(sparse);
         return NULL;
     }
     memcpy(sparse->dense_shape, dense_shape, dense_ndim * sizeof(int));
@@ -161,7 +162,7 @@ SparseCOOData* sparse_from_dense(Tensor* dense) {
         }
     }
 
-    SparseCOOData* sparse = calloc(1, sizeof(SparseCOOData));
+    SparseCOOData* sparse = cml_calloc(1, sizeof(SparseCOOData));
     if (!sparse) {
         tensor_free(indices);
         tensor_free(values);
@@ -174,11 +175,11 @@ SparseCOOData* sparse_from_dense(Tensor* dense) {
     sparse->nnz        = nnz;
     sparse->dense_ndim = ndim;
 
-    sparse->dense_shape = calloc(ndim, sizeof(int));
+    sparse->dense_shape = cml_calloc(ndim, sizeof(int));
     if (!sparse->dense_shape) {
         tensor_free(indices);
         tensor_free(values);
-        free(sparse);
+        cml_free(sparse);
         LOG_ERROR("sparse_from_dense: failed to allocate dense_shape");
         return NULL;
     }
@@ -367,9 +368,9 @@ void sparse_free(SparseCOOData* sparse) {
     }
 
     if (sparse->dense_shape) {
-        free(sparse->dense_shape);
+        cml_free(sparse->dense_shape);
         sparse->dense_shape = NULL;
     }
 
-    free(sparse);
+    cml_free(sparse);
 }

--- a/src/tensor/tensor.c
+++ b/src/tensor/tensor.c
@@ -19,6 +19,7 @@
 #include "core/error_stack.h"
 #include "core/config.h"
 #include "core/threefry.h"
+#include "alloc/cml_allocator.h"
 
 static inline uint16_t float_to_fp16(float f) {
     uint32_t x;
@@ -199,16 +200,16 @@ static void resolve_config(const TensorConfig* config, DType* dtype, DeviceType*
 
 Tensor* tensor_create(DType dtype, DeviceType device, int ndim, const int* shape,
                       bool requires_grad) {
-    Tensor* t = (Tensor*)malloc(sizeof(Tensor));
+    Tensor* t = (Tensor*)cml_malloc(sizeof(Tensor));
     if (!t)
         return NULL;
 
     t->dtype  = dtype;
     t->device = device;
     t->ndim   = ndim;
-    t->shape  = (int*)malloc(ndim * sizeof(int));
+    t->shape  = (int*)cml_malloc(ndim * sizeof(int));
     if (!t->shape) {
-        free(t);
+        cml_free(t);
         return NULL;
     }
     memcpy(t->shape, shape, ndim * sizeof(int));
@@ -220,10 +221,10 @@ Tensor* tensor_create(DType dtype, DeviceType device, int ndim, const int* shape
 
     total_size *= cml_dtype_size(dtype);
 
-    t->data = malloc(total_size);
+    t->data = cml_malloc(total_size);
     if (!t->data) {
-        free(t->shape);
-        free(t);
+        cml_free(t->shape);
+        cml_free(t);
         return NULL;
     }
 
@@ -236,9 +237,9 @@ Tensor* tensor_create(DType dtype, DeviceType device, int ndim, const int* shape
     t->base           = NULL;
     t->strides        = compute_contiguous_strides(t->shape, ndim);
     if (!t->strides && ndim > 0) {
-        free(t->data);
-        free(t->shape);
-        free(t);
+        cml_free(t->data);
+        cml_free(t->shape);
+        cml_free(t);
         return NULL;
     }
     t->storage_offset = 0;
@@ -303,7 +304,7 @@ void* tensor_data_ptr(Tensor* t) {
             // After execution, update tensor metadata from IR node's output shape
             // (e.g., reshape operations may have changed dimensions)
             if (t->ir_node && t->ir_node->output_shape && t->ir_node->output_ndim > 0) {
-                if (t->shape) free(t->shape);
+                if (t->shape) cml_free(t->shape);
                 t->shape = tensor_shape_copy(t->ir_node->output_shape, t->ir_node->output_ndim);
                 t->ndim  = t->ir_node->output_ndim;
                 t->numel = tensor_numel(t->ir_node->output_shape, t->ir_node->output_ndim);
@@ -313,7 +314,7 @@ void* tensor_data_ptr(Tensor* t) {
             // allocate it (shouldn't happen, but be safe).
             if (!t->data && t->numel > 0) {
                 size_t size = t->numel * cml_dtype_size(t->dtype);
-                t->data     = calloc(1, size);
+                t->data     = cml_calloc(1, size);
                 if (!t->data) {
                     LOG_ERROR("Failed to allocate data after execution");
                     return NULL;
@@ -324,7 +325,7 @@ void* tensor_data_ptr(Tensor* t) {
             LOG_WARNING("IR execution failed, returning zero-initialized data");
             if (!t->data && t->numel > 0) {
                 size_t size = t->numel * cml_dtype_size(t->dtype);
-                t->data     = calloc(1, size);
+                t->data     = cml_calloc(1, size);
             }
             t->is_executed = true;
             return t->data;
@@ -416,10 +417,10 @@ size_t* compute_contiguous_strides(int* shape, int ndim) {
 
     if (ndim == 0) {
         // Scalar tensor has no strides, but some functions might expect a non-NULL pointer
-        return (size_t*)malloc(sizeof(size_t));
+        return (size_t*)cml_malloc(sizeof(size_t));
     }
 
-    size_t* strides = (size_t*)malloc((size_t)ndim * sizeof(size_t));
+    size_t* strides = (size_t*)cml_malloc((size_t)ndim * sizeof(size_t));
     if (!strides) {
         LOG_ERROR("Failed to allocate memory for strides");
         return NULL;
@@ -462,7 +463,7 @@ size_t tensor_compute_storage_size(int* shape, size_t* strides, int ndim) {
 }
 
 int* tensor_shape_copy(int* shape, int ndim) {
-    int* new_shape = (int*)malloc((size_t)ndim * sizeof(int));
+    int* new_shape = (int*)cml_malloc((size_t)ndim * sizeof(int));
     if (!new_shape) {
         LOG_ERROR("Failed to allocate memory for tensor shape copy");
         return NULL;
@@ -620,7 +621,7 @@ Tensor* tensor_from_ir_node(struct IRNode* node, CMLGraph_t ir_context) {
         return node->output;
     }
 
-    Tensor* t = (Tensor*)malloc(sizeof(Tensor));
+    Tensor* t = (Tensor*)cml_malloc(sizeof(Tensor));
     if (!t)
         return NULL;
 
@@ -633,7 +634,7 @@ Tensor* tensor_from_ir_node(struct IRNode* node, CMLGraph_t ir_context) {
     if (node->output_shape) {
         t->shape = tensor_shape_copy(node->output_shape, node->output_ndim);
         if (!t->shape) {
-            free(t);
+            cml_free(t);
             return NULL;
         }
         t->ndim  = node->output_ndim;
@@ -643,13 +644,13 @@ Tensor* tensor_from_ir_node(struct IRNode* node, CMLGraph_t ir_context) {
         if (node->inputs && node->inputs[0]) {
             t->shape = tensor_shape_copy(node->inputs[0]->shape, node->inputs[0]->ndim);
             if (!t->shape) {
-                free(t);
+                cml_free(t);
                 return NULL;
             }
             t->ndim  = node->inputs[0]->ndim;
             t->numel = node->inputs[0]->numel;
         } else {
-            free(t);
+            cml_free(t);
             return NULL;
         }
     }
@@ -679,8 +680,8 @@ Tensor* tensor_from_ir_node(struct IRNode* node, CMLGraph_t ir_context) {
 
     t->strides = compute_contiguous_strides(t->shape, t->ndim);
     if (!t->strides && t->ndim > 0) {
-        free(t->shape);
-        free(t);
+        cml_free(t->shape);
+        cml_free(t);
         return NULL;
     }
     t->storage_offset    = 0;
@@ -789,7 +790,7 @@ void tensor_free(Tensor* t) {
             if (t->from_buffer_cache && t->numel > 0) {
                 cml_buffer_cache_free(t->data, t->numel * cml_dtype_size(t->dtype));
             } else {
-                free(t->data);
+                cml_free(t->data);
             }
         } else {
             device_free(t->data, t->device);
@@ -797,9 +798,9 @@ void tensor_free(Tensor* t) {
     }
 
     if (t->shape)
-        free(t->shape);
+        cml_free(t->shape);
     if (t->strides)
-        free(t->strides);
+        cml_free(t->strides);
 
     if (t->grad) {
         tensor_free(t->grad);
@@ -807,11 +808,11 @@ void tensor_free(Tensor* t) {
     }
 
     if (t->user_data) {
-        free(t->user_data);
+        cml_free(t->user_data);
         t->user_data = NULL;
     }
 
-    free(t);
+    cml_free(t);
 }
 
 Tensor* tensor_clone(Tensor* t) {
@@ -888,7 +889,7 @@ int* tensor_shape(int ndim, ...) {
         return NULL;
     }
 
-    int* shape = (int*)malloc((size_t)ndim * sizeof(int));
+    int* shape = (int*)cml_malloc((size_t)ndim * sizeof(int));
     if (!shape) {
         return NULL;
     }
@@ -927,7 +928,7 @@ Tensor* tensor_linspace(float start, float end, int steps, const TensorConfig* c
     resolve_config(config, &dtype, &device);
 
     size_t esz = cml_dtype_size(dtype);
-    void* buf  = malloc((size_t)steps * esz);
+    void* buf  = cml_malloc((size_t)steps * esz);
     if (!buf)
         return NULL;
     if (steps == 1) {
@@ -938,7 +939,7 @@ Tensor* tensor_linspace(float start, float end, int steps, const TensorConfig* c
             cml_cpu_lazy_store_float_elem(buf, (size_t)i, dtype, start + (float)i * step);
     }
     Tensor* out = uop_const(buf, (size_t)steps * esz, shape, 1, dtype, device);
-    free(buf);
+    cml_free(buf);
     return out;
 }
 
@@ -1020,7 +1021,7 @@ Tensor* tensor_squeeze(Tensor* a, int dim) {
     }
     if (new_ndim == 0) new_ndim = 1;
 
-    int* new_shape = malloc((size_t)new_ndim * sizeof(int));
+    int* new_shape = cml_malloc((size_t)new_ndim * sizeof(int));
     if (!new_shape) return NULL;
 
     int j = 0;
@@ -1035,7 +1036,7 @@ Tensor* tensor_squeeze(Tensor* a, int dim) {
     if (j == 0) new_shape[0] = 1;
 
     Tensor* result = tensor_reshape(a, new_shape, new_ndim);
-    free(new_shape);
+    cml_free(new_shape);
     return result;
 }
 
@@ -1045,7 +1046,7 @@ Tensor* tensor_unsqueeze(Tensor* a, int dim) {
     if (dim < 0 || dim > a->ndim) return NULL;
 
     int new_ndim = a->ndim + 1;
-    int* new_shape = malloc((size_t)new_ndim * sizeof(int));
+    int* new_shape = cml_malloc((size_t)new_ndim * sizeof(int));
     if (!new_shape) return NULL;
 
     int j = 0;
@@ -1058,7 +1059,7 @@ Tensor* tensor_unsqueeze(Tensor* a, int dim) {
     }
 
     Tensor* result = tensor_reshape(a, new_shape, new_ndim);
-    free(new_shape);
+    cml_free(new_shape);
     return result;
 }
 
@@ -1189,12 +1190,12 @@ Tensor* tensor_from_blob(void* data, int* shape, int ndim, const TensorConfig* c
     DeviceType device;
     resolve_config(config, &dtype, &device);
 
-    Tensor* t = (Tensor*)calloc(1, sizeof(Tensor));
+    Tensor* t = (Tensor*)cml_calloc(1, sizeof(Tensor));
     if (!t) return NULL;
 
     t->ndim = ndim;
-    t->shape = (int*)malloc((size_t)ndim * sizeof(int));
-    if (!t->shape) { free(t); return NULL; }
+    t->shape = (int*)cml_malloc((size_t)ndim * sizeof(int));
+    if (!t->shape) { cml_free(t); return NULL; }
     memcpy(t->shape, shape, (size_t)ndim * sizeof(int));
 
     t->numel = tensor_numel(shape, ndim);
@@ -1220,7 +1221,7 @@ Tensor* tensor_randperm(int n, const TensorConfig* config) {
     resolve_config(config, &dtype, &device);
 
     size_t esz = cml_dtype_size(dtype);
-    void* buf  = malloc((size_t)n * esz);
+    void* buf  = cml_malloc((size_t)n * esz);
     if (!buf)
         return NULL;
     for (int i = 0; i < n; i++)
@@ -1233,7 +1234,7 @@ Tensor* tensor_randperm(int n, const TensorConfig* config) {
         memcpy((uint8_t*)buf + (size_t)j * esz, tmp, esz);
     }
     Tensor* out = uop_const(buf, (size_t)n * esz, shape, 1, dtype, device);
-    free(buf);
+    cml_free(buf);
     return out;
 }
 
@@ -1369,7 +1370,7 @@ Tensor* tensor_scatter_reduce(Tensor* self, int dim, Tensor* index, Tensor* src,
         }
         if (mode == SCATTER_REDUCE_MEAN) {
             // Count contributions per index
-            int* counts = calloc(self->shape[0], sizeof(int));
+            int* counts = cml_calloc(self->shape[0], sizeof(int));
             if (counts) {
                 for (int i = 0; i < self->shape[0]; i++) counts[i] = 1; // self contributes 1
                 for (size_t i = 0; i < index->numel; i++) {
@@ -1381,7 +1382,7 @@ Tensor* tensor_scatter_reduce(Tensor* self, int dim, Tensor* index, Tensor* src,
                         tensor_set_float(output, i, tensor_get_float(output, i) / counts[i]);
                     }
                 }
-                free(counts);
+                cml_free(counts);
             }
         }
     } else if (self->ndim == 2) {
@@ -1440,18 +1441,18 @@ Tensor* tensor_bitcast(Tensor* a, DType target_dtype) {
     size_t new_numel = total_bytes / dst_size;
 
     int new_ndim = a->ndim;
-    int* new_shape = malloc(new_ndim * sizeof(int));
+    int* new_shape = cml_malloc(new_ndim * sizeof(int));
     if (!new_shape) return NULL;
 
     for (int i = 0; i < new_ndim - 1; i++) new_shape[i] = a->shape[i];
     size_t leading = 1;
     for (int i = 0; i < new_ndim - 1; i++) leading *= a->shape[i];
-    if (leading == 0) { free(new_shape); return NULL; }
+    if (leading == 0) { cml_free(new_shape); return NULL; }
     new_shape[new_ndim - 1] = (int)(new_numel / leading);
 
     TensorConfig config = {.dtype = target_dtype, .device = a->device, .has_dtype = true, .has_device = true};
     Tensor* out = tensor_empty(new_shape, new_ndim, &config);
-    free(new_shape);
+    cml_free(new_shape);
     if (!out) return NULL;
     tensor_ensure_executed(out);
 
@@ -1474,18 +1475,18 @@ QRResult tensor_qr(Tensor* a) {
     int k = m < n ? m : n;
 
     // Work on a copy of A (will become R)
-    float* R = malloc((size_t)m * n * sizeof(float));
+    float* R = cml_malloc((size_t)m * n * sizeof(float));
     if (!R) return result;
     for (int i = 0; i < m * n; i++)
         R[i] = tensor_get_float(a, i);
 
     // Q starts as identity [m, m]
-    float* Q = calloc((size_t)m * m, sizeof(float));
-    if (!Q) { free(R); return result; }
+    float* Q = cml_calloc((size_t)m * m, sizeof(float));
+    if (!Q) { cml_free(R); return result; }
     for (int i = 0; i < m; i++) Q[i * m + i] = 1.0f;
 
-    float* v = malloc((size_t)m * sizeof(float));
-    if (!v) { free(R); free(Q); return result; }
+    float* v = cml_malloc((size_t)m * sizeof(float));
+    if (!v) { cml_free(R); cml_free(Q); return result; }
 
     for (int j = 0; j < k; j++) {
         // Extract column j from row j..m-1
@@ -1521,14 +1522,14 @@ QRResult tensor_qr(Tensor* a) {
             for (int i = j; i < m; i++) Q[r * m + i] -= dot * v[i];
         }
     }
-    free(v);
+    cml_free(v);
 
     // Create reduced Q [m, k] and R [k, n]
     TensorConfig config = {.dtype = a->dtype, .device = a->device, .has_dtype = true, .has_device = true};
 
     int q_shape[] = {m, k};
     result.Q = tensor_empty(q_shape, 2, &config);
-    if (!result.Q) { free(R); free(Q); return result; }
+    if (!result.Q) { cml_free(R); cml_free(Q); return result; }
     tensor_ensure_executed(result.Q);
     float* q_out = (float*)result.Q->data;
     for (int i = 0; i < m; i++)
@@ -1537,15 +1538,15 @@ QRResult tensor_qr(Tensor* a) {
 
     int r_shape[] = {k, n};
     result.R = tensor_empty(r_shape, 2, &config);
-    if (!result.R) { free(R); free(Q); tensor_free(result.Q); result.Q = NULL; return result; }
+    if (!result.R) { cml_free(R); cml_free(Q); tensor_free(result.Q); result.Q = NULL; return result; }
     tensor_ensure_executed(result.R);
     float* r_out = (float*)result.R->data;
     for (int i = 0; i < k; i++)
         for (int j = 0; j < n; j++)
             r_out[i * n + j] = R[i * n + j];
 
-    free(R);
-    free(Q);
+    cml_free(R);
+    cml_free(Q);
     return result;
 }
 
@@ -1564,14 +1565,14 @@ SVDResult tensor_svd(Tensor* a) {
 
     // Work on A^T * A for right singular vectors, or use Jacobi on A directly
     // Use one-sided Jacobi: iterate on columns of A copy
-    float* W = malloc((size_t)m * n * sizeof(float));
+    float* W = cml_malloc((size_t)m * n * sizeof(float));
     if (!W) return result;
     for (int i = 0; i < m * n; i++)
         W[i] = tensor_get_float(a, i);
 
     // V starts as identity [n, n]
-    float* V = calloc((size_t)n * n, sizeof(float));
-    if (!V) { free(W); return result; }
+    float* V = cml_calloc((size_t)n * n, sizeof(float));
+    if (!V) { cml_free(W); return result; }
     for (int i = 0; i < n; i++) V[i * n + i] = 1.0f;
 
     // One-sided Jacobi rotations
@@ -1616,16 +1617,16 @@ SVDResult tensor_svd(Tensor* a) {
     }
 
     // Compute singular values (column norms of W) and U = W / sigma
-    float* sigma = malloc((size_t)k * sizeof(float));
-    float* U = malloc((size_t)m * k * sizeof(float));
-    if (!sigma || !U) { free(W); free(V); free(sigma); free(U); return result; }
+    float* sigma = cml_malloc((size_t)k * sizeof(float));
+    float* U = cml_malloc((size_t)m * k * sizeof(float));
+    if (!sigma || !U) { cml_free(W); cml_free(V); cml_free(sigma); cml_free(U); return result; }
 
-    int* order = malloc((size_t)n * sizeof(int));
-    if (!order) { free(W); free(V); free(sigma); free(U); return result; }
+    int* order = cml_malloc((size_t)n * sizeof(int));
+    if (!order) { cml_free(W); cml_free(V); cml_free(sigma); cml_free(U); return result; }
     for (int i = 0; i < n; i++) order[i] = i;
 
-    float* col_norms = malloc((size_t)n * sizeof(float));
-    if (!col_norms) { free(W); free(V); free(sigma); free(U); free(order); return result; }
+    float* col_norms = cml_malloc((size_t)n * sizeof(float));
+    if (!col_norms) { cml_free(W); cml_free(V); cml_free(sigma); cml_free(U); cml_free(order); return result; }
     for (int j = 0; j < n; j++) {
         float norm = 0.0f;
         for (int i = 0; i < m; i++) norm += W[i * n + j] * W[i * n + j];
@@ -1676,7 +1677,7 @@ SVDResult tensor_svd(Tensor* a) {
         }
     }
 
-    free(W); free(V); free(sigma); free(U); free(order); free(col_norms);
+    cml_free(W); cml_free(V); cml_free(sigma); cml_free(U); cml_free(order); cml_free(col_norms);
     return result;
 }
 
@@ -1735,7 +1736,7 @@ int tensor_assign(Tensor* t, Tensor* src) {
             cml_backend_buffer_free(t->buffer_handle);
             t->buffer_handle = NULL;
         } else if (t->device == DEVICE_CPU || t->device == DEVICE_AUTO) {
-            free(t->data);
+            cml_free(t->data);
         } else {
             device_free(t->data, t->device);
         }
@@ -1747,7 +1748,7 @@ int tensor_assign(Tensor* t, Tensor* src) {
         t->buffer_handle = NULL;
         t->from_buffer_cache = false;
     } else {
-        t->data = malloc(nbytes);
+        t->data = cml_malloc(nbytes);
         if (!t->data) return -1;
         memcpy(t->data, src->data, nbytes);
         t->owns_data = true;
@@ -1764,7 +1765,7 @@ int tensor_assign_data(Tensor* t, const void* data, size_t nbytes) {
     if (nbytes > expected) return -1;
 
     if (!t->data) {
-        t->data = malloc(expected);
+        t->data = cml_malloc(expected);
         if (!t->data) return -1;
         t->owns_data = true;
     }

--- a/src/tensor/tensor_manipulation.c
+++ b/src/tensor/tensor_manipulation.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 Tensor* tensor_concat(Tensor** tensors, int num_tensors, int dim) {
     return uop_cat(tensors, num_tensors, dim);
@@ -39,29 +40,29 @@ Tensor** tensor_split(Tensor* tensor, int num_splits, int dim, int* split_sizes)
     } else {
         int base_size = dim_size / num_splits;
         int remainder = dim_size % num_splits;
-        sizes = malloc((size_t)num_splits * sizeof(int));
+        sizes = cml_malloc((size_t)num_splits * sizeof(int));
         if (!sizes) return NULL;
         need_free = 1;
         for (int i = 0; i < num_splits; i++)
             sizes[i] = base_size + (i < remainder ? 1 : 0);
     }
 
-    Tensor** results = malloc((size_t)num_splits * sizeof(Tensor*));
+    Tensor** results = cml_malloc((size_t)num_splits * sizeof(Tensor*));
     if (!results) {
-        if (need_free) free(sizes);
+        if (need_free) cml_free(sizes);
         return NULL;
     }
 
     int offset = 0;
     for (int i = 0; i < num_splits; i++) {
-        int* starts = calloc((size_t)tensor->ndim, sizeof(int));
-        int* ends   = malloc((size_t)tensor->ndim * sizeof(int));
-        int* steps  = malloc((size_t)tensor->ndim * sizeof(int));
+        int* starts = cml_calloc((size_t)tensor->ndim, sizeof(int));
+        int* ends   = cml_malloc((size_t)tensor->ndim * sizeof(int));
+        int* steps  = cml_malloc((size_t)tensor->ndim * sizeof(int));
         if (!starts || !ends || !steps) {
-            free(starts); free(ends); free(steps);
+            cml_free(starts); cml_free(ends); cml_free(steps);
             for (int j = 0; j < i; j++) tensor_free(results[j]);
-            free(results);
-            if (need_free) free(sizes);
+            cml_free(results);
+            if (need_free) cml_free(sizes);
             return NULL;
         }
         for (int d = 0; d < tensor->ndim; d++) {
@@ -70,12 +71,12 @@ Tensor** tensor_split(Tensor* tensor, int num_splits, int dim, int* split_sizes)
             steps[d]  = 1;
         }
 
-        SliceParams* sp = malloc(sizeof(SliceParams));
+        SliceParams* sp = cml_malloc(sizeof(SliceParams));
         if (!sp) {
-            free(starts); free(ends); free(steps);
+            cml_free(starts); cml_free(ends); cml_free(steps);
             for (int j = 0; j < i; j++) tensor_free(results[j]);
-            free(results);
-            if (need_free) free(sizes);
+            cml_free(results);
+            if (need_free) cml_free(sizes);
             return NULL;
         }
         sp->start    = starts;
@@ -87,7 +88,7 @@ Tensor** tensor_split(Tensor* tensor, int num_splits, int dim, int* split_sizes)
         offset += sizes[i];
     }
 
-    if (need_free) free(sizes);
+    if (need_free) cml_free(sizes);
     return results;
 }
 
@@ -134,13 +135,13 @@ Tensor* tensor_gather(Tensor* input, Tensor* indices, int dim) {
     size_t* output_strides = compute_contiguous_strides(output->shape, output->ndim);
     if (!input_strides || !output_strides) {
         tensor_free(output);
-        free(input_strides);
-        free(output_strides);
+        cml_free(input_strides);
+        cml_free(output_strides);
         return NULL;
     }
 
     for (size_t i = 0; i < output->numel; i++) {
-        int* out_indices = malloc((size_t)output->ndim * sizeof(int));
+        int* out_indices = cml_malloc((size_t)output->ndim * sizeof(int));
         size_t idx       = i;
         for (int d = output->ndim - 1; d >= 0; d--) {
             out_indices[d] = (int)(idx % (size_t)output->shape[d]);
@@ -153,16 +154,16 @@ Tensor* tensor_gather(Tensor* input, Tensor* indices, int dim) {
         int gather_idx = idx_data[idx_offset];
 
         if (gather_idx < 0 || gather_idx >= input->shape[normalized_dim]) {
-            free(out_indices);
-            free(input_strides);
-            free(output_strides);
+            cml_free(out_indices);
+            cml_free(input_strides);
+            cml_free(output_strides);
             tensor_free(output);
             LOG_ERROR("tensor_gather: index %d out of range [0, %d)", gather_idx,
                       input->shape[normalized_dim]);
             return NULL;
         }
 
-        int* in_indices = malloc((size_t)input->ndim * sizeof(int));
+        int* in_indices = cml_malloc((size_t)input->ndim * sizeof(int));
         for (int d = 0; d < input->ndim; d++)
             in_indices[d] = (d == normalized_dim) ? gather_idx : out_indices[d];
 
@@ -172,12 +173,12 @@ Tensor* tensor_gather(Tensor* input, Tensor* indices, int dim) {
 
         out_data[i] = in_data[in_offset];
 
-        free(out_indices);
-        free(in_indices);
+        cml_free(out_indices);
+        cml_free(in_indices);
     }
 
-    free(input_strides);
-    free(output_strides);
+    cml_free(input_strides);
+    cml_free(output_strides);
     return output;
 }
 

--- a/src/tensor/tensor_ops_extra.c
+++ b/src/tensor/tensor_ops_extra.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <math.h>
 #include <ctype.h>
+#include "alloc/cml_allocator.h"
 
 Tensor* tensor_where(Tensor* condition, Tensor* x, Tensor* y) {
     if (!condition || !x || !y) return NULL;
@@ -75,7 +76,7 @@ Tensor* tensor_multinomial(Tensor* probs, int num_samples, bool replacement) {
     Tensor* output = tensor_empty(out_shape, out_ndim, &config);
     if (!output) return NULL;
 
-    float* cumsum = (float*)malloc(num_categories * sizeof(float));
+    float* cumsum = (float*)cml_malloc(num_categories * sizeof(float));
     if (!cumsum) { tensor_free(output); return NULL; }
 
     int32_t* out_data = (int32_t*)tensor_data_ptr(output);
@@ -90,7 +91,7 @@ Tensor* tensor_multinomial(Tensor* probs, int num_samples, bool replacement) {
 
         if (total <= 0.0f) {
             LOG_ERROR("tensor_multinomial: probabilities sum to zero");
-            free(cumsum);
+            cml_free(cumsum);
             tensor_free(output);
             return NULL;
         }
@@ -100,8 +101,8 @@ Tensor* tensor_multinomial(Tensor* probs, int num_samples, bool replacement) {
 
         bool* used = NULL;
         if (!replacement) {
-            used = (bool*)calloc(num_categories, sizeof(bool));
-            if (!used) { free(cumsum); tensor_free(output); return NULL; }
+            used = (bool*)cml_calloc(num_categories, sizeof(bool));
+            if (!used) { cml_free(cumsum); tensor_free(output); return NULL; }
         }
 
         for (int s = 0; s < num_samples; s++) {
@@ -135,10 +136,10 @@ Tensor* tensor_multinomial(Tensor* probs, int num_samples, bool replacement) {
             out_data[out_idx] = selected;
         }
 
-        free(used);
+        cml_free(used);
     }
 
-    free(cumsum);
+    cml_free(cumsum);
     return output;
 }
 

--- a/src/tensor/tensor_views.c
+++ b/src/tensor/tensor_views.c
@@ -4,6 +4,7 @@
 #include "tensor/tensor_views.h"
 #include "tensor/tensor_manipulation.h"
 #include "core/logging.h"
+#include "alloc/cml_allocator.h"
 
 static bool can_reshape_as_view(Tensor* t, int* new_shape, int new_ndim) {
     if (!t->is_contiguous)
@@ -36,7 +37,7 @@ Tensor* tensor_reshape(Tensor* t, int* new_shape, int new_ndim) {
     }
 
     if (can_reshape_as_view(t, new_shape, new_ndim)) {
-        Tensor* view = calloc(1, sizeof(Tensor));
+        Tensor* view = cml_calloc(1, sizeof(Tensor));
         if (!view) {
             LOG_ERROR("Failed to allocate memory for tensor view");
             return NULL;
@@ -44,14 +45,14 @@ Tensor* tensor_reshape(Tensor* t, int* new_shape, int new_ndim) {
 
         view->shape = tensor_shape_copy(new_shape, new_ndim);
         if (!view->shape) {
-            free(view);
+            cml_free(view);
             return NULL;
         }
 
         view->strides = compute_contiguous_strides(new_shape, new_ndim);
         if (!view->strides) {
-            free(view->shape);
-            free(view);
+            cml_free(view->shape);
+            cml_free(view);
             return NULL;
         }
 
@@ -96,7 +97,7 @@ Tensor* tensor_as_strided(Tensor* t, int* shape, int ndim, size_t* strides, size
         return NULL;
     }
 
-    Tensor* view = calloc(1, sizeof(Tensor));
+    Tensor* view = cml_calloc(1, sizeof(Tensor));
     if (!view) {
         LOG_ERROR("Failed to allocate memory for strided view");
         return NULL;
@@ -104,14 +105,14 @@ Tensor* tensor_as_strided(Tensor* t, int* shape, int ndim, size_t* strides, size
 
     view->shape = tensor_shape_copy(shape, ndim);
     if (!view->shape) {
-        free(view);
+        cml_free(view);
         return NULL;
     }
 
-    view->strides = malloc((size_t)ndim * sizeof(size_t));
+    view->strides = cml_malloc((size_t)ndim * sizeof(size_t));
     if (!view->strides) {
-        free(view->shape);
-        free(view);
+        cml_free(view->shape);
+        cml_free(view);
         return NULL;
     }
     memcpy(view->strides, strides, (size_t)ndim * sizeof(size_t));

--- a/src/zoo/bert.c
+++ b/src/zoo/bert.c
@@ -4,6 +4,7 @@
 #include "core/logging.h"
 #include <stdlib.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 BERTConfig cml_zoo_bert_config_tiny(void) {
     return (BERTConfig){
@@ -108,17 +109,17 @@ static void bert_block_free(Module* module) {
         module_free((Module*)block->mlp);
     if (block->mlp_norm)
         module_free((Module*)block->mlp_norm);
-    free(block);
+    cml_free(block);
 }
 
 static Module* create_bert_block(int hidden_size, int n_head, int intermediate_size,
                                   int n_layer, DType dtype, DeviceType device) {
-    BERTEncoderBlock* block = malloc(sizeof(BERTEncoderBlock));
+    BERTEncoderBlock* block = cml_malloc(sizeof(BERTEncoderBlock));
     if (!block)
         return NULL;
 
     if (module_init((Module*)block, "BERTEncoderBlock", bert_block_forward, bert_block_free) != 0) {
-        free(block);
+        cml_free(block);
         return NULL;
     }
 
@@ -212,19 +213,19 @@ static void bert_free(Module* module) {
         module_free((Module*)bert->layers);
     if (bert->pooler)
         module_free((Module*)bert->pooler);
-    free(bert);
+    cml_free(bert);
 }
 
 Module* cml_zoo_bert_create(BERTConfig* config, DType dtype, DeviceType device) {
     if (!config)
         return NULL;
 
-    BERTModel* bert = malloc(sizeof(BERTModel));
+    BERTModel* bert = cml_malloc(sizeof(BERTModel));
     if (!bert)
         return NULL;
 
     if (module_init((Module*)bert, "BERT", bert_forward, bert_free) != 0) {
-        free(bert);
+        cml_free(bert);
         return NULL;
     }
 

--- a/src/zoo/clip.c
+++ b/src/zoo/clip.c
@@ -5,6 +5,7 @@
 #include "core/logging.h"
 #include <stdlib.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 CMLCLIPConfig cml_zoo_clip_config_vit_b32(void) {
     return (CMLCLIPConfig){
@@ -94,16 +95,16 @@ static void clip_vision_block_free(Module* module) {
     if (block->attn) module_free((Module*)block->attn);
     if (block->norm2) module_free((Module*)block->norm2);
     if (block->mlp) module_free((Module*)block->mlp);
-    free(block);
+    cml_free(block);
 }
 
 static Module* create_vision_block(int dim, int n_head, DType dtype, DeviceType device) {
-    CLIPVisionBlock* block = malloc(sizeof(CLIPVisionBlock));
+    CLIPVisionBlock* block = cml_malloc(sizeof(CLIPVisionBlock));
     if (!block) return NULL;
 
     if (module_init((Module*)block, "CLIPVisionBlock",
                     clip_vision_block_forward, clip_vision_block_free) != 0) {
-        free(block);
+        cml_free(block);
         return NULL;
     }
 
@@ -160,16 +161,16 @@ static void clip_text_block_free(Module* module) {
     if (block->attn) module_free((Module*)block->attn);
     if (block->norm2) module_free((Module*)block->norm2);
     if (block->mlp) module_free((Module*)block->mlp);
-    free(block);
+    cml_free(block);
 }
 
 static Module* create_text_block(int dim, int n_head, DType dtype, DeviceType device) {
-    CLIPTextBlock* block = malloc(sizeof(CLIPTextBlock));
+    CLIPTextBlock* block = cml_malloc(sizeof(CLIPTextBlock));
     if (!block) return NULL;
 
     if (module_init((Module*)block, "CLIPTextBlock",
                     clip_text_block_forward, clip_text_block_free) != 0) {
-        free(block);
+        cml_free(block);
         return NULL;
     }
 
@@ -233,7 +234,7 @@ static void clip_free(Module* module) {
     if (clip->text_norm) module_free((Module*)clip->text_norm);
     if (clip->text_proj) module_free((Module*)clip->text_proj);
 
-    free(clip);
+    cml_free(clip);
 }
 
 Tensor* clip_encode_image(Module* module, Tensor* image) {
@@ -341,12 +342,12 @@ Module* cml_zoo_clip_create(CMLCLIPConfig* config, DType dtype, DeviceType devic
     if (!config)
         return NULL;
 
-    CLIPModel* clip = malloc(sizeof(CLIPModel));
+    CLIPModel* clip = cml_malloc(sizeof(CLIPModel));
     if (!clip)
         return NULL;
 
     if (module_init((Module*)clip, "CLIP", clip_forward, clip_free) != 0) {
-        free(clip);
+        cml_free(clip);
         return NULL;
     }
 

--- a/src/zoo/convnext.c
+++ b/src/zoo/convnext.c
@@ -3,6 +3,7 @@
 #include "autograd/forward_ops.h"
 #include "core/logging.h"
 #include <stdlib.h>
+#include "alloc/cml_allocator.h"
 
 ConvNeXtConfig cml_zoo_convnext_config_tiny(void) {
     ConvNeXtConfig cfg = {
@@ -66,16 +67,16 @@ static void convnext_block_free(Module* module) {
         return;
     if (block->path)
         module_free((Module*)block->path);
-    free(block);
+    cml_free(block);
 }
 
 static Module* create_convnext_block(int dim, DType dtype, DeviceType device) {
-    ConvNeXtBlock* block = malloc(sizeof(ConvNeXtBlock));
+    ConvNeXtBlock* block = cml_malloc(sizeof(ConvNeXtBlock));
     if (!block)
         return NULL;
 
     if (module_init((Module*)block, "ConvNeXtBlock", convnext_block_forward, convnext_block_free) != 0) {
-        free(block);
+        cml_free(block);
         return NULL;
     }
 
@@ -83,7 +84,7 @@ static Module* create_convnext_block(int dim, DType dtype, DeviceType device) {
 
     block->path = nn_sequential();
     if (!block->path) {
-        free(block);
+        cml_free(block);
         return NULL;
     }
 

--- a/src/zoo/gpt2.c
+++ b/src/zoo/gpt2.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 GPT2Config cml_zoo_gpt2_config_small(void) {
     return (GPT2Config){
@@ -95,16 +96,16 @@ static void gpt2_block_free(Module* module) {
         module_free((Module*)block->ln_mlp);
     if (block->mlp)
         module_free((Module*)block->mlp);
-    free(block);
+    cml_free(block);
 }
 
 static Module* create_gpt2_block(int n_embd, int n_head, int n_layer, DType dtype, DeviceType device) {
-    GPT2Block* block = malloc(sizeof(GPT2Block));
+    GPT2Block* block = cml_malloc(sizeof(GPT2Block));
     if (!block)
         return NULL;
 
     if (module_init((Module*)block, "GPT2Block", gpt2_block_forward, gpt2_block_free) != 0) {
-        free(block);
+        cml_free(block);
         return NULL;
     }
 
@@ -221,19 +222,19 @@ static void gpt2_free(Module* module) {
         module_free((Module*)gpt2->ln_f);
     if (gpt2->lm_head)
         module_free((Module*)gpt2->lm_head);
-    free(gpt2);
+    cml_free(gpt2);
 }
 
 Module* cml_zoo_gpt2_create(GPT2Config* config, DType dtype, DeviceType device) {
     if (!config)
         return NULL;
 
-    GPT2Model* gpt2 = malloc(sizeof(GPT2Model));
+    GPT2Model* gpt2 = cml_malloc(sizeof(GPT2Model));
     if (!gpt2)
         return NULL;
 
     if (module_init((Module*)gpt2, "GPT2", gpt2_forward, gpt2_free) != 0) {
-        free(gpt2);
+        cml_free(gpt2);
         return NULL;
     }
 

--- a/src/zoo/inception.c
+++ b/src/zoo/inception.c
@@ -4,6 +4,7 @@
 #include "tensor/tensor_manipulation.h"
 #include "core/logging.h"
 #include <stdlib.h>
+#include "alloc/cml_allocator.h"
 
 static Module* conv_bn_relu(int in_ch, int out_ch, int kernel, int stride, int padding,
                              DType dtype, DeviceType device) {
@@ -29,20 +30,20 @@ static Tensor* concat_forward(Module* module, Tensor* input) {
     if (!blk || !input)
         return NULL;
 
-    Tensor** outputs = malloc(sizeof(Tensor*) * blk->num_branches);
+    Tensor** outputs = cml_malloc(sizeof(Tensor*) * blk->num_branches);
     if (!outputs)
         return NULL;
 
     for (int i = 0; i < blk->num_branches; i++) {
         outputs[i] = module_forward(blk->branches[i], input);
         if (!outputs[i]) {
-            free(outputs);
+            cml_free(outputs);
             return NULL;
         }
     }
 
     Tensor* result = tensor_concat(outputs, blk->num_branches, 1);
-    free(outputs);
+    cml_free(outputs);
     return result;
 }
 
@@ -52,23 +53,23 @@ static void concat_free(Module* module) {
         return;
     for (int i = 0; i < blk->num_branches; i++)
         module_free(blk->branches[i]);
-    free(blk->branches);
-    free(blk);
+    cml_free(blk->branches);
+    cml_free(blk);
 }
 
 static ConcatBlock* create_concat_block(const char* name, int num_branches) {
-    ConcatBlock* blk = malloc(sizeof(ConcatBlock));
+    ConcatBlock* blk = cml_malloc(sizeof(ConcatBlock));
     if (!blk)
         return NULL;
 
     if (module_init((Module*)blk, name, concat_forward, concat_free) != 0) {
-        free(blk);
+        cml_free(blk);
         return NULL;
     }
 
-    blk->branches = calloc(num_branches, sizeof(Module*));
+    blk->branches = cml_calloc(num_branches, sizeof(Module*));
     if (!blk->branches) {
-        free(blk);
+        cml_free(blk);
         return NULL;
     }
     blk->num_branches = num_branches;

--- a/src/zoo/mask_rcnn.c
+++ b/src/zoo/mask_rcnn.c
@@ -5,6 +5,7 @@
 #include "tensor/tensor_manipulation.h"
 #include "core/logging.h"
 #include <stdlib.h>
+#include "alloc/cml_allocator.h"
 
 MaskRCNNConfig cml_zoo_mask_rcnn_default_config(void) {
     MaskRCNNConfig cfg = {
@@ -69,15 +70,15 @@ static void backbone_free(Module* module) {
     if (bb->layer2) module_free((Module*)bb->layer2);
     if (bb->layer3) module_free((Module*)bb->layer3);
     if (bb->layer4) module_free((Module*)bb->layer4);
-    free(bb);
+    cml_free(bb);
 }
 
 static Module* create_backbone(DType dtype, DeviceType device) {
-    Backbone* bb = malloc(sizeof(Backbone));
+    Backbone* bb = cml_malloc(sizeof(Backbone));
     if (!bb) return NULL;
 
     if (module_init((Module*)bb, "ResNet50+FPN_Backbone", backbone_forward, backbone_free) != 0) {
-        free(bb);
+        cml_free(bb);
         return NULL;
     }
 
@@ -130,15 +131,15 @@ static void fpn_free(Module* module) {
     if (fpn->smooth3) module_free(fpn->smooth3);
     if (fpn->smooth4) module_free(fpn->smooth4);
     if (fpn->smooth5) module_free(fpn->smooth5);
-    free(fpn);
+    cml_free(fpn);
 }
 
 static Module* create_fpn(int fpn_ch, DType dtype, DeviceType device) {
-    FPN* fpn = malloc(sizeof(FPN));
+    FPN* fpn = cml_malloc(sizeof(FPN));
     if (!fpn) return NULL;
 
     if (module_init((Module*)fpn, "FPN", fpn_forward, fpn_free) != 0) {
-        free(fpn);
+        cml_free(fpn);
         return NULL;
     }
 
@@ -177,15 +178,15 @@ static void rpn_free(Module* module) {
     if (rpn->rpn_conv) module_free(rpn->rpn_conv);
     if (rpn->rpn_cls) module_free(rpn->rpn_cls);
     if (rpn->rpn_bbox) module_free(rpn->rpn_bbox);
-    free(rpn);
+    cml_free(rpn);
 }
 
 static Module* create_rpn(int fpn_ch, int num_anchors, DType dtype, DeviceType device) {
-    RPN* rpn = malloc(sizeof(RPN));
+    RPN* rpn = cml_malloc(sizeof(RPN));
     if (!rpn) return NULL;
 
     if (module_init((Module*)rpn, "RPN", rpn_forward, rpn_free) != 0) {
-        free(rpn);
+        cml_free(rpn);
         return NULL;
     }
 
@@ -227,16 +228,16 @@ static void roi_head_free(Module* module) {
     if (head->fc2) module_free(head->fc2);
     if (head->cls_score) module_free(head->cls_score);
     if (head->bbox_pred) module_free(head->bbox_pred);
-    free(head);
+    cml_free(head);
 }
 
 static Module* create_roi_head(int fpn_ch, int roi_size, int num_classes,
                                 DType dtype, DeviceType device) {
-    ROIHead* head = malloc(sizeof(ROIHead));
+    ROIHead* head = cml_malloc(sizeof(ROIHead));
     if (!head) return NULL;
 
     if (module_init((Module*)head, "ROIHead", roi_head_forward, roi_head_free) != 0) {
-        free(head);
+        cml_free(head);
         return NULL;
     }
 
@@ -277,15 +278,15 @@ static void mask_head_free(Module* module) {
     if (head->conv_layers) module_free((Module*)head->conv_layers);
     if (head->deconv) module_free(head->deconv);
     if (head->mask_pred) module_free(head->mask_pred);
-    free(head);
+    cml_free(head);
 }
 
 static Module* create_mask_head(int fpn_ch, int num_classes, DType dtype, DeviceType device) {
-    MaskHead* head = malloc(sizeof(MaskHead));
+    MaskHead* head = cml_malloc(sizeof(MaskHead));
     if (!head) return NULL;
 
     if (module_init((Module*)head, "MaskHead", mask_head_forward, mask_head_free) != 0) {
-        free(head);
+        cml_free(head);
         return NULL;
     }
 
@@ -332,7 +333,7 @@ static void mask_rcnn_free(Module* module) {
     if (net->rpn) module_free(net->rpn);
     if (net->roi_head) module_free(net->roi_head);
     if (net->mask_head) module_free(net->mask_head);
-    free(net);
+    cml_free(net);
 }
 
 Module* cml_zoo_mask_rcnn_create(const MaskRCNNConfig* cfg, DType dtype, DeviceType device) {
@@ -343,11 +344,11 @@ Module* cml_zoo_mask_rcnn_create(const MaskRCNNConfig* cfg, DType dtype, DeviceT
     if (c.roi_output_size <= 0) c.roi_output_size = 7;
     if (c.mask_output_size <= 0) c.mask_output_size = 14;
 
-    MaskRCNN* net = malloc(sizeof(MaskRCNN));
+    MaskRCNN* net = cml_malloc(sizeof(MaskRCNN));
     if (!net) return NULL;
 
     if (module_init((Module*)net, "MaskRCNN", mask_rcnn_forward, mask_rcnn_free) != 0) {
-        free(net);
+        cml_free(net);
         return NULL;
     }
 

--- a/src/zoo/resnet.c
+++ b/src/zoo/resnet.c
@@ -3,6 +3,7 @@
 #include "autograd/forward_ops.h"
 #include "core/logging.h"
 #include <stdlib.h>
+#include "alloc/cml_allocator.h"
 
 typedef struct {
     Module base;
@@ -38,23 +39,23 @@ static void bottleneck_free(Module* module) {
         module_free((Module*)block->conv);
     if (block->downsample)
         module_free((Module*)block->downsample);
-    free(block);
+    cml_free(block);
 }
 
 static Module* create_bottleneck(int in_channels, int mid_channels, int out_channels,
                                   int stride, DType dtype, DeviceType device) {
-    BottleneckBlock* block = malloc(sizeof(BottleneckBlock));
+    BottleneckBlock* block = cml_malloc(sizeof(BottleneckBlock));
     if (!block)
         return NULL;
 
     if (module_init((Module*)block, "Bottleneck", bottleneck_forward, bottleneck_free) != 0) {
-        free(block);
+        cml_free(block);
         return NULL;
     }
 
     block->conv = nn_sequential();
     if (!block->conv) {
-        free(block);
+        cml_free(block);
         return NULL;
     }
 
@@ -113,23 +114,23 @@ static void basic_block_free(Module* module) {
         module_free((Module*)block->conv);
     if (block->downsample)
         module_free((Module*)block->downsample);
-    free(block);
+    cml_free(block);
 }
 
 static Module* create_basic_block(int in_channels, int out_channels, int stride,
                                    DType dtype, DeviceType device) {
-    BasicBlock* block = malloc(sizeof(BasicBlock));
+    BasicBlock* block = cml_malloc(sizeof(BasicBlock));
     if (!block)
         return NULL;
 
     if (module_init((Module*)block, "BasicBlock", basic_block_forward, basic_block_free) != 0) {
-        free(block);
+        cml_free(block);
         return NULL;
     }
 
     block->conv = nn_sequential();
     if (!block->conv) {
-        free(block);
+        cml_free(block);
         return NULL;
     }
 

--- a/src/zoo/retinanet.c
+++ b/src/zoo/retinanet.c
@@ -5,6 +5,7 @@
 #include "tensor/tensor_manipulation.h"
 #include "core/logging.h"
 #include <stdlib.h>
+#include "alloc/cml_allocator.h"
 
 RetinaNetConfig cml_zoo_retinanet_default_config(void) {
     RetinaNetConfig cfg = {
@@ -44,7 +45,7 @@ static void backbone_free(Module* module) {
     if (bb->layer2) module_free((Module*)bb->layer2);
     if (bb->layer3) module_free((Module*)bb->layer3);
     if (bb->layer4) module_free((Module*)bb->layer4);
-    free(bb);
+    cml_free(bb);
 }
 
 typedef struct {
@@ -75,15 +76,15 @@ static void fpn_free(Module* module) {
     if (fpn->smooth5) module_free(fpn->smooth5);
     if (fpn->extra_p6) module_free(fpn->extra_p6);
     if (fpn->extra_p7) module_free(fpn->extra_p7);
-    free(fpn);
+    cml_free(fpn);
 }
 
 static Module* create_fpn(int fpn_ch, DType dtype, DeviceType device) {
-    FPN* fpn = malloc(sizeof(FPN));
+    FPN* fpn = cml_malloc(sizeof(FPN));
     if (!fpn) return NULL;
 
     if (module_init((Module*)fpn, "FPN", fpn_forward, fpn_free) != 0) {
-        free(fpn);
+        cml_free(fpn);
         return NULL;
     }
 
@@ -147,7 +148,7 @@ static void retinanet_free(Module* module) {
     if (net->fpn) module_free(net->fpn);
     if (net->cls_subnet) module_free(net->cls_subnet);
     if (net->box_subnet) module_free(net->box_subnet);
-    free(net);
+    cml_free(net);
 }
 
 Module* cml_zoo_retinanet_create(const RetinaNetConfig* cfg, DType dtype, DeviceType device) {
@@ -156,21 +157,21 @@ Module* cml_zoo_retinanet_create(const RetinaNetConfig* cfg, DType dtype, Device
     if (c.num_anchors <= 0) c.num_anchors = 9;
     if (c.fpn_channels <= 0) c.fpn_channels = 256;
 
-    RetinaNet* net = malloc(sizeof(RetinaNet));
+    RetinaNet* net = cml_malloc(sizeof(RetinaNet));
     if (!net) return NULL;
 
     if (module_init((Module*)net, "RetinaNet", retinanet_forward, retinanet_free) != 0) {
-        free(net);
+        cml_free(net);
         return NULL;
     }
 
     net->num_classes = c.num_classes;
     net->num_anchors = c.num_anchors;
 
-    ResNet50Backbone* bb = malloc(sizeof(ResNet50Backbone));
-    if (!bb) { free(net); return NULL; }
+    ResNet50Backbone* bb = cml_malloc(sizeof(ResNet50Backbone));
+    if (!bb) { cml_free(net); return NULL; }
     if (module_init((Module*)bb, "ResNet50Backbone", backbone_forward, backbone_free) != 0) {
-        free(bb); free(net); return NULL;
+        cml_free(bb); cml_free(net); return NULL;
     }
 
     bb->backbone_stem = nn_sequential();

--- a/src/zoo/rnnt.c
+++ b/src/zoo/rnnt.c
@@ -5,6 +5,7 @@
 #include "core/logging.h"
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 CMLRNNTConfig cml_zoo_rnnt_config_default(void) {
     return (CMLRNNTConfig){
@@ -36,22 +37,22 @@ static void rnnt_free(Module* module) {
         if (net->encoder_lstms[i]) module_free(net->encoder_lstms[i]);
         if (net->encoder_lnorms[i]) module_free(net->encoder_lnorms[i]);
     }
-    free(net->encoder_lstms);
-    free(net->encoder_lnorms);
+    cml_free(net->encoder_lstms);
+    cml_free(net->encoder_lnorms);
 
     if (net->pred_embedding) module_free(net->pred_embedding);
     for (int i = 0; i < net->num_pred_layers; i++) {
         if (net->pred_lstms[i]) module_free(net->pred_lstms[i]);
         if (net->pred_lnorms[i]) module_free(net->pred_lnorms[i]);
     }
-    free(net->pred_lstms);
-    free(net->pred_lnorms);
+    cml_free(net->pred_lstms);
+    cml_free(net->pred_lnorms);
 
     if (net->joint_linear1) module_free(net->joint_linear1);
     if (net->joint_relu) module_free(net->joint_relu);
     if (net->joint_linear2) module_free(net->joint_linear2);
 
-    free(net);
+    cml_free(net);
 }
 
 Tensor* cml_rnnt_encode(Module* module, Tensor* audio_features) {
@@ -114,11 +115,11 @@ Tensor* cml_rnnt_joint(Module* module, Tensor* enc_out, Tensor* pred_out) {
 Module* cml_zoo_rnnt_create(const CMLRNNTConfig* config, DType dtype, DeviceType device) {
     if (!config) return NULL;
 
-    CMLRNNT* net = calloc(1, sizeof(CMLRNNT));
+    CMLRNNT* net = cml_calloc(1, sizeof(CMLRNNT));
     if (!net) return NULL;
 
     if (module_init((Module*)net, "RNN-T", rnnt_forward, rnnt_free) != 0) {
-        free(net);
+        cml_free(net);
         return NULL;
     }
 
@@ -133,8 +134,8 @@ Module* cml_zoo_rnnt_create(const CMLRNNTConfig* config, DType dtype, DeviceType
         pad, 1, true, dtype, device);
 
     net->num_enc_layers = config->encoder_layers;
-    net->encoder_lstms = calloc(config->encoder_layers, sizeof(Module*));
-    net->encoder_lnorms = calloc(config->encoder_layers, sizeof(Module*));
+    net->encoder_lstms = cml_calloc(config->encoder_layers, sizeof(Module*));
+    net->encoder_lnorms = cml_calloc(config->encoder_layers, sizeof(Module*));
 
     for (int i = 0; i < config->encoder_layers; i++) {
         int in_sz = config->encoder_dim;
@@ -149,8 +150,8 @@ Module* cml_zoo_rnnt_create(const CMLRNNTConfig* config, DType dtype, DeviceType
         config->vocab_size, config->pred_dim, -1, dtype, device);
 
     net->num_pred_layers = config->pred_layers;
-    net->pred_lstms = calloc(config->pred_layers, sizeof(Module*));
-    net->pred_lnorms = calloc(config->pred_layers, sizeof(Module*));
+    net->pred_lstms = cml_calloc(config->pred_layers, sizeof(Module*));
+    net->pred_lnorms = cml_calloc(config->pred_layers, sizeof(Module*));
 
     for (int i = 0; i < config->pred_layers; i++) {
         int in_sz = config->pred_dim;

--- a/src/zoo/t5.c
+++ b/src/zoo/t5.c
@@ -4,6 +4,7 @@
 #include "core/logging.h"
 #include <stdlib.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 T5Config cml_zoo_t5_config_small(void) {
     return (T5Config){
@@ -84,17 +85,17 @@ static void t5_enc_block_free(Module* module) {
     if (block->self_attn) module_free((Module*)block->self_attn);
     if (block->norm2) module_free((Module*)block->norm2);
     if (block->mlp) module_free((Module*)block->mlp);
-    free(block);
+    cml_free(block);
 }
 
 static Module* create_t5_enc_block(int d_model, int n_head, int d_ff, int num_buckets,
                                     int n_layer, DType dtype, DeviceType device) {
-    T5EncoderBlock* block = malloc(sizeof(T5EncoderBlock));
+    T5EncoderBlock* block = cml_malloc(sizeof(T5EncoderBlock));
     if (!block) return NULL;
 
     if (module_init((Module*)block, "T5EncoderBlock",
                     t5_enc_block_forward, t5_enc_block_free) != 0) {
-        free(block);
+        cml_free(block);
         return NULL;
     }
 
@@ -216,17 +217,17 @@ static void t5_dec_block_free(Module* module) {
     if (block->cross_attn) module_free((Module*)block->cross_attn);
     if (block->norm3) module_free((Module*)block->norm3);
     if (block->mlp) module_free((Module*)block->mlp);
-    free(block);
+    cml_free(block);
 }
 
 static Module* create_t5_dec_block(int d_model, int n_head, int d_ff, int num_buckets,
                                     int n_layer, DType dtype, DeviceType device) {
-    T5DecoderBlock* block = malloc(sizeof(T5DecoderBlock));
+    T5DecoderBlock* block = cml_malloc(sizeof(T5DecoderBlock));
     if (!block) return NULL;
 
     if (module_init((Module*)block, "T5DecoderBlock",
                     t5_dec_block_forward, t5_dec_block_free) != 0) {
-        free(block);
+        cml_free(block);
         return NULL;
     }
 
@@ -315,7 +316,7 @@ static void t5_free(Module* module) {
     if (t5->dec_blocks) module_free((Module*)t5->dec_blocks);
     if (t5->dec_norm) module_free((Module*)t5->dec_norm);
     if (t5->lm_head) module_free((Module*)t5->lm_head);
-    free(t5);
+    cml_free(t5);
 }
 
 Tensor* t5_encode(Module* module, Tensor* input) {
@@ -359,12 +360,12 @@ Module* cml_zoo_t5_create(T5Config* config, DType dtype, DeviceType device) {
     if (!config)
         return NULL;
 
-    T5Model* t5 = malloc(sizeof(T5Model));
+    T5Model* t5 = cml_malloc(sizeof(T5Model));
     if (!t5)
         return NULL;
 
     if (module_init((Module*)t5, "T5", t5_forward, t5_free) != 0) {
-        free(t5);
+        cml_free(t5);
         return NULL;
     }
 

--- a/src/zoo/unet.c
+++ b/src/zoo/unet.c
@@ -4,6 +4,7 @@
 #include "tensor/tensor_manipulation.h"
 #include "core/logging.h"
 #include <stdlib.h>
+#include "alloc/cml_allocator.h"
 
 CMLUNetConfig cml_zoo_unet_config_default(void) {
     return (CMLUNetConfig){
@@ -84,7 +85,7 @@ static void unet_free(Module* module) {
     }
     if (unet->bottleneck) module_free((Module*)unet->bottleneck);
     if (unet->final_conv) module_free((Module*)unet->final_conv);
-    free(unet);
+    cml_free(unet);
 }
 
 Module* cml_zoo_unet_create(CMLUNetConfig* config, DType dtype, DeviceType device) {
@@ -95,12 +96,12 @@ Module* cml_zoo_unet_create(CMLUNetConfig* config, DType dtype, DeviceType devic
     if (depth > UNET_MAX_DEPTH)
         depth = UNET_MAX_DEPTH;
 
-    UNetModel* unet = malloc(sizeof(UNetModel));
+    UNetModel* unet = cml_malloc(sizeof(UNetModel));
     if (!unet)
         return NULL;
 
     if (module_init((Module*)unet, "UNet", unet_forward, unet_free) != 0) {
-        free(unet);
+        cml_free(unet);
         return NULL;
     }
 

--- a/src/zoo/unet3d.c
+++ b/src/zoo/unet3d.c
@@ -4,6 +4,7 @@
 #include "tensor/tensor_manipulation.h"
 #include "core/logging.h"
 #include <stdlib.h>
+#include "alloc/cml_allocator.h"
 
 CMLUNet3DConfig cml_zoo_unet3d_config_default(void) {
     return (CMLUNet3DConfig){
@@ -87,7 +88,7 @@ static void unet3d_free(Module* module) {
     }
     if (net->bottleneck) module_free((Module*)net->bottleneck);
     if (net->final_conv) module_free((Module*)net->final_conv);
-    free(net);
+    cml_free(net);
 }
 
 Module* cml_zoo_unet3d_create(const CMLUNet3DConfig* config, DType dtype, DeviceType device) {
@@ -97,11 +98,11 @@ Module* cml_zoo_unet3d_create(const CMLUNet3DConfig* config, DType dtype, Device
     if (depth > UNET3D_MAX_DEPTH)
         depth = UNET3D_MAX_DEPTH;
 
-    UNet3DModel* net = calloc(1, sizeof(UNet3DModel));
+    UNet3DModel* net = cml_calloc(1, sizeof(UNet3DModel));
     if (!net) return NULL;
 
     if (module_init((Module*)net, "UNet3D", unet3d_forward, unet3d_free) != 0) {
-        free(net);
+        cml_free(net);
         return NULL;
     }
 

--- a/src/zoo/vit.c
+++ b/src/zoo/vit.c
@@ -4,6 +4,7 @@
 #include "tensor/tensor_manipulation.h"
 #include "core/logging.h"
 #include <stdlib.h>
+#include "alloc/cml_allocator.h"
 
 ViTConfig cml_zoo_vit_config_tiny(void) {
     return (ViTConfig){
@@ -101,17 +102,17 @@ static void vit_block_free(Module* module) {
         module_free((Module*)block->mlp);
     if (block->norm2)
         module_free((Module*)block->norm2);
-    free(block);
+    cml_free(block);
 }
 
 static Module* create_vit_block(int hidden_size, int n_head, int mlp_dim,
                                  DType dtype, DeviceType device) {
-    ViTBlock* block = malloc(sizeof(ViTBlock));
+    ViTBlock* block = cml_malloc(sizeof(ViTBlock));
     if (!block)
         return NULL;
 
     if (module_init((Module*)block, "ViTBlock", vit_block_forward, vit_block_free) != 0) {
-        free(block);
+        cml_free(block);
         return NULL;
     }
 
@@ -196,19 +197,19 @@ static void vit_free(Module* module) {
         module_free((Module*)vit->norm);
     if (vit->head)
         module_free((Module*)vit->head);
-    free(vit);
+    cml_free(vit);
 }
 
 Module* cml_zoo_vit_create(ViTConfig* config, DType dtype, DeviceType device) {
     if (!config)
         return NULL;
 
-    ViTModel* vit = malloc(sizeof(ViTModel));
+    ViTModel* vit = cml_malloc(sizeof(ViTModel));
     if (!vit)
         return NULL;
 
     if (module_init((Module*)vit, "ViT", vit_forward, vit_free) != 0) {
-        free(vit);
+        cml_free(vit);
         return NULL;
     }
 

--- a/tests/bench_backends.c
+++ b/tests/bench_backends.c
@@ -13,6 +13,7 @@
 #include "autograd/forward_ops.h"
 #include "backend/blas.h"
 #include "core/logging.h"
+#include "alloc/cml_allocator.h"
 
 typedef struct {
     struct timespec start;
@@ -80,7 +81,7 @@ static void bench_matmul(int size, int iterations) {
     {
         CMLBlasContext* blas = cml_blas_init();
         if (blas) {
-            float* C = (float*)calloc(size * size, sizeof(float));
+            float* C = (float*)cml_calloc(size * size, sizeof(float));
 
             double total_time = 0;
             for (int i = 0; i < iterations; i++) {
@@ -93,7 +94,7 @@ static void bench_matmul(int size, int iterations) {
             printf("  BLAS (%s): %8.2f ms avg (%.2f ms total)\n",
                    cml_blas_get_library_name(blas), total_time / iterations, total_time);
 
-            free(C);
+            cml_free(C);
             cml_blas_free(blas);
         } else {
             printf("  BLAS:            Not available\n");

--- a/tests/test_am_driver.c
+++ b/tests/test_am_driver.c
@@ -6,6 +6,8 @@
 #include "ops/ir/gpu/am_driver.h"
 #include "ops/ir/gpu/amdgpu_kd.h"
 
+#include "alloc/cml_allocator.h"
+
 #ifdef CML_AM_MOCK_GPU
 #include "ops/ir/gpu/am_mock.h"
 #endif
@@ -146,10 +148,10 @@ static bool test_buffer_upload_download(void) {
         return true;
     }
 
-    float* src = (float*)malloc(size);
-    float* dst = (float*)calloc(256, sizeof(float));
+    float* src = (float*)cml_malloc(size);
+    float* dst = (float*)cml_calloc(256, sizeof(float));
     if (!src || !dst) {
-        free(src); free(dst);
+        cml_free(src); cml_free(dst);
         cml_am_buffer_free(drv, buf);
         cml_am_driver_free(drv);
         return false;
@@ -160,7 +162,7 @@ static bool test_buffer_upload_download(void) {
 
     if (cml_am_buffer_upload(drv, buf, src, size) != 0) {
         printf("(upload failed) ");
-        free(src); free(dst);
+        cml_free(src); cml_free(dst);
         cml_am_buffer_free(drv, buf);
         cml_am_driver_free(drv);
         return true;
@@ -168,7 +170,7 @@ static bool test_buffer_upload_download(void) {
 
     if (cml_am_buffer_download(drv, buf, dst, size) != 0) {
         printf("(download failed) ");
-        free(src); free(dst);
+        cml_free(src); cml_free(dst);
         cml_am_buffer_free(drv, buf);
         cml_am_driver_free(drv);
         return true;
@@ -179,8 +181,8 @@ static bool test_buffer_upload_download(void) {
         if (dst[i] != src[i]) { match = false; break; }
     }
 
-    free(src);
-    free(dst);
+    cml_free(src);
+    cml_free(dst);
     cml_am_buffer_free(drv, buf);
     cml_am_driver_free(drv);
     return match;
@@ -275,7 +277,7 @@ static bool test_enumerate_gpus(void) {
     if (ret == 0) {
         printf("(found %d GPU(s)) ", count);
         if (g_hw_available && count == 0) {
-            free(gpus);
+            cml_free(gpus);
             return false;
         }
         for (int i = 0; i < count; i++) {
@@ -286,7 +288,7 @@ static bool test_enumerate_gpus(void) {
         if (count > 0) printf("\n    ");
     }
 
-    free(gpus);
+    cml_free(gpus);
     return true;
 }
 
@@ -603,7 +605,7 @@ static bool test_mock_enumerate_gpus(void) {
     int count = 0;
     int ret = cml_am_enumerate_gpus(&gpus, &count);
     if (ret != 0) return false;
-    if (count < 1) { free(gpus); return false; }
+    if (count < 1) { cml_free(gpus); return false; }
 
     CMLAMMockGPU* mock = cml_am_mock_get();
     bool ok = (gpus[0].gpu_id == mock->gpu_id);
@@ -614,7 +616,7 @@ static bool test_mock_enumerate_gpus(void) {
     printf("(found %d GPU: %s [%s] gpu_id=%u) ",
            count, gpus[0].name, gpus[0].gfx_version, gpus[0].gpu_id);
 
-    free(gpus);
+    cml_free(gpus);
     return ok;
 }
 
@@ -655,14 +657,14 @@ static bool test_mock_buffer_lifecycle(void) {
     if (buf->gpu_va == 0) { cml_am_buffer_free(drv, buf); cml_am_driver_free(drv); return false; }
     if (buf->is_vram)     { cml_am_buffer_free(drv, buf); cml_am_driver_free(drv); return false; }
 
-    float* src = (float*)malloc(size);
-    float* dst = (float*)calloc(256, sizeof(float));
-    if (!src || !dst) { free(src); free(dst); cml_am_buffer_free(drv, buf); cml_am_driver_free(drv); return false; }
+    float* src = (float*)cml_malloc(size);
+    float* dst = (float*)cml_calloc(256, sizeof(float));
+    if (!src || !dst) { cml_free(src); cml_free(dst); cml_am_buffer_free(drv, buf); cml_am_driver_free(drv); return false; }
 
     for (int i = 0; i < 256; i++) src[i] = (float)i * 2.5f;
 
-    if (cml_am_buffer_upload(drv, buf, src, size) != 0) { free(src); free(dst); cml_am_buffer_free(drv, buf); cml_am_driver_free(drv); return false; }
-    if (cml_am_buffer_download(drv, buf, dst, size) != 0) { free(src); free(dst); cml_am_buffer_free(drv, buf); cml_am_driver_free(drv); return false; }
+    if (cml_am_buffer_upload(drv, buf, src, size) != 0) { cml_free(src); cml_free(dst); cml_am_buffer_free(drv, buf); cml_am_driver_free(drv); return false; }
+    if (cml_am_buffer_download(drv, buf, dst, size) != 0) { cml_free(src); cml_free(dst); cml_am_buffer_free(drv, buf); cml_am_driver_free(drv); return false; }
 
     bool match = true;
     for (int i = 0; i < 256; i++) {
@@ -676,8 +678,8 @@ static bool test_mock_buffer_lifecycle(void) {
         cml_am_buffer_free(drv, vbuf);
     }
 
-    free(src);
-    free(dst);
+    cml_free(src);
+    cml_free(dst);
     cml_am_buffer_free(drv, buf);
     cml_am_driver_free(drv);
     return match && vram_ok;

--- a/tests/test_compiler_features.c
+++ b/tests/test_compiler_features.c
@@ -8,6 +8,7 @@
 #include "ops/ir/internal.h"
 #include "ops/uops.h"
 #include "tensor/tensor.h"
+#include "alloc/cml_allocator.h"
 
 static int tests_run    = 0;
 static int tests_passed = 0;
@@ -46,7 +47,7 @@ static int test_multi_output_analyze_no_merge(void) {
 
     int ok = (num_merges == 0);
 
-    free(merge_groups);
+    cml_free(merge_groups);
     cml_fusion_schedule_free(s);
     cml_ir_free(g);
     tensor_free(a);
@@ -93,7 +94,7 @@ static int test_multi_output_same_inputs(void) {
         ok = (s->num_groups < groups_before);
     }
 
-    free(merge_groups);
+    cml_free(merge_groups);
     cml_fusion_schedule_free(s);
     cml_ir_free(g);
     tensor_free(a);
@@ -287,7 +288,7 @@ static int test_bfs_all_groups_visited(void) {
 
     int ok = (s != NULL && s->num_ordered == s->num_groups);
 
-    int* visited = calloc((size_t)s->num_groups, sizeof(int));
+    int* visited = cml_calloc((size_t)s->num_groups, sizeof(int));
     if (ok && visited) {
         for (int i = 0; i < s->num_ordered; i++) {
             visited[s->execution_order[i]] = 1;
@@ -296,7 +297,7 @@ static int test_bfs_all_groups_visited(void) {
             if (!visited[i]) { ok = 0; break; }
         }
     }
-    free(visited);
+    cml_free(visited);
 
     cml_fusion_schedule_free(s);
     cml_ir_free(g);

--- a/tests/test_convergence.c
+++ b/tests/test_convergence.c
@@ -6,6 +6,7 @@
 
 #include "cml.h"
 #include "tensor/realize.h"
+#include "alloc/cml_allocator.h"
 
 static float get_scalar(Tensor* t) {
     float* p = (float*)tensor_data_ptr(t);
@@ -28,7 +29,7 @@ static int test_xor_mlp(void) {
     Optimizer* optimizer = optim_adam(params, num_params, 0.01f, 0.0f, 0.9f, 0.999f, 1e-8f);
     if (!optimizer) {
         printf("    ERROR: failed to create optimizer\n");
-        free(params);
+        cml_free(params);
         module_free((Module*)model);
         return 0;
     }
@@ -69,7 +70,7 @@ static int test_xor_mlp(void) {
     tensor_free(X);
     tensor_free(Y);
     optimizer_free(optimizer);
-    free(params);
+    cml_free(params);
     module_free((Module*)model);
 
     return pass;
@@ -88,7 +89,7 @@ static int test_linear_regression(void) {
     Optimizer* optimizer = optim_sgd(params, num_params, 0.01f, 0.0f, 0.0f);
     if (!optimizer) {
         printf("    ERROR: failed to create optimizer\n");
-        free(params);
+        cml_free(params);
         module_free(model);
         return 0;
     }
@@ -158,7 +159,7 @@ static int test_linear_regression(void) {
     tensor_free(X);
     tensor_free(Y);
     optimizer_free(optimizer);
-    free(params);
+    cml_free(params);
     module_free(model);
 
     return pass;
@@ -177,7 +178,7 @@ static int test_conv2d_pattern(void) {
     Optimizer* optimizer = optim_adam(params, num_params, 0.01f, 0.0f, 0.9f, 0.999f, 1e-8f);
     if (!optimizer) {
         printf("    ERROR: failed to create optimizer\n");
-        free(params);
+        cml_free(params);
         module_free((Module*)model);
         return 0;
     }
@@ -261,7 +262,7 @@ static int test_conv2d_pattern(void) {
     tensor_free(X);
     tensor_free(Y);
     optimizer_free(optimizer);
-    free(params);
+    cml_free(params);
     module_free((Module*)model);
 
     return pass;

--- a/tests/test_cross_boundary_fusion.c
+++ b/tests/test_cross_boundary_fusion.c
@@ -7,6 +7,7 @@
 #include "ops/ir/internal.h"
 #include "ops/ir/fusion_patterns.h"
 #include "tensor/tensor.h"
+#include "alloc/cml_allocator.h"
 
 static int tests_run = 0;
 static int tests_passed = 0;
@@ -133,7 +134,7 @@ static int test_analyze_with_schedule(void) {
     int count = 0;
     int ret = cml_cross_boundary_analyze(&sched, &out, &count);
 
-    if (out) free(out);
+    if (out) cml_free(out);
     return ret == 0 && count == 0;
 }
 

--- a/tests/test_disk_cache.c
+++ b/tests/test_disk_cache.c
@@ -5,6 +5,7 @@
 #include <unistd.h>
 
 #include "ops/ir/disk_cache.h"
+#include "alloc/cml_allocator.h"
 
 static int tests_run = 0;
 static int tests_passed = 0;
@@ -59,7 +60,7 @@ static int test_put_get(void) {
     }
 
     int ok = (out_size == sizeof(data)) && (memcmp(out, data, sizeof(data)) == 0);
-    free(out);
+    cml_free(out);
     cml_disk_cache_close(cache);
     unlink(tmp_path);
     return ok;
@@ -123,7 +124,7 @@ static int test_overwrite(void) {
     cml_disk_cache_get(cache, 100, &out, &out_size);
 
     int ok = (out_size == sizeof(data2)) && (memcmp(out, data2, sizeof(data2)) == 0);
-    free(out);
+    cml_free(out);
     cml_disk_cache_close(cache);
     unlink(tmp_path);
     return ok;
@@ -145,7 +146,7 @@ static int test_persistence(void) {
     int ok = (cml_disk_cache_get(cache, 555, &out, &out_size) == 0) &&
              (out_size == sizeof(data)) &&
              (memcmp(out, data, sizeof(data)) == 0);
-    free(out);
+    cml_free(out);
     cml_disk_cache_close(cache);
     unlink(tmp_path);
     return ok;
@@ -168,7 +169,7 @@ static int test_large_blob(void) {
     if (!cache) return 1;
 
     size_t size = 1024 * 1024;
-    uint8_t* data = malloc(size);
+    uint8_t* data = cml_malloc(size);
     for (size_t i = 0; i < size; i++)
         data[i] = (uint8_t)(i & 0xFF);
 
@@ -179,8 +180,8 @@ static int test_large_blob(void) {
     cml_disk_cache_get(cache, 7777, &out, &out_size);
 
     int ok = (out_size == size) && (memcmp(out, data, size) == 0);
-    free(out);
-    free(data);
+    cml_free(out);
+    cml_free(data);
     cml_disk_cache_close(cache);
     unlink(tmp_path);
     return ok;

--- a/tests/test_dispatch.c
+++ b/tests/test_dispatch.c
@@ -10,6 +10,7 @@
 #include "tensor/tensor.h"
 #include "autograd/forward_ops.h"
 #include "core/logging.h"
+#include "alloc/cml_allocator.h"
 
 static int tests_run = 0;
 static int tests_passed = 0;
@@ -286,7 +287,7 @@ static int test_env_backend_selection(void) {
     char* original = getenv("CML_BACKEND");
     char* saved = NULL;
     if (original) {
-        saved = strdup(original);
+        saved = cml_strdup(original);
     }
 
     // Test setting via env
@@ -296,7 +297,7 @@ static int test_env_backend_selection(void) {
     // Restore original env
     if (saved) {
         setenv("CML_BACKEND", saved, 1);
-        free(saved);
+        cml_free(saved);
     } else {
         unsetenv("CML_BACKEND");
     }

--- a/tests/test_fused_codegen.c
+++ b/tests/test_fused_codegen.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 static int tests_passed = 0;
 static int tests_failed = 0;
@@ -20,11 +21,11 @@ static int tests_failed = 0;
 
 /* Helper: create a minimal LinearProgram manually */
 static CMLLinearProgram* make_test_program(void) {
-    CMLLinearProgram* prog = calloc(1, sizeof(CMLLinearProgram));
+    CMLLinearProgram* prog = cml_calloc(1, sizeof(CMLLinearProgram));
     if (!prog) return NULL;
     prog->capacity = 16;
-    prog->ops = calloc(16, sizeof(CMLLinearOp));
-    if (!prog->ops) { free(prog); return NULL; }
+    prog->ops = cml_calloc(16, sizeof(CMLLinearOp));
+    if (!prog->ops) { cml_free(prog); return NULL; }
 
     /* LOAD v0 from buf0 */
     prog->ops[0] = (CMLLinearOp){.kind = LINOP_LOAD, .dest_reg = 0};
@@ -130,7 +131,7 @@ static void test_cuda_codegen(void) {
         fclose(f);
         printf("  CUDA source saved to /tmp/cml_matmul.cu\n");
     }
-    free(cuda_src);
+    cml_free(cuda_src);
 
     cuda_src = cml_ptx_gen_conv2d(cg, "conv2d_kernel");
     ASSERT(cuda_src != NULL, "conv2d CUDA source");
@@ -142,7 +143,7 @@ static void test_cuda_codegen(void) {
         fclose(f);
         printf("  CUDA source saved to /tmp/cml_conv2d.cu\n");
     }
-    free(cuda_src);
+    cml_free(cuda_src);
 
     cml_ptx_codegen_destroy(cg);
     tests_passed++;
@@ -184,10 +185,10 @@ static void test_linear_program_print(void) {
 static void test_mul_chain_codegen(void) {
     printf("test_mul_chain_codegen...\n");
 
-    CMLLinearProgram* prog = calloc(1, sizeof(CMLLinearProgram));
+    CMLLinearProgram* prog = cml_calloc(1, sizeof(CMLLinearProgram));
     ASSERT(prog != NULL, "alloc");
     prog->capacity = 16;
-    prog->ops = calloc(16, sizeof(CMLLinearOp));
+    prog->ops = cml_calloc(16, sizeof(CMLLinearOp));
     ASSERT(prog->ops != NULL, "alloc ops");
 
     /* LOAD v0 */

--- a/tests/test_fuzzer_ops.c
+++ b/tests/test_fuzzer_ops.c
@@ -7,6 +7,7 @@
 #include "cml.h"
 #include "tensor/tensor.h"
 #include "ops/uops.h"
+#include "alloc/cml_allocator.h"
 
 static uint64_t rng_state;
 
@@ -74,34 +75,34 @@ static int make_shape(int* shape, int* ndim_out, int max_numel) {
 static Tensor* make_positive_tensor(int* shape, int ndim, float range) {
     int n = 1;
     for (int i = 0; i < ndim; i++) n *= shape[i];
-    float* data = malloc(n * sizeof(float));
+    float* data = cml_malloc(n * sizeof(float));
     for (int i = 0; i < n; i++)
         data[i] = rng_float(0.01f, range);
     Tensor* t = tensor_from_data(data, shape, ndim, &cpu_f32);
-    free(data);
+    cml_free(data);
     return t;
 }
 
 static Tensor* make_signed_tensor(int* shape, int ndim, float range) {
     int n = 1;
     for (int i = 0; i < ndim; i++) n *= shape[i];
-    float* data = malloc(n * sizeof(float));
+    float* data = cml_malloc(n * sizeof(float));
     for (int i = 0; i < n; i++)
         data[i] = rng_float(-range, range);
     Tensor* t = tensor_from_data(data, shape, ndim, &cpu_f32);
-    free(data);
+    cml_free(data);
     return t;
 }
 
 static Tensor* make_asin_safe_tensor(int* shape, int ndim) {
     int n = 1;
     for (int i = 0; i < ndim; i++) n *= shape[i];
-    float* data = malloc(n * sizeof(float));
+    float* data = cml_malloc(n * sizeof(float));
     for (int i = 0; i < n; i++) {
         data[i] = (float)sin((double)rng_int(0, 1000) / 100.0);
     }
     Tensor* t = tensor_from_data(data, shape, ndim, &cpu_f32);
-    free(data);
+    cml_free(data);
     return t;
 }
 typedef Tensor* (*UnaryOp)(Tensor*);
@@ -398,12 +399,12 @@ static int fuzz_where(void) {
         int n = rng_int(2, 64);
         int shape[] = {n};
         
-        float* cd = malloc(n * sizeof(float));
+        float* cd = cml_malloc(n * sizeof(float));
         for (int i = 0; i < n; i++) cd[i] = (float)(rng_int(0, 2));
         Tensor* cond = tensor_from_data(cd, shape, 1, &cpu_f32);
         Tensor* a = make_signed_tensor(shape, 1, 3.0f);
         Tensor* b = make_signed_tensor(shape, 1, 3.0f);
-        free(cd);
+        cml_free(cd);
         if (!cond || !a || !b) {
             if (cond) tensor_free(cond);
             if (a)    tensor_free(a);

--- a/tests/test_gqa_flash.c
+++ b/tests/test_gqa_flash.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 static int tests_passed = 0;
 static int tests_failed = 0;
@@ -28,7 +29,7 @@ static int tests_failed = 0;
 
 static Tensor* make_rand_tensor(int b, int s, int d) {
     size_t n = (size_t)b * s * d;
-    float* buf = (float*)malloc(n * sizeof(float));
+    float* buf = (float*)cml_malloc(n * sizeof(float));
     if (!buf) return NULL;
     for (size_t i = 0; i < n; i++) {
         buf[i] = ((float)rand() / (float)RAND_MAX - 0.5f) * 0.1f;
@@ -37,7 +38,7 @@ static Tensor* make_rand_tensor(int b, int s, int d) {
     TensorConfig cfg = {.dtype = DTYPE_FLOAT32, .device = DEVICE_CPU,
                         .has_dtype = true, .has_device = true};
     Tensor* t = tensor_from_data(buf, shape, 3, &cfg);
-    free(buf);
+    cml_free(buf);
     return t;
 }
 

--- a/tests/test_grad_check.c
+++ b/tests/test_grad_check.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include "tensor/tensor.h"
 #include "ops/uops.h"
+#include "alloc/cml_allocator.h"
 
 static int tests_passed = 0;
 static int tests_total  = 0;
@@ -32,8 +33,8 @@ typedef Tensor* (*UnaryFn)(Tensor*);
 
 static float numerical_grad(const float* base, int n, int shape[],
                              int idx, UnaryFn f_fn, float eps) {
-    float* xp = malloc(n * sizeof(float));
-    float* xm = malloc(n * sizeof(float));
+    float* xp = cml_malloc(n * sizeof(float));
+    float* xm = cml_malloc(n * sizeof(float));
     memcpy(xp, base, n * sizeof(float));
     memcpy(xm, base, n * sizeof(float));
     xp[idx] += eps;
@@ -56,7 +57,7 @@ static float numerical_grad(const float* base, int n, int shape[],
 
     tensor_free(tp); tensor_free(tm);
     tensor_free(op); tensor_free(om);
-    free(xp); free(xm);
+    cml_free(xp); cml_free(xm);
     return grad;
 }
 

--- a/tests/test_graph_cache_integration.c
+++ b/tests/test_graph_cache_integration.c
@@ -13,6 +13,7 @@
 #include "ops/ir/ir.h"
 #include "ops/ir/execution.h"
 #include "ops/ir/graph_cache.h"
+#include "alloc/cml_allocator.h"
 
 static int tests_passed = 0;
 static int tests_total  = 0;
@@ -29,8 +30,8 @@ static void test_cache_population(void) {
     size_t h0 = cache->hits, m0 = cache->misses;
     TensorConfig cfg = {0};
     int sa[] = {32, 64}, sb[] = {64, 32};
-    float* a = malloc(32*64*sizeof(float));
-    float* b = malloc(64*32*sizeof(float));
+    float* a = cml_malloc(32*64*sizeof(float));
+    float* b = cml_malloc(64*32*sizeof(float));
     for (int i = 0; i < 32*64; i++) a[i] = (float)(i%7)*0.1f;
     for (int i = 0; i < 64*32; i++) b[i] = (float)(i%5)*0.1f;
 
@@ -57,7 +58,7 @@ static void test_cache_population(void) {
 
     CHECK("results consistent across reset", v1 == v2);
 
-    free(a); free(b);
+    cml_free(a); cml_free(b);
 }
 
 static void test_multi_node_cache(void) {
@@ -65,9 +66,9 @@ static void test_multi_node_cache(void) {
     CMLGraphCache* cache = cml_get_graph_cache();
     TensorConfig cfg = {0};
     int sa[] = {16, 32}, sb[] = {32, 16}, sbi[] = {16};
-    float* a = malloc(16*32*sizeof(float));
-    float* b = malloc(32*16*sizeof(float));
-    float* bias = malloc(16*sizeof(float));
+    float* a = cml_malloc(16*32*sizeof(float));
+    float* b = cml_malloc(32*16*sizeof(float));
+    float* bias = cml_malloc(16*sizeof(float));
     for (int i = 0; i < 16*32; i++) a[i] = (float)(i%9)*0.05f;
     for (int i = 0; i < 32*16; i++) b[i] = (float)(i%7)*0.05f;
     for (int i = 0; i < 16; i++) bias[i] = 0.1f;
@@ -90,7 +91,7 @@ static void test_multi_node_cache(void) {
     CHECK("multi-node: iter 0==1", results[0] == results[1]);
     CHECK("multi-node: iter 1==2", results[1] == results[2]);
 
-    free(a); free(b); free(bias);
+    cml_free(a); cml_free(b); cml_free(bias);
 }
 
 static void test_cache_stats(void) {

--- a/tests/test_heuristic_opt.c
+++ b/tests/test_heuristic_opt.c
@@ -4,6 +4,7 @@
 
 #include "ops/ir/heuristic_opt.h"
 #include "ops/ir/linearize.h"
+#include "alloc/cml_allocator.h"
 
 static int tests_run = 0;
 static int tests_passed = 0;
@@ -28,7 +29,7 @@ static LinearProgram* make_prog(int num_axes, const int* extents,
     for (int i = 0; i < num_axes; i++) {
         if (prog->num_axes >= prog->axes_capacity) {
             int nc = prog->axes_capacity * 2;
-            int* tmp = realloc(prog->loop_axes, (size_t)nc * sizeof(int));
+            int* tmp = cml_realloc(prog->loop_axes, (size_t)nc * sizeof(int));
             if (!tmp) { linear_program_free(prog); return NULL; }
             prog->loop_axes = tmp;
             prog->axes_capacity = nc;

--- a/tests/test_llama.c
+++ b/tests/test_llama.c
@@ -6,6 +6,7 @@
 
 #include "cml.h"
 #include "nn/llama.h"
+#include "alloc/cml_allocator.h"
 
 static int tests_run = 0;
 static int tests_passed = 0;
@@ -400,11 +401,11 @@ static int test_generation_result_free(void) {
     cml_generation_result_free(NULL);
 
     /* Create and free a result */
-    CMLGenerationResult* result = (CMLGenerationResult*)calloc(1, sizeof(CMLGenerationResult));
+    CMLGenerationResult* result = (CMLGenerationResult*)cml_calloc(1, sizeof(CMLGenerationResult));
     if (!result) return 0;
-    result->token_ids = (int*)malloc(4 * sizeof(int));
+    result->token_ids = (int*)cml_malloc(4 * sizeof(int));
     result->num_tokens = 4;
-    result->text = (char*)malloc(16);
+    result->text = (char*)cml_malloc(16);
     if (result->text) strcpy(result->text, "hello");
     cml_generation_result_free(result);
     return 1;

--- a/tests/test_llm_ops.c
+++ b/tests/test_llm_ops.c
@@ -6,6 +6,7 @@
 
 #include "cml.h"
 #include "nn/llm_ops.h"
+#include "alloc/cml_allocator.h"
 
 static int tests_run = 0;
 static int tests_passed = 0;
@@ -574,14 +575,14 @@ static int test_tokenizer_encode_simple(void) {
     if (!ids) { cml_tokenizer_free(tok); return 0; }
 
     /* "hello" -> 5 character tokens: h=0, e=1, l=2, l=2, o=3 */
-    if (num_tokens != 5) { free(ids); cml_tokenizer_free(tok); return 0; }
-    if (ids[0] != 0) { free(ids); cml_tokenizer_free(tok); return 0; }  /* h */
-    if (ids[1] != 1) { free(ids); cml_tokenizer_free(tok); return 0; }  /* e */
-    if (ids[2] != 2) { free(ids); cml_tokenizer_free(tok); return 0; }  /* l */
-    if (ids[3] != 2) { free(ids); cml_tokenizer_free(tok); return 0; }  /* l */
-    if (ids[4] != 3) { free(ids); cml_tokenizer_free(tok); return 0; }  /* o */
+    if (num_tokens != 5) { cml_free(ids); cml_tokenizer_free(tok); return 0; }
+    if (ids[0] != 0) { cml_free(ids); cml_tokenizer_free(tok); return 0; }  /* h */
+    if (ids[1] != 1) { cml_free(ids); cml_tokenizer_free(tok); return 0; }  /* e */
+    if (ids[2] != 2) { cml_free(ids); cml_tokenizer_free(tok); return 0; }  /* l */
+    if (ids[3] != 2) { cml_free(ids); cml_tokenizer_free(tok); return 0; }  /* l */
+    if (ids[4] != 3) { cml_free(ids); cml_tokenizer_free(tok); return 0; }  /* o */
 
-    free(ids);
+    cml_free(ids);
     cml_tokenizer_free(tok);
     return 1;
 }
@@ -596,9 +597,9 @@ static int test_tokenizer_decode_simple(void) {
     int tokens[] = {0, 1, 2, 2, 3}; /* h, e, l, l, o */
     char* text = cml_tokenizer_decode(tok, tokens, 5);
     if (!text) { cml_tokenizer_free(tok); return 0; }
-    if (strcmp(text, "hello") != 0) { free(text); cml_tokenizer_free(tok); return 0; }
+    if (strcmp(text, "hello") != 0) { cml_free(text); cml_tokenizer_free(tok); return 0; }
 
-    free(text);
+    cml_free(text);
     cml_tokenizer_free(tok);
     return 1;
 }
@@ -619,19 +620,19 @@ static int test_tokenizer_encode_decode_roundtrip(void) {
     if (!ids) { cml_tokenizer_free(tok); return 0; }
 
     /* "abc" -> "ab" + "c" after BPE merge => 2 tokens */
-    if (num_tokens != 2) { free(ids); cml_tokenizer_free(tok); return 0; }
+    if (num_tokens != 2) { cml_free(ids); cml_tokenizer_free(tok); return 0; }
 
     char* decoded = cml_tokenizer_decode(tok, ids, num_tokens);
-    free(ids);
+    cml_free(ids);
 
     if (!decoded) { cml_tokenizer_free(tok); return 0; }
     if (strcmp(decoded, original) != 0) {
-        free(decoded);
+        cml_free(decoded);
         cml_tokenizer_free(tok);
         return 0;
     }
 
-    free(decoded);
+    cml_free(decoded);
     cml_tokenizer_free(tok);
     return 1;
 }
@@ -682,13 +683,13 @@ static int test_tokenizer_unknown_token(void) {
     int num_tokens = 0;
     int* ids = cml_tokenizer_encode(tok, "ax", &num_tokens);
     if (!ids) { cml_tokenizer_free(tok); return 0; }
-    if (num_tokens != 2) { free(ids); cml_tokenizer_free(tok); return 0; }
+    if (num_tokens != 2) { cml_free(ids); cml_tokenizer_free(tok); return 0; }
 
     /* 'a' -> 0, 'x' not in vocab -> unk_token_id = 1 */
-    if (ids[0] != 0) { free(ids); cml_tokenizer_free(tok); return 0; }
-    if (ids[1] != 1) { free(ids); cml_tokenizer_free(tok); return 0; }
+    if (ids[0] != 0) { cml_free(ids); cml_tokenizer_free(tok); return 0; }
+    if (ids[1] != 1) { cml_free(ids); cml_tokenizer_free(tok); return 0; }
 
-    free(ids);
+    cml_free(ids);
     cml_tokenizer_free(tok);
     return 1;
 }
@@ -708,10 +709,10 @@ static int test_tokenizer_bpe_merge(void) {
     if (!ids) { cml_tokenizer_free(tok); return 0; }
 
     /* "abc" -> first merge "ab" gives ["ab", "c"], then merge "abc" gives ["abc"] => 1 token */
-    if (num_tokens != 1) { free(ids); cml_tokenizer_free(tok); return 0; }
-    if (ids[0] != 4) { free(ids); cml_tokenizer_free(tok); return 0; } /* "abc" = ID 4 */
+    if (num_tokens != 1) { cml_free(ids); cml_tokenizer_free(tok); return 0; }
+    if (ids[0] != 4) { cml_free(ids); cml_tokenizer_free(tok); return 0; } /* "abc" = ID 4 */
 
-    free(ids);
+    cml_free(ids);
     cml_tokenizer_free(tok);
     return 1;
 }

--- a/tests/test_metal_backend.c
+++ b/tests/test_metal_backend.c
@@ -4,6 +4,7 @@
 #include <assert.h>
 
 #include "ops/ir/gpu/metal_backend.h"
+#include "alloc/cml_allocator.h"
 
 int main(void) {
     printf("Metal Backend Tests\n");
@@ -41,7 +42,7 @@ int main(void) {
         assert(buffer != NULL);
 
         /* Upload some data */
-        float* host_data = (float*)calloc(1024, sizeof(float));
+        float* host_data = (float*)cml_calloc(1024, sizeof(float));
         assert(host_data != NULL);
         for (int i = 0; i < 1024; i++) {
             host_data[i] = (float)i;
@@ -50,7 +51,7 @@ int main(void) {
         assert(ret == 0);
 
         /* Download and verify */
-        float* host_out = (float*)calloc(1024, sizeof(float));
+        float* host_out = (float*)cml_calloc(1024, sizeof(float));
         assert(host_out != NULL);
         ret = cml_metal_download(backend, host_out, buffer, buf_size);
         assert(ret == 0);
@@ -58,8 +59,8 @@ int main(void) {
             assert(host_out[i] == (float)i);
         }
 
-        free(host_data);
-        free(host_out);
+        cml_free(host_data);
+        cml_free(host_out);
         cml_metal_free(backend, buffer);
         printf(" PASS\n");
 

--- a/tests/test_multi_gpu.c
+++ b/tests/test_multi_gpu.c
@@ -19,6 +19,7 @@
 #include "distributed/distributed.h"
 #include "distributed/data_parallel.h"
 #include "distributed/pipeline_parallel.h"
+#include "alloc/cml_allocator.h"
 #endif
 
 /* Test counters */
@@ -809,7 +810,7 @@ static int test_ddp_training_loop(void) {
     printf("(final_loss=%.4f, decreased=%s) ", prev_loss, loss_decreased ? "yes" : "no");
 
     optimizer_free(optimizer);
-    free(params);
+    cml_free(params);
     cml_ddp_free(ddp);
     module_free((Module*)model);
     cml_dist_destroy();

--- a/tests/test_new_features.c
+++ b/tests/test_new_features.c
@@ -255,7 +255,12 @@ static int test_muon_optimizer(void) {
 
     Parameter* params[] = {param};
     Optimizer* opt = optim_muon(params, 1, 0.02f, 0.95f, 0.0f, true);
-    if (!opt) { cml_free(param); tensor_free(weight); return 0; }
+    if (!opt) {
+        cml_free(param->name);
+        cml_free(param);
+        tensor_free(weight);
+        return 0;
+    }
 
     // Step should not crash
     optimizer_step(opt);

--- a/tests/test_new_features.c
+++ b/tests/test_new_features.c
@@ -12,6 +12,7 @@
 #include "core/gguf.h"
 #include "core/safetensors.h"
 #include "core/serialization.h"
+#include "alloc/cml_allocator.h"
 
 static int tests_passed = 0;
 static int tests_total  = 0;
@@ -246,15 +247,15 @@ static int test_muon_optimizer(void) {
     weight->requires_grad = true;
     weight->grad = tensor_ones(shape, 2, &cpu_f32);
 
-    Parameter* param = (Parameter*)malloc(sizeof(Parameter));
+    Parameter* param = (Parameter*)cml_malloc(sizeof(Parameter));
     if (!param) { tensor_free(weight); return 0; }
     param->tensor = weight;
-    param->name = strdup("test_weight");
+    param->name = cml_strdup("test_weight");
     param->requires_grad = true;
 
     Parameter* params[] = {param};
     Optimizer* opt = optim_muon(params, 1, 0.02f, 0.95f, 0.0f, true);
-    if (!opt) { free(param); tensor_free(weight); return 0; }
+    if (!opt) { cml_free(param); tensor_free(weight); return 0; }
 
     // Step should not crash
     optimizer_step(opt);
@@ -273,8 +274,8 @@ static int test_muon_optimizer(void) {
         tensor_free(g);
     }
     tensor_free(weight);
-    free(param->name);
-    free(param);
+    cml_free(param->name);
+    cml_free(param);
     return changed;
 }
 
@@ -464,15 +465,15 @@ static int test_nadam_optimizer(void) {
     weight->requires_grad = true;
     weight->grad = tensor_ones(shape, 2, &cpu_f32);
 
-    Parameter* param = (Parameter*)malloc(sizeof(Parameter));
+    Parameter* param = (Parameter*)cml_malloc(sizeof(Parameter));
     if (!param) { tensor_free(weight); return 0; }
     param->tensor = weight;
-    param->name = strdup("w");
+    param->name = cml_strdup("w");
     param->requires_grad = true;
 
     Parameter* params[] = {param};
     Optimizer* opt = optim_nadam(params, 1, 0.01f, 0.0f, 0.9f, 0.999f, 1e-8f);
-    if (!opt) { free(param->name); free(param); tensor_free(weight); return 0; }
+    if (!opt) { cml_free(param->name); cml_free(param); tensor_free(weight); return 0; }
 
     optimizer_step(opt);
     tensor_ensure_executed(weight);
@@ -482,8 +483,8 @@ static int test_nadam_optimizer(void) {
     optimizer_free(opt);
     if (weight->grad) { Tensor* g = weight->grad; weight->grad = NULL; tensor_free(g); }
     tensor_free(weight);
-    free(param->name);
-    free(param);
+    cml_free(param->name);
+    cml_free(param);
     return changed;
 }
 
@@ -493,15 +494,15 @@ static int test_adamax_optimizer(void) {
     weight->requires_grad = true;
     weight->grad = tensor_ones(shape, 2, &cpu_f32);
 
-    Parameter* param = (Parameter*)malloc(sizeof(Parameter));
+    Parameter* param = (Parameter*)cml_malloc(sizeof(Parameter));
     if (!param) { tensor_free(weight); return 0; }
     param->tensor = weight;
-    param->name = strdup("w");
+    param->name = cml_strdup("w");
     param->requires_grad = true;
 
     Parameter* params[] = {param};
     Optimizer* opt = optim_adamax(params, 1, 0.002f, 0.0f, 0.9f, 0.999f, 1e-8f);
-    if (!opt) { free(param->name); free(param); tensor_free(weight); return 0; }
+    if (!opt) { cml_free(param->name); cml_free(param); tensor_free(weight); return 0; }
 
     optimizer_step(opt);
     tensor_ensure_executed(weight);
@@ -511,8 +512,8 @@ static int test_adamax_optimizer(void) {
     optimizer_free(opt);
     if (weight->grad) { Tensor* g = weight->grad; weight->grad = NULL; tensor_free(g); }
     tensor_free(weight);
-    free(param->name);
-    free(param);
+    cml_free(param->name);
+    cml_free(param);
     return changed;
 }
 

--- a/tests/test_nv_driver.c
+++ b/tests/test_nv_driver.c
@@ -6,6 +6,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "alloc/cml_allocator.h"
+
 
 static int tests_run    = 0;
 static int tests_passed = 0;
@@ -189,10 +191,10 @@ static int test_buffer_upload_download(void) {
         SKIP("buffer create failed");
     }
 
-    float *src = (float *)malloc(n);
-    float *dst = (float *)calloc(256, sizeof(float));
+    float *src = (float *)cml_malloc(n);
+    float *dst = (float *)cml_calloc(256, sizeof(float));
     if (!src || !dst) {
-        free(src); free(dst);
+        cml_free(src); cml_free(dst);
         cml_nv_buffer_free(drv, buf);
         cml_nv_driver_free(drv);
         return 0;
@@ -201,14 +203,14 @@ static int test_buffer_upload_download(void) {
         src[i] = (float)i * 0.5f;
 
     if (cml_nv_buffer_upload(drv, buf, src, n) != 0) {
-        free(src); free(dst);
+        cml_free(src); cml_free(dst);
         cml_nv_buffer_free(drv, buf);
         cml_nv_driver_free(drv);
         return 0;
     }
 
     if (cml_nv_buffer_download(drv, buf, dst, n) != 0) {
-        free(src); free(dst);
+        cml_free(src); cml_free(dst);
         cml_nv_buffer_free(drv, buf);
         cml_nv_driver_free(drv);
         return 0;
@@ -223,8 +225,8 @@ static int test_buffer_upload_download(void) {
         }
     }
 
-    free(src);
-    free(dst);
+    cml_free(src);
+    cml_free(dst);
     cml_nv_buffer_free(drv, buf);
     cml_nv_driver_free(drv);
     return ok;
@@ -456,6 +458,7 @@ static int test_buffer_copy_null(void) {
 
 #ifdef CML_NV_MOCK_GPU
 #include "ops/ir/gpu/nv_mock.h"
+#include "alloc/cml_allocator.h"
 
 static CMLNVDriver* mock_create_and_init(void) {
     CMLNVDriver *drv = cml_nv_driver_create();

--- a/tests/test_opencl_ir.c
+++ b/tests/test_opencl_ir.c
@@ -13,6 +13,7 @@
 
 #ifdef CML_HAS_OPENCL
 #include "ops/ir/gpu/opencl_ir_backend.h"
+#include "alloc/cml_allocator.h"
 #endif
 
 static int tests_passed = 0;
@@ -40,8 +41,8 @@ static void test_matmul(void) {
 
     /* CPU reference */
     TensorConfig cfg = {0};
-    float* a_data = malloc(M * K * sizeof(float));
-    float* b_data = malloc(K * N * sizeof(float));
+    float* a_data = cml_malloc(M * K * sizeof(float));
+    float* b_data = cml_malloc(K * N * sizeof(float));
     for (int i = 0; i < M * K; i++) a_data[i] = (float)(i % 7) * 0.1f;
     for (int i = 0; i < K * N; i++) b_data[i] = (float)(i % 5) * 0.1f;
 
@@ -52,7 +53,7 @@ static void test_matmul(void) {
     Tensor* tc_cpu = uop_matmul(ta_cpu, tb_cpu);
     float* cpu_result = (float*)tensor_data_ptr(tc_cpu);
 
-    float* cpu_copy = malloc(M * N * sizeof(float));
+    float* cpu_copy = cml_malloc(M * N * sizeof(float));
     memcpy(cpu_copy, cpu_result, M * N * sizeof(float));
 
     tensor_free(ta_cpu);
@@ -77,15 +78,15 @@ static void test_matmul(void) {
     cml_reset_ir_context();
     unsetenv("CML_BACKEND");
 
-    free(a_data);
-    free(b_data);
-    free(cpu_copy);
+    cml_free(a_data);
+    cml_free(b_data);
+    cml_free(cpu_copy);
 }
 
 static void test_elementwise(void) {
     printf("Testing elementwise ops on GPU...\n");
     int n = 1024;
-    float* data = malloc(n * sizeof(float));
+    float* data = cml_malloc(n * sizeof(float));
     for (int i = 0; i < n; i++) data[i] = (float)(i - 512) * 0.01f;
 
     int shape[] = {n};
@@ -97,7 +98,7 @@ static void test_elementwise(void) {
         Tensor* t = tensor_from_data(data, shape, 1, &cfg);
         Tensor* r = uop_relu(t);
         float* cpu_res = (float*)tensor_data_ptr(r);
-        float* cpu_copy = malloc(n * sizeof(float));
+        float* cpu_copy = cml_malloc(n * sizeof(float));
         memcpy(cpu_copy, cpu_res, n * sizeof(float));
         tensor_free(t); tensor_free(r);
         cml_reset_ir_context();
@@ -112,12 +113,12 @@ static void test_elementwise(void) {
         tensor_free(t); tensor_free(r);
         cml_reset_ir_context();
         unsetenv("CML_BACKEND");
-        free(cpu_copy);
+        cml_free(cpu_copy);
     }
 
     /* Test ADD with broadcast */
     {
-        float* data2 = malloc(sizeof(float));
+        float* data2 = cml_malloc(sizeof(float));
         data2[0] = 3.14f;
         int shape2[] = {1};
 
@@ -126,7 +127,7 @@ static void test_elementwise(void) {
         Tensor* tb = tensor_from_data(data2, shape2, 1, &cfg);
         Tensor* r = uop_add(ta, tb);
         float* cpu_res = (float*)tensor_data_ptr(r);
-        float* cpu_copy = malloc(n * sizeof(float));
+        float* cpu_copy = cml_malloc(n * sizeof(float));
         memcpy(cpu_copy, cpu_res, n * sizeof(float));
         tensor_free(ta); tensor_free(tb); tensor_free(r);
         cml_reset_ir_context();
@@ -142,18 +143,18 @@ static void test_elementwise(void) {
         tensor_free(ta); tensor_free(tb); tensor_free(r);
         cml_reset_ir_context();
         unsetenv("CML_BACKEND");
-        free(cpu_copy);
-        free(data2);
+        cml_free(cpu_copy);
+        cml_free(data2);
     }
 
-    free(data);
+    cml_free(data);
 }
 
 static void test_large_matmul_perf(void) {
     printf("Testing large MATMUL performance...\n");
     int M = 512, K = 512, N = 512;
-    float* a_data = malloc(M * K * sizeof(float));
-    float* b_data = malloc(K * N * sizeof(float));
+    float* a_data = cml_malloc(M * K * sizeof(float));
+    float* b_data = cml_malloc(K * N * sizeof(float));
     for (int i = 0; i < M * K; i++) a_data[i] = (float)(i % 11) * 0.01f;
     for (int i = 0; i < K * N; i++) b_data[i] = (float)(i % 13) * 0.01f;
 
@@ -203,8 +204,8 @@ static void test_large_matmul_perf(void) {
     printf("    GEMM 512x512: GPU %.2fms, CPU %.2fms (%.2fx)\n", gpu_ms, cpu_ms, cpu_ms / gpu_ms);
     CHECK("MATMUL 512x512 GPU runs", gpu_ms > 0);
 
-    free(a_data);
-    free(b_data);
+    cml_free(a_data);
+    cml_free(b_data);
 }
 
 int main(void) {

--- a/tests/test_opt_transforms.c
+++ b/tests/test_opt_transforms.c
@@ -5,6 +5,7 @@
 
 #include "ops/ir/opt_transforms.h"
 #include "ops/ir/linearize.h"
+#include "alloc/cml_allocator.h"
 
 static int tests_run = 0;
 static int tests_passed = 0;
@@ -30,7 +31,7 @@ static LinearProgram* make_test_prog(int num_axes, const int* extents) {
     for (int i = 0; i < num_axes; i++) {
         if (prog->num_axes >= prog->axes_capacity) {
             int nc = prog->axes_capacity * 2;
-            int* tmp = realloc(prog->loop_axes, (size_t)nc * sizeof(int));
+            int* tmp = cml_realloc(prog->loop_axes, (size_t)nc * sizeof(int));
             if (!tmp) { linear_program_free(prog); return NULL; }
             prog->loop_axes = tmp;
             prog->axes_capacity = nc;
@@ -438,7 +439,7 @@ static int test_enumerate_basic(void) {
     if (count < 2) {
         printf("(too few combinations: %d) ", count);
         for (int i = 0; i < count; i++) cml_opt_list_free(lists[i]);
-        free(lists);
+        cml_free(lists);
         linear_program_free(prog);
         return 0;
     }
@@ -447,13 +448,13 @@ static int test_enumerate_basic(void) {
     if (lists[0]->num_opts != 0) {
         printf("(first list not empty) ");
         for (int i = 0; i < count; i++) cml_opt_list_free(lists[i]);
-        free(lists);
+        cml_free(lists);
         linear_program_free(prog);
         return 0;
     }
 
     for (int i = 0; i < count; i++) cml_opt_list_free(lists[i]);
-    free(lists);
+    cml_free(lists);
     linear_program_free(prog);
     return 1;
 }
@@ -472,13 +473,13 @@ static int test_enumerate_respects_max(void) {
     if (count > 10) {
         printf("(count %d exceeds max 10) ", count);
         for (int i = 0; i < count; i++) cml_opt_list_free(lists[i]);
-        free(lists);
+        cml_free(lists);
         linear_program_free(prog);
         return 0;
     }
 
     for (int i = 0; i < count; i++) cml_opt_list_free(lists[i]);
-    free(lists);
+    cml_free(lists);
     linear_program_free(prog);
     return 1;
 }
@@ -509,7 +510,7 @@ static int test_enumerate_all_valid(void) {
     }
 
     for (int i = 0; i < count; i++) cml_opt_list_free(lists[i]);
-    free(lists);
+    cml_free(lists);
     linear_program_free(prog);
 
     /* At least the baseline should always be valid. */

--- a/tests/test_optim.c
+++ b/tests/test_optim.c
@@ -5,6 +5,7 @@
 #include <math.h>
 
 #include "cml.h"
+#include "alloc/cml_allocator.h"
 
 static int tests_run = 0;
 static int tests_passed = 0;
@@ -56,7 +57,7 @@ static int test_sgd(void) {
     printf("(ok) ");
 
     optimizer_free(opt);
-    free(params);
+    cml_free(params);
     module_free((Module*)model);
     return 1;
 }
@@ -72,7 +73,7 @@ static int test_adam(void) {
     printf("(ok) ");
 
     optimizer_free(opt);
-    free(params);
+    cml_free(params);
     module_free((Module*)model);
     return 1;
 }
@@ -88,7 +89,7 @@ static int test_adamw(void) {
     printf("(ok) ");
 
     optimizer_free(opt);
-    free(params);
+    cml_free(params);
     module_free((Module*)model);
     return 1;
 }
@@ -104,7 +105,7 @@ static int test_rmsprop(void) {
     printf("(ok) ");
 
     optimizer_free(opt);
-    free(params);
+    cml_free(params);
     module_free((Module*)model);
     return 1;
 }
@@ -120,7 +121,7 @@ static int test_adagrad(void) {
     printf("(ok) ");
 
     optimizer_free(opt);
-    free(params);
+    cml_free(params);
     module_free((Module*)model);
     return 1;
 }
@@ -136,7 +137,7 @@ static int test_adadelta(void) {
     printf("(ok) ");
 
     optimizer_free(opt);
-    free(params);
+    cml_free(params);
     module_free((Module*)model);
     return 1;
 }
@@ -146,13 +147,13 @@ static int test_lamb(void) {
     create_test_model(&model, &params, &num_params);
 
     Optimizer* opt = optim_lamb(params, num_params, 0.001f, 0.01f, 0.9f, 0.999f, 1e-6f);
-    if (!opt) { free(params); module_free((Module*)model); return 0; }
+    if (!opt) { cml_free(params); module_free((Module*)model); return 0; }
 
     optimizer_step(opt);
     printf("(ok) ");
 
     optimizer_free(opt);
-    free(params);
+    cml_free(params);
     module_free((Module*)model);
     return 1;
 }
@@ -162,13 +163,13 @@ static int test_lars(void) {
     create_test_model(&model, &params, &num_params);
 
     Optimizer* opt = optim_lars(params, num_params, 0.01f, 0.9f, 0.0f, 0.02f);
-    if (!opt) { free(params); module_free((Module*)model); return 0; }
+    if (!opt) { cml_free(params); module_free((Module*)model); return 0; }
 
     optimizer_step(opt);
     printf("(ok) ");
 
     optimizer_free(opt);
-    free(params);
+    cml_free(params);
     module_free((Module*)model);
     return 1;
 }
@@ -184,7 +185,7 @@ static int test_zero_grad(void) {
     printf("(ok) ");
 
     optimizer_free(opt);
-    free(params);
+    cml_free(params);
     module_free((Module*)model);
     return 1;
 }
@@ -197,7 +198,7 @@ static int test_lr_scheduler_step(void) {
     if (!opt) return 0;
 
     LRScheduler* sched = lr_scheduler_step(opt, 10, 0.1f);
-    if (!sched) { optimizer_free(opt); free(params); module_free((Module*)model); return 0; }
+    if (!sched) { optimizer_free(opt); cml_free(params); module_free((Module*)model); return 0; }
 
     float lr_before = lr_scheduler_get_lr(sched);
     for (int i = 0; i < 10; i++)
@@ -209,7 +210,7 @@ static int test_lr_scheduler_step(void) {
 
     lr_scheduler_free(sched);
     optimizer_free(opt);
-    free(params);
+    cml_free(params);
     module_free((Module*)model);
     return ok;
 }

--- a/tests/test_paged_attention.c
+++ b/tests/test_paged_attention.c
@@ -6,6 +6,7 @@
 
 #include "cml.h"
 #include "nn/paged_attention.h"
+#include "alloc/cml_allocator.h"
 
 static int tests_run = 0;
 static int tests_passed = 0;
@@ -144,28 +145,28 @@ static int test_append_tokens(void) {
     if (seq < 0) { cml_paged_kv_cache_free(cache); return 0; }
 
     size_t kv_floats = (size_t)num_kv_heads * head_dim;
-    float* key = (float*)malloc(kv_floats * sizeof(float));
-    float* val = (float*)malloc(kv_floats * sizeof(float));
-    if (!key || !val) { free(key); free(val); cml_paged_kv_cache_free(cache); return 0; }
+    float* key = (float*)cml_malloc(kv_floats * sizeof(float));
+    float* val = (float*)cml_malloc(kv_floats * sizeof(float));
+    if (!key || !val) { cml_free(key); cml_free(val); cml_paged_kv_cache_free(cache); return 0; }
 
     /* Append 5 tokens */
     for (int t = 0; t < 5; t++) {
         fill_float(key, kv_floats, (float)(t + 1));
         fill_float(val, kv_floats, (float)(t + 1) * 0.1f);
         if (cml_paged_cache_append(cache, seq, key, val) != 0) {
-            free(key); free(val);
+            cml_free(key); cml_free(val);
             cml_paged_kv_cache_free(cache);
             return 0;
         }
     }
 
     CMLBlockTable* bt = &cache->sequences[seq];
-    if (bt->seq_len != 5) { free(key); free(val); cml_paged_kv_cache_free(cache); return 0; }
+    if (bt->seq_len != 5) { cml_free(key); cml_free(val); cml_paged_kv_cache_free(cache); return 0; }
     /* 5 tokens < block_size (16) => 1 block */
-    if (bt->num_blocks != 1) { free(key); free(val); cml_paged_kv_cache_free(cache); return 0; }
+    if (bt->num_blocks != 1) { cml_free(key); cml_free(val); cml_paged_kv_cache_free(cache); return 0; }
 
-    free(key);
-    free(val);
+    cml_free(key);
+    cml_free(val);
     cml_paged_kv_cache_free(cache);
     return 1;
 }
@@ -338,21 +339,21 @@ static int test_paged_gqa_output_shape(void) {
 
     /* Populate sequence with 10 tokens */
     size_t kv_floats = (size_t)num_kv_heads * head_dim;
-    float* key = (float*)malloc(kv_floats * sizeof(float));
-    float* val = (float*)malloc(kv_floats * sizeof(float));
-    if (!key || !val) { free(key); free(val); cml_paged_kv_cache_free(cache); return 0; }
+    float* key = (float*)cml_malloc(kv_floats * sizeof(float));
+    float* val = (float*)cml_malloc(kv_floats * sizeof(float));
+    if (!key || !val) { cml_free(key); cml_free(val); cml_paged_kv_cache_free(cache); return 0; }
 
     for (int t = 0; t < 10; t++) {
         fill_float(key, kv_floats, 0.1f * (t + 1));
         fill_float(val, kv_floats, 0.01f * (t + 1));
         cml_paged_cache_append(cache, seq, key, val);
     }
-    free(key);
-    free(val);
+    cml_free(key);
+    cml_free(val);
 
     /* Create Q tensor: [1, 1, num_heads * head_dim] (single query token) */
     int q_dim = num_heads * head_dim;
-    float* q_data = (float*)malloc((size_t)q_dim * sizeof(float));
+    float* q_data = (float*)cml_malloc((size_t)q_dim * sizeof(float));
     if (!q_data) { cml_paged_kv_cache_free(cache); return 0; }
     fill_float(q_data, (size_t)q_dim, 0.5f);
 
@@ -360,7 +361,7 @@ static int test_paged_gqa_output_shape(void) {
     TensorConfig cfg = {.dtype = DTYPE_FLOAT32, .device = DEVICE_CPU,
                         .has_dtype = true, .has_device = true};
     Tensor* Q = tensor_from_data(q_data, q_shape, 3, &cfg);
-    free(q_data);
+    cml_free(q_data);
     if (!Q) { cml_paged_kv_cache_free(cache); return 0; }
 
     CMLGQAConfig gqa_cfg = {
@@ -414,7 +415,7 @@ static int test_paged_gqa_multi_query_tokens(void) {
     int q_dim = num_heads * head_dim;
     int seq_q = 3;
     int total_q = seq_q * q_dim;
-    float* q_data = (float*)malloc((size_t)total_q * sizeof(float));
+    float* q_data = (float*)cml_malloc((size_t)total_q * sizeof(float));
     if (!q_data) { cml_paged_kv_cache_free(cache); return 0; }
     fill_float(q_data, (size_t)total_q, 0.3f);
 
@@ -422,7 +423,7 @@ static int test_paged_gqa_multi_query_tokens(void) {
     TensorConfig cfg = {.dtype = DTYPE_FLOAT32, .device = DEVICE_CPU,
                         .has_dtype = true, .has_device = true};
     Tensor* Q = tensor_from_data(q_data, q_shape, 3, &cfg);
-    free(q_data);
+    cml_free(q_data);
     if (!Q) { cml_paged_kv_cache_free(cache); return 0; }
 
     CMLGQAConfig gqa_cfg = {

--- a/tests/test_ptx_codegen.c
+++ b/tests/test_ptx_codegen.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 static int tests_passed = 0;
 static int tests_failed = 0;
@@ -22,7 +23,7 @@ static int tests_failed = 0;
     do { if (strstr((haystack), (needle)) == NULL) { \
         char _msg[512]; \
         snprintf(_msg, sizeof(_msg), "Missing '%s' in PTX output", (needle)); \
-        FAIL(_msg); free(ptx); return; \
+        FAIL(_msg); cml_free(ptx); return; \
     }} while(0)
 
 static void assert_ptx_common(const char* ptx, const char* kernel_name) {
@@ -59,7 +60,7 @@ static void test_unary_neg(void) {
     ASSERT_CONTAINS(ptx, "param_in");
     ASSERT_CONTAINS(ptx, "param_out");
     ASSERT_CONTAINS(ptx, "sm_50");
-    free(ptx);
+    cml_free(ptx);
     cml_ptx_codegen_destroy(cg);
     PASS();
 }
@@ -72,7 +73,7 @@ static void test_unary_exp(void) {
     assert_ptx_common(ptx, "kernel_exp");
     ASSERT_CONTAINS(ptx, "ex2.approx.f32");
     ASSERT_CONTAINS(ptx, "mul.f32");
-    free(ptx);
+    cml_free(ptx);
     cml_ptx_codegen_destroy(cg);
     PASS();
 }
@@ -84,7 +85,7 @@ static void test_unary_log(void) {
     ASSERT_NOT_NULL(ptx);
     assert_ptx_common(ptx, "kernel_log");
     ASSERT_CONTAINS(ptx, "lg2.approx.f32");
-    free(ptx);
+    cml_free(ptx);
     cml_ptx_codegen_destroy(cg);
     PASS();
 }
@@ -95,7 +96,7 @@ static void test_unary_sqrt(void) {
     char* ptx = cml_ptx_gen_unary(cg, UOP_SQRT, "kernel_sqrt");
     ASSERT_NOT_NULL(ptx);
     ASSERT_CONTAINS(ptx, "sqrt.approx.f32");
-    free(ptx);
+    cml_free(ptx);
     cml_ptx_codegen_destroy(cg);
     PASS();
 }
@@ -106,7 +107,7 @@ static void test_unary_abs(void) {
     char* ptx = cml_ptx_gen_unary(cg, UOP_ABS, "kernel_abs");
     ASSERT_NOT_NULL(ptx);
     ASSERT_CONTAINS(ptx, "abs.f32");
-    free(ptx);
+    cml_free(ptx);
     cml_ptx_codegen_destroy(cg);
     PASS();
 }
@@ -117,7 +118,7 @@ static void test_unary_sin(void) {
     char* ptx = cml_ptx_gen_unary(cg, UOP_SIN, "kernel_sin");
     ASSERT_NOT_NULL(ptx);
     ASSERT_CONTAINS(ptx, "sin.approx.f32");
-    free(ptx);
+    cml_free(ptx);
     cml_ptx_codegen_destroy(cg);
     PASS();
 }
@@ -128,7 +129,7 @@ static void test_unary_cos(void) {
     char* ptx = cml_ptx_gen_unary(cg, UOP_COS, "kernel_cos");
     ASSERT_NOT_NULL(ptx);
     ASSERT_CONTAINS(ptx, "cos.approx.f32");
-    free(ptx);
+    cml_free(ptx);
     cml_ptx_codegen_destroy(cg);
     PASS();
 }
@@ -142,7 +143,7 @@ static void test_unary_sigmoid(void) {
     ASSERT_CONTAINS(ptx, "neg.f32");
     ASSERT_CONTAINS(ptx, "ex2.approx.f32");
     ASSERT_CONTAINS(ptx, "rcp.approx.f32");
-    free(ptx);
+    cml_free(ptx);
     cml_ptx_codegen_destroy(cg);
     PASS();
 }
@@ -155,7 +156,7 @@ static void test_unary_tanh(void) {
     ASSERT_CONTAINS(ptx, "ex2.approx.f32");
     ASSERT_CONTAINS(ptx, "rcp.approx.f32");
     ASSERT_CONTAINS(ptx, "sub.f32");
-    free(ptx);
+    cml_free(ptx);
     cml_ptx_codegen_destroy(cg);
     PASS();
 }
@@ -169,7 +170,7 @@ static void test_binary_add(void) {
     ASSERT_CONTAINS(ptx, "add.f32");
     ASSERT_CONTAINS(ptx, "param_a");
     ASSERT_CONTAINS(ptx, "param_b");
-    free(ptx);
+    cml_free(ptx);
     cml_ptx_codegen_destroy(cg);
     PASS();
 }
@@ -180,7 +181,7 @@ static void test_binary_mul(void) {
     char* ptx = cml_ptx_gen_binary(cg, UOP_MUL, "kernel_mul");
     ASSERT_NOT_NULL(ptx);
     ASSERT_CONTAINS(ptx, "mul.f32");
-    free(ptx);
+    cml_free(ptx);
     cml_ptx_codegen_destroy(cg);
     PASS();
 }
@@ -191,7 +192,7 @@ static void test_binary_max(void) {
     char* ptx = cml_ptx_gen_binary(cg, UOP_MAX, "kernel_max");
     ASSERT_NOT_NULL(ptx);
     ASSERT_CONTAINS(ptx, "max.f32");
-    free(ptx);
+    cml_free(ptx);
     cml_ptx_codegen_destroy(cg);
     PASS();
 }
@@ -203,7 +204,7 @@ static void test_binary_cmplt(void) {
     ASSERT_NOT_NULL(ptx);
     ASSERT_CONTAINS(ptx, "setp.lt.f32");
     ASSERT_CONTAINS(ptx, "selp.f32");
-    free(ptx);
+    cml_free(ptx);
     cml_ptx_codegen_destroy(cg);
     PASS();
 }
@@ -215,7 +216,7 @@ static void test_binary_pow(void) {
     ASSERT_NOT_NULL(ptx);
     ASSERT_CONTAINS(ptx, "lg2.approx.f32");
     ASSERT_CONTAINS(ptx, "ex2.approx.f32");
-    free(ptx);
+    cml_free(ptx);
     cml_ptx_codegen_destroy(cg);
     PASS();
 }
@@ -229,7 +230,7 @@ static void test_fill(void) {
     ASSERT_CONTAINS(ptx, "mov.f32");
     ASSERT_CONTAINS(ptx, "st.global.f32");
     ASSERT_CONTAINS(ptx, "0f");  // IEEE hex float
-    free(ptx);
+    cml_free(ptx);
     cml_ptx_codegen_destroy(cg);
     PASS();
 }
@@ -243,7 +244,7 @@ static void test_where(void) {
     ASSERT_CONTAINS(ptx, "param_cond");
     ASSERT_CONTAINS(ptx, "selp.f32");
     ASSERT_CONTAINS(ptx, "setp.ne.f32");
-    free(ptx);
+    cml_free(ptx);
     cml_ptx_codegen_destroy(cg);
     PASS();
 }
@@ -255,7 +256,7 @@ static void test_reduction_sum(void) {
     ASSERT_NOT_NULL(ptx);
     assert_ptx_common(ptx, "kernel_sum");
     ASSERT_CONTAINS(ptx, "atom.global.add.f32");
-    free(ptx);
+    cml_free(ptx);
     cml_ptx_codegen_destroy(cg);
     PASS();
 }
@@ -267,7 +268,7 @@ static void test_reduction_mean(void) {
     ASSERT_NOT_NULL(ptx);
     ASSERT_CONTAINS(ptx, "atom.global.add.f32");
     ASSERT_CONTAINS(ptx, "div.approx.f32");
-    free(ptx);
+    cml_free(ptx);
     cml_ptx_codegen_destroy(cg);
     PASS();
 }
@@ -283,7 +284,7 @@ static void test_matmul(void) {
     ASSERT_CONTAINS(ptx, "param_N");
     ASSERT_CONTAINS(ptx, "param_K");
     ASSERT_CONTAINS(ptx, "bra");
-    free(ptx);
+    cml_free(ptx);
     cml_ptx_codegen_destroy(cg);
     PASS();
 }
@@ -294,7 +295,7 @@ static void test_sm_version(void) {
     char* ptx = cml_ptx_gen_unary(cg, UOP_NEG, "kernel_neg86");
     ASSERT_NOT_NULL(ptx);
     ASSERT_CONTAINS(ptx, "sm_86");
-    free(ptx);
+    cml_free(ptx);
     cml_ptx_codegen_destroy(cg);
     PASS();
 }
@@ -308,7 +309,7 @@ static void test_kernel_count(void) {
     char* p3 = cml_ptx_gen_fill(cg, 0.0f, "k3");
     if (cg->kernel_count != 3) { FAIL("Expected count 3"); }
     else { PASS(); }
-    free(p1); free(p2); free(p3);
+    cml_free(p1); cml_free(p2); cml_free(p3);
     cml_ptx_codegen_destroy(cg);
 }
 
@@ -316,7 +317,7 @@ static void test_invalid_unary_op(void) {
     TEST(invalid_unary_op);
     CMLPTXCodegen* cg = cml_ptx_codegen_create(50, NULL);
     char* ptx = cml_ptx_gen_unary(cg, UOP_ADD, "invalid"); // ADD is binary, not unary
-    if (ptx != NULL) { FAIL("Should return NULL for invalid op"); free(ptx); }
+    if (ptx != NULL) { FAIL("Should return NULL for invalid op"); cml_free(ptx); }
     else { PASS(); }
     cml_ptx_codegen_destroy(cg);
 }
@@ -330,7 +331,7 @@ static void test_register_declarations(void) {
     ASSERT_CONTAINS(ptx, ".reg .b32");
     ASSERT_CONTAINS(ptx, ".reg .b64");
     ASSERT_CONTAINS(ptx, ".reg .f32");
-    free(ptx);
+    cml_free(ptx);
     cml_ptx_codegen_destroy(cg);
     PASS();
 }
@@ -342,7 +343,7 @@ static void test_bounds_check(void) {
     ASSERT_NOT_NULL(ptx);
     ASSERT_CONTAINS(ptx, "setp.ge.u32");
     ASSERT_CONTAINS(ptx, "ret");
-    free(ptx);
+    cml_free(ptx);
     cml_ptx_codegen_destroy(cg);
     PASS();
 }

--- a/tests/test_qlora.c
+++ b/tests/test_qlora.c
@@ -6,6 +6,7 @@
 
 #include "cml.h"
 #include "nn/qlora.h"
+#include "alloc/cml_allocator.h"
 
 static int tests_run = 0;
 static int tests_passed = 0;
@@ -56,7 +57,7 @@ static int test_nf4_roundtrip(void) {
     int expected_blocks = (numel + block_size - 1) / block_size;
     if (num_scales != expected_blocks) {
         printf("(expected %d blocks, got %d) ", expected_blocks, num_scales);
-        free(scales);
+        cml_free(scales);
         tensor_free(packed);
         tensor_free(original);
         return 0;
@@ -66,7 +67,7 @@ static int test_nf4_roundtrip(void) {
     Tensor* reconstructed = cml_dequantize_nf4(packed, scales, num_scales,
                                                 block_size, (size_t)numel);
     if (!reconstructed) {
-        free(scales);
+        cml_free(scales);
         tensor_free(packed);
         tensor_free(original);
         return 0;
@@ -98,7 +99,7 @@ static int test_nf4_roundtrip(void) {
         ok = 0;
     }
 
-    free(scales);
+    cml_free(scales);
     tensor_free(packed);
     tensor_free(reconstructed);
     tensor_free(original);

--- a/tests/test_remote_device.c
+++ b/tests/test_remote_device.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include "alloc/cml_allocator.h"
 
 #define TEST_PORT 19876
 
@@ -91,8 +92,8 @@ static void test_upload_download(void) {
     uint64_t h = cml_remote_alloc(dev, n);
     assert(h != 0);
 
-    float* send_buf = (float*)malloc(n);
-    float* recv_buf = (float*)malloc(n);
+    float* send_buf = (float*)cml_malloc(n);
+    float* recv_buf = (float*)cml_malloc(n);
     for (int i = 0; i < 256; i++) send_buf[i] = (float)i * 1.5f;
 
     assert(cml_remote_upload(dev, h, send_buf, n) == 0);
@@ -102,8 +103,8 @@ static void test_upload_download(void) {
         assert(recv_buf[i] == send_buf[i]);
     }
 
-    free(send_buf);
-    free(recv_buf);
+    cml_free(send_buf);
+    cml_free(recv_buf);
     cml_remote_free(dev, h);
     cml_remote_disconnect(dev);
     cml_remote_server_stop(srv);

--- a/tests/test_runtime_compiler.c
+++ b/tests/test_runtime_compiler.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "alloc/cml_allocator.h"
 
 static int tests_passed = 0;
 static int tests_failed = 0;
@@ -19,11 +20,11 @@ static int tests_failed = 0;
 
 /* Helper: create a minimal LinearProgram */
 static CMLLinearProgram* make_test_program(int variant) {
-    CMLLinearProgram* prog = calloc(1, sizeof(CMLLinearProgram));
+    CMLLinearProgram* prog = cml_calloc(1, sizeof(CMLLinearProgram));
     if (!prog) return NULL;
     prog->capacity = 16;
-    prog->ops = calloc(16, sizeof(CMLLinearOp));
-    if (!prog->ops) { free(prog); return NULL; }
+    prog->ops = cml_calloc(16, sizeof(CMLLinearOp));
+    if (!prog->ops) { cml_free(prog); return NULL; }
 
     /* LOAD v0, LOAD v1 */
     prog->ops[prog->num_ops++] = (CMLLinearOp){.kind = LINOP_LOAD, .dest_reg = 0};

--- a/tests/test_schedule.c
+++ b/tests/test_schedule.c
@@ -6,6 +6,7 @@
 #include "ops/ir/ir.h"
 #include "ops/uops.h"
 #include "tensor/tensor.h"
+#include "alloc/cml_allocator.h"
 
 static int tests_run    = 0;
 static int tests_passed = 0;
@@ -336,7 +337,7 @@ static int test_schedule_to_string(void) {
     CMLSchedule* s = cml_schedule_create(g, NULL);
     char* str = cml_schedule_to_string(s);
     int ok = (str != NULL && strlen(str) > 0);
-    free(str);
+    cml_free(str);
 
     /* NULL schedule returns NULL */
     char* str2 = cml_schedule_to_string(NULL);
@@ -349,7 +350,7 @@ static int test_schedule_to_string(void) {
 }
 
 static int test_schedule_free_null(void) {
-    /* free(NULL) must not crash */
+    /* cml_free(NULL) must not crash */
     cml_schedule_free(NULL);
     return 1;
 }

--- a/tests/test_serialization.c
+++ b/tests/test_serialization.c
@@ -6,6 +6,7 @@
 #include <unistd.h>
 
 #include "cml.h"
+#include "alloc/cml_allocator.h"
 
 static int tests_run = 0;
 static int tests_passed = 0;
@@ -79,8 +80,8 @@ static int test_model_save_load(void) {
 
     printf("(params_match=%s) ", ok ? "yes" : "no");
 
-    if (orig_params) free(orig_params);
-    if (loaded_params) free(loaded_params);
+    if (orig_params) cml_free(orig_params);
+    if (loaded_params) cml_free(loaded_params);
     module_free((Module*)model);
     module_free((Module*)loaded);
     unlink(filepath);
@@ -98,7 +99,7 @@ static int test_checkpoint_save_load(void) {
     module_collect_parameters((Module*)model, &params, &num_params, true);
 
     Optimizer* opt = cml_optim_sgd(params, num_params, 0.01f, 0.0f, 0.0f);
-    if (!opt) { free(params); module_free((Module*)model); return 0; }
+    if (!opt) { cml_free(params); module_free((Module*)model); return 0; }
 
     int save_epoch = 5;
     float save_loss = 0.123f;
@@ -106,7 +107,7 @@ static int test_checkpoint_save_load(void) {
     int ret = model_save_checkpoint((Module*)model, opt, save_epoch, save_loss, filepath);
     if (ret != 0) {
         printf("(checkpoint save failed) ");
-        optimizer_free(opt); free(params); module_free((Module*)model);
+        optimizer_free(opt); cml_free(params); module_free((Module*)model);
         return 0;
     }
 
@@ -127,7 +128,7 @@ static int test_checkpoint_save_load(void) {
     if (ret != 0) {
         printf("(checkpoint load failed) ");
         optimizer_free(opt); optimizer_free(loaded_opt);
-        free(params); free(loaded_params);
+        cml_free(params); cml_free(loaded_params);
         module_free((Module*)model); module_free((Module*)loaded);
         unlink(filepath);
         return 0;
@@ -137,7 +138,7 @@ static int test_checkpoint_save_load(void) {
     int ok = (load_epoch == save_epoch) && APPROX_EQ(load_loss, save_loss);
 
     optimizer_free(opt); optimizer_free(loaded_opt);
-    free(params); free(loaded_params);
+    cml_free(params); cml_free(loaded_params);
     module_free((Module*)model); module_free((Module*)loaded);
     unlink(filepath);
     return ok;

--- a/tests/test_symbolic.c
+++ b/tests/test_symbolic.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include "alloc/cml_allocator.h"
 
 static int tests_passed = 0;
 static int tests_failed = 0;
@@ -454,10 +455,10 @@ static void test_shape_broadcast_symbolic(void) {
     // Shape (N, 1) broadcast with (1, 5) -> (N, 5)
     SymExpr* n = sym_var("N", 1, 64);
 
-    SymShape* a = (SymShape*)calloc(1, sizeof(SymShape));
+    SymShape* a = (SymShape*)cml_calloc(1, sizeof(SymShape));
     a->ndim = 2;
     a->ref_count = 1;
-    a->dims = (SymDim*)calloc(2, sizeof(SymDim));
+    a->dims = (SymDim*)cml_calloc(2, sizeof(SymDim));
     a->dims[0] = sym_dim_symbolic(n);
     a->dims[1] = sym_dim_concrete(1);
 
@@ -482,10 +483,10 @@ static void test_shape_eval(void) {
     TEST(shape_eval);
     SymExpr* n = sym_var("N", 1, 64);
 
-    SymShape* s = (SymShape*)calloc(1, sizeof(SymShape));
+    SymShape* s = (SymShape*)cml_calloc(1, sizeof(SymShape));
     s->ndim = 2;
     s->ref_count = 1;
-    s->dims = (SymDim*)calloc(2, sizeof(SymDim));
+    s->dims = (SymDim*)cml_calloc(2, sizeof(SymDim));
     s->dims[0] = sym_dim_symbolic(n);
     s->dims[1] = sym_dim_concrete(10);
 
@@ -506,10 +507,10 @@ static void test_shape_to_string(void) {
     TEST(shape_to_string);
     SymExpr* n = sym_var("N", 1, 64);
 
-    SymShape* s = (SymShape*)calloc(1, sizeof(SymShape));
+    SymShape* s = (SymShape*)cml_calloc(1, sizeof(SymShape));
     s->ndim = 2;
     s->ref_count = 1;
-    s->dims = (SymDim*)calloc(2, sizeof(SymDim));
+    s->dims = (SymDim*)cml_calloc(2, sizeof(SymDim));
     s->dims[0] = sym_dim_symbolic(n);
     s->dims[1] = sym_dim_concrete(10);
 

--- a/tests/test_tc_opt.c
+++ b/tests/test_tc_opt.c
@@ -6,6 +6,7 @@
 #include "ops/ir/pattern_matcher.h"
 #include "ops/ir/internal.h"
 #include "ops/ir/gpu/wmma.h"
+#include "alloc/cml_allocator.h"
 
 static int tests_run = 0;
 static int tests_passed = 0;
@@ -23,37 +24,37 @@ static int tests_passed = 0;
 } while(0)
 
 static struct CMLGraph* make_empty_graph(void) {
-    struct CMLGraph* g = calloc(1, sizeof(struct CMLGraph));
+    struct CMLGraph* g = cml_calloc(1, sizeof(struct CMLGraph));
     if (!g) return NULL;
     g->target = IR_TARGET_CUDA;
     return g;
 }
 
 static struct IRNode* make_matmul_node(const char* name, int m, int n, int k) {
-    struct IRNode* node = calloc(1, sizeof(struct IRNode));
+    struct IRNode* node = cml_calloc(1, sizeof(struct IRNode));
     if (!node) return NULL;
 
     node->type = UOP_MATMUL;
     node->num_inputs = 2;
-    node->input_names = malloc(2 * sizeof(char*));
-    node->input_names[0] = strdup("input_a");
-    node->input_names[1] = strdup("input_b");
-    node->output_name = strdup(name);
+    node->input_names = cml_malloc(2 * sizeof(char*));
+    node->input_names[0] = cml_strdup("input_a");
+    node->input_names[1] = cml_strdup("input_b");
+    node->output_name = cml_strdup(name);
 
-    node->input_ndims = malloc(2 * sizeof(int));
+    node->input_ndims = cml_malloc(2 * sizeof(int));
     node->input_ndims[0] = 2;
     node->input_ndims[1] = 2;
 
-    node->input_shapes = malloc(2 * sizeof(int*));
-    node->input_shapes[0] = malloc(2 * sizeof(int));
+    node->input_shapes = cml_malloc(2 * sizeof(int*));
+    node->input_shapes[0] = cml_malloc(2 * sizeof(int));
     node->input_shapes[0][0] = m;
     node->input_shapes[0][1] = k;
-    node->input_shapes[1] = malloc(2 * sizeof(int));
+    node->input_shapes[1] = cml_malloc(2 * sizeof(int));
     node->input_shapes[1][0] = k;
     node->input_shapes[1][1] = n;
 
     node->output_ndim = 2;
-    node->output_shape = malloc(2 * sizeof(int));
+    node->output_shape = cml_malloc(2 * sizeof(int));
     node->output_shape[0] = m;
     node->output_shape[1] = n;
 
@@ -62,17 +63,17 @@ static struct IRNode* make_matmul_node(const char* name, int m, int n, int k) {
 
 static struct IRNode* make_simple_node(const char* name, UOpType type,
                                        int num_inputs, const char** input_names) {
-    struct IRNode* node = calloc(1, sizeof(struct IRNode));
+    struct IRNode* node = cml_calloc(1, sizeof(struct IRNode));
     if (!node) return NULL;
 
     node->type = type;
     node->num_inputs = num_inputs;
     if (num_inputs > 0) {
-        node->input_names = malloc((size_t)num_inputs * sizeof(char*));
+        node->input_names = cml_malloc((size_t)num_inputs * sizeof(char*));
         for (int i = 0; i < num_inputs; i++)
-            node->input_names[i] = strdup(input_names[i]);
+            node->input_names[i] = cml_strdup(input_names[i]);
     }
-    node->output_name = strdup(name);
+    node->output_name = cml_strdup(name);
     return node;
 }
 
@@ -94,23 +95,23 @@ static void free_graph(struct CMLGraph* g) {
         struct IRNode* next = n->next;
         if (n->input_names) {
             for (int i = 0; i < n->num_inputs; i++)
-                free(n->input_names[i]);
-            free(n->input_names);
+                cml_free(n->input_names[i]);
+            cml_free(n->input_names);
         }
         if (n->input_shapes) {
             for (int i = 0; i < n->num_inputs; i++)
-                free(n->input_shapes[i]);
-            free(n->input_shapes);
+                cml_free(n->input_shapes[i]);
+            cml_free(n->input_shapes);
         }
-        free(n->input_ndims);
-        free(n->output_name);
-        free(n->output_shape);
-        free(n->params);
-        free(n->users);
-        free(n);
+        cml_free(n->input_ndims);
+        cml_free(n->output_name);
+        cml_free(n->output_shape);
+        cml_free(n->params);
+        cml_free(n->users);
+        cml_free(n);
         n = next;
     }
-    free(g);
+    cml_free(g);
 }
 
 static int test_config_defaults(void) {
@@ -159,7 +160,7 @@ static int test_optimize_empty_graph(void) {
     struct CMLGraph* g = make_empty_graph();
     if (!g) return 0;
     int ret = cml_tc_optimize(g);
-    free(g);
+    cml_free(g);
     return ret == 0;
 }
 

--- a/tests/test_tensor_hash.c
+++ b/tests/test_tensor_hash.c
@@ -7,6 +7,7 @@
 #include "tensor/tensor.h"
 #include "ops/ir/ir.h"
 #include "ops/ir/context.h"
+#include "alloc/cml_allocator.h"
 
 static int tests_run = 0;
 static int tests_passed = 0;
@@ -215,12 +216,12 @@ static int test_keccak_large_tensor(void) {
     cml_ir_set_global_context(ir);
 
     int n = 1024;
-    float* data = malloc(n * sizeof(float));
+    float* data = cml_malloc(n * sizeof(float));
     for (int i = 0; i < n; i++) data[i] = (float)i;
     int shape[] = {n};
 
     Tensor* t = tensor_from_data(data, shape, 1, NULL);
-    free(data);
+    cml_free(data);
     if (!t) { cml_ir_free(ir); return 0; }
 
     uint8_t hash[32];

--- a/tests/test_tlsf.c
+++ b/tests/test_tlsf.c
@@ -5,6 +5,7 @@
 #include <stdint.h>
 
 #include "alloc/tlsf_alloc.h"
+#include "alloc/cml_allocator.h"
 
 static int tests_run = 0;
 static int tests_passed = 0;
@@ -268,25 +269,25 @@ static int test_create_with_pool(void)
 {
     /* User-provided pool */
     size_t pool_size = 4096;
-    void* pool = malloc(pool_size);
+    void* pool = cml_malloc(pool_size);
     if (!pool) return 0;
 
     CMLTLSFAllocator* alloc = cml_tlsf_create_with_pool(pool, pool_size);
-    if (!alloc) { free(pool); return 0; }
+    if (!alloc) { cml_free(pool); return 0; }
 
     void* ptr = cml_tlsf_alloc(alloc, 64);
-    if (!ptr) { cml_tlsf_destroy(alloc); free(pool); return 0; }
+    if (!ptr) { cml_tlsf_destroy(alloc); cml_free(pool); return 0; }
 
     /* Pointer should be within the pool */
     if ((char*)ptr < (char*)pool || (char*)ptr >= (char*)pool + pool_size) {
         cml_tlsf_destroy(alloc);
-        free(pool);
+        cml_free(pool);
         return 0;
     }
 
     cml_tlsf_free(alloc, ptr);
     cml_tlsf_destroy(alloc);
-    free(pool);
+    cml_free(pool);
     return 1;
 }
 

--- a/tests/test_tree_automaton.c
+++ b/tests/test_tree_automaton.c
@@ -8,34 +8,35 @@
 #include "ops/ir/pattern_matcher.h"
 #include "ops/ir/internal.h"
 #include "ops/uops.h"
+#include "alloc/cml_allocator.h"
 
 static struct IRNode* make_node(UOpType type, const char* output,
                                 const char** inputs, int num_inputs) {
-    struct IRNode* node = calloc(1, sizeof(struct IRNode));
+    struct IRNode* node = cml_calloc(1, sizeof(struct IRNode));
     node->type = type;
-    node->output_name = strdup(output);
+    node->output_name = cml_strdup(output);
     node->num_inputs = num_inputs;
     if (num_inputs > 0) {
-        node->input_names = malloc((size_t)num_inputs * sizeof(char*));
+        node->input_names = cml_malloc((size_t)num_inputs * sizeof(char*));
         for (int i = 0; i < num_inputs; i++)
-            node->input_names[i] = strdup(inputs[i]);
+            node->input_names[i] = cml_strdup(inputs[i]);
     }
     return node;
 }
 
 static struct IRNode* make_fill_node(const char* output, float value) {
-    struct IRNode* node = calloc(1, sizeof(struct IRNode));
+    struct IRNode* node = cml_calloc(1, sizeof(struct IRNode));
     node->type = UOP_FILL;
-    node->output_name = strdup(output);
+    node->output_name = cml_strdup(output);
     node->num_inputs = 0;
     node->output_ndim = 1;
-    node->output_shape = malloc(sizeof(int));
+    node->output_shape = cml_malloc(sizeof(int));
     node->output_shape[0] = 1;
 
-    FillParams* fp = malloc(sizeof(FillParams));
+    FillParams* fp = cml_malloc(sizeof(FillParams));
     fp->value = value;
     fp->ndim = 1;
-    fp->shape = malloc(sizeof(int));
+    fp->shape = cml_malloc(sizeof(int));
     fp->shape[0] = 1;
     node->params = fp;
     return node;
@@ -59,20 +60,20 @@ static void free_graph_nodes(struct CMLGraph* g) {
         struct IRNode* next = n->next;
         if (n->input_names) {
             for (int i = 0; i < n->num_inputs; i++)
-                free(n->input_names[i]);
-            free(n->input_names);
+                cml_free(n->input_names[i]);
+            cml_free(n->input_names);
         }
-        free(n->output_name);
-        free(n->output_shape);
+        cml_free(n->output_name);
+        cml_free(n->output_shape);
         if (n->params) {
             if (n->type == UOP_FILL) {
                 FillParams* fp = (FillParams*)n->params;
-                free(fp->shape);
+                cml_free(fp->shape);
             }
-            free(n->params);
+            cml_free(n->params);
         }
-        free(n->users);
-        free(n);
+        cml_free(n->users);
+        cml_free(n);
         n = next;
     }
     g->head = g->tail = NULL;

--- a/tests/test_vulkan_backend.c
+++ b/tests/test_vulkan_backend.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include "alloc/cml_allocator.h"
 
 static int tests_run = 0;
 static int tests_passed = 0;
@@ -38,19 +39,19 @@ static int test_spirv_gen_unary_neg(void) {
     size_t size = 0;
     uint32_t* spirv = cml_spirv_gen_unary(cg, UOP_NEG, "test_neg", &size);
     if (!spirv) { cml_spirv_codegen_destroy(cg); return 0; }
-    if (size == 0) { free(spirv); cml_spirv_codegen_destroy(cg); return 0; }
+    if (size == 0) { cml_free(spirv); cml_spirv_codegen_destroy(cg); return 0; }
 
     /* Verify SPIR-V magic number */
     if (spirv[0] != 0x07230203) {
-        free(spirv); cml_spirv_codegen_destroy(cg); return 0;
+        cml_free(spirv); cml_spirv_codegen_destroy(cg); return 0;
     }
 
     /* Verify size is multiple of 4 bytes */
     if (size % 4 != 0) {
-        free(spirv); cml_spirv_codegen_destroy(cg); return 0;
+        cml_free(spirv); cml_spirv_codegen_destroy(cg); return 0;
     }
 
-    free(spirv);
+    cml_free(spirv);
     cml_spirv_codegen_destroy(cg);
     return 1;
 }
@@ -62,9 +63,9 @@ static int test_spirv_gen_unary_exp(void) {
     size_t size = 0;
     uint32_t* spirv = cml_spirv_gen_unary(cg, UOP_EXP, "test_exp", &size);
     if (!spirv || size == 0) { cml_spirv_codegen_destroy(cg); return 0; }
-    if (spirv[0] != 0x07230203) { free(spirv); cml_spirv_codegen_destroy(cg); return 0; }
+    if (spirv[0] != 0x07230203) { cml_free(spirv); cml_spirv_codegen_destroy(cg); return 0; }
 
-    free(spirv);
+    cml_free(spirv);
     cml_spirv_codegen_destroy(cg);
     return 1;
 }
@@ -76,9 +77,9 @@ static int test_spirv_gen_unary_sqrt(void) {
     size_t size = 0;
     uint32_t* spirv = cml_spirv_gen_unary(cg, UOP_SQRT, "test_sqrt", &size);
     if (!spirv || size == 0) { cml_spirv_codegen_destroy(cg); return 0; }
-    if (spirv[0] != 0x07230203) { free(spirv); cml_spirv_codegen_destroy(cg); return 0; }
+    if (spirv[0] != 0x07230203) { cml_free(spirv); cml_spirv_codegen_destroy(cg); return 0; }
 
-    free(spirv);
+    cml_free(spirv);
     cml_spirv_codegen_destroy(cg);
     return 1;
 }
@@ -90,9 +91,9 @@ static int test_spirv_gen_binary_add(void) {
     size_t size = 0;
     uint32_t* spirv = cml_spirv_gen_binary(cg, UOP_ADD, "test_add", &size);
     if (!spirv || size == 0) { cml_spirv_codegen_destroy(cg); return 0; }
-    if (spirv[0] != 0x07230203) { free(spirv); cml_spirv_codegen_destroy(cg); return 0; }
+    if (spirv[0] != 0x07230203) { cml_free(spirv); cml_spirv_codegen_destroy(cg); return 0; }
 
-    free(spirv);
+    cml_free(spirv);
     cml_spirv_codegen_destroy(cg);
     return 1;
 }
@@ -104,9 +105,9 @@ static int test_spirv_gen_binary_mul(void) {
     size_t size = 0;
     uint32_t* spirv = cml_spirv_gen_binary(cg, UOP_MUL, "test_mul", &size);
     if (!spirv || size == 0) { cml_spirv_codegen_destroy(cg); return 0; }
-    if (spirv[0] != 0x07230203) { free(spirv); cml_spirv_codegen_destroy(cg); return 0; }
+    if (spirv[0] != 0x07230203) { cml_free(spirv); cml_spirv_codegen_destroy(cg); return 0; }
 
-    free(spirv);
+    cml_free(spirv);
     cml_spirv_codegen_destroy(cg);
     return 1;
 }
@@ -228,7 +229,7 @@ static int test_vulkan_kernel_dispatch(void) {
 
     /* Create kernel with 3 buffers (in, out, params) */
     CMLVulkanKernel* kernel = cml_vulkan_kernel_create(backend, spirv, spirv_size, "main", 3);
-    free(spirv);
+    cml_free(spirv);
     cml_spirv_codegen_destroy(cg);
 
     if (!kernel) {

--- a/tests/test_webgpu_backend.c
+++ b/tests/test_webgpu_backend.c
@@ -6,6 +6,7 @@
 #include "ops/ir/gpu/webgpu_backend.h"
 #include "ops/ir/internal.h"
 #include "ops/uops.h"
+#include "alloc/cml_allocator.h"
 
 static void test_wgsl_generate_add(void) {
     printf("  test_wgsl_generate_add...");
@@ -27,7 +28,7 @@ static void test_wgsl_generate_add(void) {
     assert(strstr(wgsl, "result") != NULL);
 
     printf(" (generated %zu bytes) ", strlen(wgsl));
-    free(wgsl);
+    cml_free(wgsl);
     printf("PASS\n");
 }
 
@@ -45,7 +46,7 @@ static void test_wgsl_generate_mul(void) {
     assert(strstr(wgsl, "@compute") != NULL);
     assert(strstr(wgsl, "@workgroup_size") != NULL);
 
-    free(wgsl);
+    cml_free(wgsl);
     printf(" PASS\n");
 }
 
@@ -63,7 +64,7 @@ static void test_wgsl_generate_exp(void) {
     assert(strstr(wgsl, "@compute") != NULL);
     assert(strstr(wgsl, "@workgroup_size") != NULL);
 
-    free(wgsl);
+    cml_free(wgsl);
     printf(" PASS\n");
 }
 

--- a/tests/test_winograd.c
+++ b/tests/test_winograd.c
@@ -5,6 +5,7 @@
 #include <assert.h>
 
 #include "ops/winograd.h"
+#include "alloc/cml_allocator.h"
 
 static void test_winograd_applicable_true(void) {
     printf("  test_winograd_applicable_true...");
@@ -62,14 +63,14 @@ static void test_winograd_conv2d_basic(void) {
     int groups = 1;
 
     /* Allocate input: 1x1x8x8, all 1.0 */
-    float* input = (float*)calloc(batch * in_c * H * W, sizeof(float));
+    float* input = (float*)cml_calloc(batch * in_c * H * W, sizeof(float));
     assert(input != NULL);
     for (int i = 0; i < batch * in_c * H * W; i++) {
         input[i] = 1.0f;
     }
 
     /* Allocate weight: 1x1x3x3, all 1.0 */
-    float* weight = (float*)calloc(out_c * in_c * 3 * 3, sizeof(float));
+    float* weight = (float*)cml_calloc(out_c * in_c * 3 * 3, sizeof(float));
     assert(weight != NULL);
     for (int i = 0; i < out_c * in_c * 3 * 3; i++) {
         weight[i] = 1.0f;
@@ -78,7 +79,7 @@ static void test_winograd_conv2d_basic(void) {
     /* Output dimensions with padding=1: same as input -> 8x8 */
     int out_h = H;
     int out_w = W;
-    float* output = (float*)calloc(batch * out_c * out_h * out_w, sizeof(float));
+    float* output = (float*)cml_calloc(batch * out_c * out_h * out_w, sizeof(float));
     assert(output != NULL);
 
     WinogradConfig config;
@@ -112,9 +113,9 @@ static void test_winograd_conv2d_basic(void) {
     float edge_val = output[1];
     assert(fabsf(edge_val - 6.0f) < 1e-3f);
 
-    free(input);
-    free(weight);
-    free(output);
+    cml_free(input);
+    cml_free(weight);
+    cml_free(output);
     printf(" PASS\n");
 }
 

--- a/tests/test_wmma.c
+++ b/tests/test_wmma.c
@@ -4,6 +4,7 @@
 #include <assert.h>
 
 #include "ops/ir/gpu/wmma.h"
+#include "alloc/cml_allocator.h"
 
 static void test_select_config_basic(void) {
     printf("  test_select_config_basic...");
@@ -98,7 +99,7 @@ static void test_generate_kernel(void) {
     assert(strstr(kernel_src, "wmma") != NULL);
 
     printf(" (generated %zu bytes) ", strlen(kernel_src));
-    free(kernel_src);
+    cml_free(kernel_src);
     printf("PASS\n");
 }
 
@@ -127,7 +128,7 @@ static void test_generate_kernel_various_sizes(void) {
         char* src = cml_wmma_generate_kernel(&config, M, N, K);
         assert(src != NULL);
         assert(strstr(src, "wmma") != NULL);
-        free(src);
+        cml_free(src);
     }
 
     printf(" PASS\n");
@@ -163,9 +164,9 @@ static void test_wmma_matmul_if_available(void) {
     size_t fp32_size = M * N * 4;  /* 4 bytes per fp32 */
 
     /* Allocate host buffers (simplified: using calloc for zero-init) */
-    void* A = calloc(1, fp16_size);
-    void* B = calloc(1, fp16_size);
-    void* C = calloc(1, fp32_size);
+    void* A = cml_calloc(1, fp16_size);
+    void* B = cml_calloc(1, fp16_size);
+    void* C = cml_calloc(1, fp32_size);
     assert(A != NULL && B != NULL && C != NULL);
 
     int ret = cml_wmma_matmul(A, B, C, M, N, K);
@@ -177,9 +178,9 @@ static void test_wmma_matmul_if_available(void) {
         assert(C_fp32[i] == 0.0f);
     }
 
-    free(A);
-    free(B);
-    free(C);
+    cml_free(A);
+    cml_free(B);
+    cml_free(C);
     printf(" PASS\n");
 }
 


### PR DESCRIPTION
Add cml_allocator (thread-cached size-class segregated fit allocator with slab backing and direct large-object path via posix_memalign/malloc).

Replace virtually all direct libc heap calls across the entire repo (src/, examples/, tests/, benchmarks/, main.c) with the new cml_malloc, cml_calloc, cml_realloc, cml_free and cml_strdup (plus aligned variants).

- New files: include/alloc/cml_allocator.h, src/alloc/cml_allocator.c
- Update CMakeLists.txt to build the new allocator
- Pull allocator declarations in via include/cml.h and core/logging.h (robust against platform #ifdef include blocks in various .c files)
- Legacy cml_safe_* wrappers now delegate to the fast path
- Minor supporting fixes (include ordering, AVX target attributes for certain SIMD paths to keep builds happy)

Goal: much faster allocation paths with lower variance for ML use cases (tensors, IR graphs, layers, tokenizers, etc.).

The allocator itself still uses raw malloc/mmap only for its internal slab acquisition (standard and required).